### PR TITLE
feat(cn): run one compute node per GPU with explicit memory carve-outs and a readiness gate

### DIFF
--- a/experimental/starrocks/.gitignore
+++ b/experimental/starrocks/.gitignore
@@ -1,2 +1,6 @@
 target/
 .pixi/
+.cn1/
+.cn2/
+.cn*/
+sirius-cn-*/

--- a/experimental/starrocks/src/engine.rs
+++ b/experimental/starrocks/src/engine.rs
@@ -23,6 +23,7 @@ use sirius::SiriusContext;
 use starrocks_plan_translator::TranslatedPlan;
 use tracing::info;
 
+use crate::engine_settings::{EngineSettings, resolve_cuda_visible_devices};
 use crate::fragment_executor::{FragmentExecutor, FragmentResult};
 
 /// One execution request handed to the engine thread.
@@ -51,14 +52,16 @@ impl SiriusEngine {
     /// Brings up the engine on a dedicated thread (fail-fast) and returns a handle.
     ///
     /// Blocks until the context is initialized — or bring-up fails — so a bad config or GPU
-    /// failure surfaces here, before any RPC is served. `config` is the optional Sirius YAML path
-    /// (built-in defaults when `None`).
-    pub fn start(config: Option<PathBuf>) -> Result<Self, String> {
+    /// failure surfaces here, before any RPC is served. `settings` carries the resolved Sirius
+    /// YAML path (built-in defaults when `None`), the engine artifact directory, and the CUDA
+    /// device pin.
+    pub fn start(settings: EngineSettings) -> Result<Self, String> {
+        Self::configure_engine_environment(&settings)?;
         let (request_tx, request_rx) = channel::<ExecuteRequest>();
         let (ready_tx, ready_rx) = channel::<Result<(), String>>();
         let thread = std::thread::Builder::new()
             .name("sirius-engine".to_string())
-            .spawn(move || engine_thread(config, request_rx, ready_tx))
+            .spawn(move || engine_thread(settings.config, request_rx, ready_tx))
             .map_err(|err| format!("failed to spawn sirius-engine thread: {err}"))?;
         match ready_rx.recv() {
             Ok(Ok(())) => Ok(Self {
@@ -68,6 +71,36 @@ impl SiriusEngine {
             Ok(Err(err)) => Err(err),
             Err(_) => Err("sirius-engine thread exited during bring-up".to_string()),
         }
+    }
+
+    /// Points the engine's log directory at `<engine_dir>/log` and pins the CUDA device when
+    /// requested. An operator-exported `SIRIUS_LOG_DIR` wins. An exported `CUDA_VISIBLE_DEVICES`
+    /// must name the same device as `--gpu-device`, or bring-up is refused (see
+    /// [`resolve_cuda_visible_devices`]): letting the export win silently is how N CNs launched
+    /// on N GPUs ended up priming the same device.
+    fn configure_engine_environment(settings: &EngineSettings) -> Result<(), String> {
+        if std::env::var_os("SIRIUS_LOG_DIR").is_none() {
+            let log_dir = settings.engine_dir.join("log");
+            std::fs::create_dir_all(&log_dir).map_err(|err| {
+                format!(
+                    "failed to create engine log directory {}: {err}",
+                    log_dir.display()
+                )
+            })?;
+            // SAFETY: this runs before the engine thread and RPC servers start, so no concurrent
+            // code reads or writes these process environment variables.
+            unsafe { std::env::set_var("SIRIUS_LOG_DIR", &log_dir) };
+        }
+        let exported =
+            std::env::var_os("CUDA_VISIBLE_DEVICES").map(|v| v.to_string_lossy().into_owned());
+        if let Some(device) =
+            resolve_cuda_visible_devices(settings.gpu_device, exported.as_deref())?
+        {
+            // SAFETY: same pre-thread-spawn window as above; nothing else touches the
+            // environment yet.
+            unsafe { std::env::set_var("CUDA_VISIBLE_DEVICES", device) };
+        }
+        Ok(())
     }
 }
 
@@ -168,6 +201,15 @@ mod tests {
     use parquet::arrow::ArrowWriter;
 
     use super::*;
+
+    /// Default-config engine settings pointing engine artifacts at a scratch directory.
+    fn test_settings() -> EngineSettings {
+        EngineSettings {
+            config: None,
+            engine_dir: std::env::temp_dir().join("sirius-engine-test"),
+            gpu_device: None,
+        }
+    }
 
     /// Builds a single-file `local_files` parquet read plan with `names` as the root output
     /// names — the shape DuckDB's Substrait reader resolves to `parquet_scan(<path>)`.
@@ -283,7 +325,10 @@ mod tests {
     fn engine_replays_dumped_substrait_plan() {
         let path = std::env::var("SIRIUS_SUBSTRAIT_PLAN").expect("SIRIUS_SUBSTRAIT_PLAN not set");
         let plan = std::fs::read(&path).expect("read dumped substrait plan");
-        let engine = SiriusEngine::start(None).expect("bring up sirius engine");
+        let _guard = crate::GPU_ENGINE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        let engine = SiriusEngine::start(test_settings()).expect("bring up sirius engine");
         let (respond_tx, respond_rx) = channel();
         engine
             .requests
@@ -313,6 +358,9 @@ mod tests {
     /// test.
     #[test]
     fn engine_executes_local_files_plan() {
+        let _guard = crate::GPU_ENGINE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("rows.parquet");
         let schema = Arc::new(Schema::new(vec![
@@ -334,7 +382,7 @@ mod tests {
             vec!["id".to_string(), "name".to_string()],
         );
 
-        let engine = SiriusEngine::start(None).expect("bring up sirius engine");
+        let engine = SiriusEngine::start(test_settings()).expect("bring up sirius engine");
         let result = engine.execute(&plan).expect("execute fragment on GPU");
         let total_rows: usize = result.batches.iter().map(RecordBatch::num_rows).sum();
         assert_eq!(total_rows, 3, "expected 3 rows from the parquet fixture");

--- a/experimental/starrocks/src/engine_settings.rs
+++ b/experimental/starrocks/src/engine_settings.rs
@@ -1,0 +1,384 @@
+//! Resolved Sirius engine bring-up settings and the derived-config YAML they may carry.
+//!
+//! The CLI exposes coarse GPU knobs (`--gpu-memory-limit`, `--gpu-memory-fraction`,
+//! `--host-memory-limit`) so an operator can carve out a slice of a shared device without
+//! writing a full Sirius YAML config. This module turns those knobs into the exact YAML the
+//! C++ config loader (`sirius_config.cpp`) understands. Byte values are passed through
+//! verbatim: the authoritative parser is the C++ `parse_bytes`, so nothing is converted here.
+
+use std::path::{Path, PathBuf};
+
+/// Engine bring-up settings after CLI resolution: which config file to load (an operator-supplied
+/// one or a derived carve-out config), where engine artifacts live, and which CUDA device to pin.
+#[derive(Clone, Debug)]
+pub struct EngineSettings {
+    /// Sirius YAML config path (built-in defaults when `None`).
+    pub config: Option<PathBuf>,
+    /// Directory for engine artifacts: derived config, logs, telemetry.
+    pub engine_dir: PathBuf,
+    /// CUDA device ordinal to export as `CUDA_VISIBLE_DEVICES` before engine bring-up.
+    pub gpu_device: Option<u32>,
+}
+
+/// Renders the derived Sirius config for the given memory carve-out flags, or `None` when no
+/// memory flag is set (only `--gpu-device`/`--engine-dir` do not need a config file).
+///
+/// `reservation_limit_fraction` is pinned to 1.0 so the carve-out itself is the whole budget:
+/// the engine may reserve up to 100% of the configured limit, not 100% of the device — that is
+/// what lets two CNs coexist on one GPU.
+///
+/// `cpu_affinity` confines the engine's unpinned thread pools to one socket (see
+/// [`crate::gpu_affinity`]). It only *decorates* a config that a memory flag already called for:
+/// on its own it must not conjure one, because a derived config takes precedence over an
+/// operator-supplied `--sirius-config` at the call site.
+pub fn derive_sirius_config_yaml(
+    gpu_memory_limit: Option<&str>,
+    gpu_memory_fraction: Option<f64>,
+    host_memory_limit: Option<&str>,
+    engine_dir: &Path,
+    cpu_affinity: Option<&[u32]>,
+) -> Option<String> {
+    assert!(
+        gpu_memory_limit.is_none() || gpu_memory_fraction.is_none(),
+        "gpu_memory_limit and gpu_memory_fraction are mutually exclusive (clap enforces this)"
+    );
+    if gpu_memory_limit.is_none() && gpu_memory_fraction.is_none() && host_memory_limit.is_none() {
+        return None;
+    }
+
+    let mut yaml = String::from("sirius:\n  topology:\n    num_gpus: 1\n  memory:\n");
+    // The gpu mapping is only emitted when a GPU limit is requested: emitting the reservation
+    // override alone would let the engine reserve the whole device it was not asked to cap.
+    if let Some(limit) = gpu_memory_limit {
+        yaml.push_str("    gpu:\n");
+        yaml.push_str(&format!(
+            "      usage_limit_bytes: \"{}\"\n",
+            yaml_escape(limit)
+        ));
+        yaml.push_str("      reservation_limit_fraction: 1.0\n");
+    } else if let Some(fraction) = gpu_memory_fraction {
+        yaml.push_str("    gpu:\n");
+        yaml.push_str(&format!("      usage_limit_fraction: {fraction:?}\n"));
+        yaml.push_str("      reservation_limit_fraction: 1.0\n");
+    }
+    // `sirius.memory.host` is the HIGH-LEVEL host config: it runs the reservation-manager
+    // configurator, whose `use_host_per_numa()` policy already emits one host space per distinct
+    // NUMA node of the configured GPUs and binds its arena there with `numa_alloc_onnode`. With
+    // `num_gpus: 1` that is exactly one host space on this CN's own socket — already correct.
+    // Do NOT "fix" this by moving to the low-level `sirius.space.host` sequence to set `numa_id`
+    // by hand: declaring any explicit space disables the configurator wholesale, taking
+    // per-host capacity and the portable-allocation heuristic with it.
+    if let Some(capacity) = host_memory_limit {
+        yaml.push_str("    host:\n");
+        yaml.push_str(&format!(
+            "      capacity_bytes: \"{}\"\n",
+            yaml_escape(capacity)
+        ));
+    }
+    // Scan datasource backend. The engine defaults to `true` (the uring sirius_datasource);
+    // setting SIRIUS_CN_USE_SIRIUS_DATASOURCE=false selects the kvikio/cudf datasource instead.
+    // That path is rejected for multi-GPU topologies (sirius_scan_manager.cpp), but each CN pins
+    // exactly one device via CUDA_VISIBLE_DEVICES and this YAML declares num_gpus: 1, so the
+    // guard does not apply per-CN. Measured on Q06/SF100 standalone: uring ~4.9 s vs cudf ~0.23 s.
+    let datasource = std::env::var_os("SIRIUS_CN_USE_SIRIUS_DATASOURCE").map(|v| {
+        let v = v.to_string_lossy().to_ascii_lowercase();
+        !matches!(v.as_str(), "false" | "0" | "no" | "off")
+    });
+    if datasource.is_some() || cpu_affinity.is_some() {
+        yaml.push_str("  executor:\n");
+        yaml.push_str("    scan_manager:\n");
+        if let Some(use_sirius) = datasource {
+            yaml.push_str(&format!("      use_sirius_datasource: {use_sirius}\n"));
+        }
+        // The three pools the engine never pins itself. The GPU pipeline pool is deliberately
+        // absent: `task_scheduler.cpp` overwrites its `cpu_affinity_list` from the discovered
+        // GPU topology, so a YAML value there would be silently discarded.
+        if let Some(cpus) = cpu_affinity {
+            let cpus = cpu_affinity_sequence(cpus);
+            yaml.push_str(&format!("      cpu_affinity: {cpus}\n"));
+            yaml.push_str("    task_creator:\n");
+            yaml.push_str(&format!("      cpu_affinity: {cpus}\n"));
+            yaml.push_str("    downgrade:\n");
+            yaml.push_str(&format!("      cpu_affinity: {cpus}\n"));
+        }
+    }
+    yaml.push_str("  telemetry:\n");
+    yaml.push_str(&format!(
+        "    output_directory: \"{}\"\n",
+        yaml_escape(&engine_dir.join("telemetry").display().to_string())
+    ));
+    Some(yaml)
+}
+
+/// Decides what the engine should see in `CUDA_VISIBLE_DEVICES`, given `--gpu-device` and the
+/// value the operator's environment already exports.
+///
+/// Returns the value to export (`Ok(Some)`), nothing to do (`Ok(None)`), or an error when the two
+/// disagree. Letting an exported value silently win is how N CNs launched with distinct
+/// `--gpu-device` ordinals all land on one GPU: the launcher believes each holds its own device,
+/// the driver hands every one of them the exported device, and the cluster still answers queries,
+/// so nobody notices until the scaling numbers look wrong. Refusing to start is the only outcome
+/// an operator sees. An exported value that names the requested ordinal verbatim is accepted; a
+/// UUID (`GPU-...`, `MIG-...`) or a device list cannot be checked here, so it is rejected too.
+pub fn resolve_cuda_visible_devices(
+    gpu_device: Option<u32>,
+    exported: Option<&str>,
+) -> Result<Option<String>, String> {
+    let Some(device) = gpu_device else {
+        return Ok(None);
+    };
+    let requested = device.to_string();
+    match exported {
+        None => Ok(Some(requested)),
+        Some(existing) if existing.trim() == requested => Ok(None),
+        Some(existing) => Err(format!(
+            "--gpu-device {requested} disagrees with the exported CUDA_VISIBLE_DEVICES={existing:?}: \
+             unset the variable (or export exactly \"{requested}\") or drop the flag. Starting anyway \
+             would put this CN on a device the launcher does not know it holds"
+        )),
+    }
+}
+
+/// Escapes a value for a double-quoted YAML scalar.
+fn yaml_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Renders CPU ordinals as a YAML flow sequence. The engine's reader requires a sequence for
+/// `cpu_affinity` (`yaml_reader.hpp` rejects a scalar), and it has no range syntax, so a whole
+/// 72-core socket is emitted core by core.
+fn cpu_affinity_sequence(cpus: &[u32]) -> String {
+    let items: Vec<String> = cpus.iter().map(u32::to_string).collect();
+    format!("[{}]", items.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `--gpu-memory-limit` value must land verbatim in `usage_limit_bytes`; the C++
+    /// `parse_bytes` is the authoritative parser.
+    #[test]
+    fn gpu_limit_passes_through_verbatim() {
+        let yaml =
+            derive_sirius_config_yaml(Some("8GiB"), None, None, Path::new(".cn1"), None).unwrap();
+        assert!(yaml.contains("usage_limit_bytes: \"8GiB\"\n"), "{yaml}");
+        assert!(!yaml.contains("usage_limit_fraction"), "{yaml}");
+    }
+
+    /// The fraction variant emits `usage_limit_fraction` instead of bytes.
+    #[test]
+    fn gpu_fraction_variant() {
+        let yaml =
+            derive_sirius_config_yaml(None, Some(0.5), None, Path::new(".cn1"), None).unwrap();
+        assert!(yaml.contains("usage_limit_fraction: 0.5\n"), "{yaml}");
+        assert!(!yaml.contains("usage_limit_bytes"), "{yaml}");
+    }
+
+    /// The host mapping appears exactly when `--host-memory-limit` is set.
+    #[test]
+    fn host_key_presence_and_absence() {
+        let with_host =
+            derive_sirius_config_yaml(Some("8GiB"), None, Some("12GiB"), Path::new(".cn1"), None)
+                .unwrap();
+        assert!(with_host.contains("    host:\n"), "{with_host}");
+        assert!(
+            with_host.contains("capacity_bytes: \"12GiB\"\n"),
+            "{with_host}"
+        );
+
+        let without_host =
+            derive_sirius_config_yaml(Some("8GiB"), None, None, Path::new(".cn1"), None).unwrap();
+        assert!(!without_host.contains("host:"), "{without_host}");
+        assert!(!without_host.contains("capacity_bytes"), "{without_host}");
+    }
+
+    /// Every GPU carve-out pins `reservation_limit_fraction` to 1.0 so the limit is the budget.
+    #[test]
+    fn reservation_limit_fraction_is_always_one() {
+        for yaml in [
+            derive_sirius_config_yaml(Some("8GiB"), None, None, Path::new(".cn1"), None).unwrap(),
+            derive_sirius_config_yaml(None, Some(0.25), None, Path::new(".cn1"), None).unwrap(),
+        ] {
+            assert!(yaml.contains("reservation_limit_fraction: 1.0\n"), "{yaml}");
+        }
+    }
+
+    /// Telemetry lands under the engine directory.
+    #[test]
+    fn telemetry_directory_is_under_engine_dir() {
+        let yaml =
+            derive_sirius_config_yaml(Some("8GiB"), None, None, Path::new(".cn2"), None).unwrap();
+        assert!(
+            yaml.contains("output_directory: \".cn2/telemetry\"\n"),
+            "{yaml}"
+        );
+    }
+
+    /// `--gpu-device`/`--engine-dir` alone need no config file at all.
+    #[test]
+    fn no_yaml_when_no_memory_flag_is_set() {
+        assert_eq!(
+            derive_sirius_config_yaml(None, None, None, Path::new(".cn1"), None),
+            None
+        );
+    }
+
+    /// A host-only carve-out must not emit a gpu mapping (its reservation override without a
+    /// usage limit would claim the whole device).
+    #[test]
+    fn host_only_omits_gpu_mapping() {
+        let yaml =
+            derive_sirius_config_yaml(None, None, Some("12GiB"), Path::new(".cn1"), None).unwrap();
+        assert!(!yaml.contains("gpu:"), "{yaml}");
+        assert!(yaml.contains("capacity_bytes: \"12GiB\"\n"), "{yaml}");
+    }
+
+    /// Full-document snapshot of the two-CNs-on-one-GPU shape, pinned against the C++ schema
+    /// (`sirius_config.cpp` rejects unknown keys).
+    #[test]
+    fn full_document_snapshot() {
+        let yaml =
+            derive_sirius_config_yaml(Some("8GiB"), None, Some("12GiB"), Path::new(".cn1"), None)
+                .unwrap();
+        assert_eq!(
+            yaml,
+            concat!(
+                "sirius:\n",
+                "  topology:\n",
+                "    num_gpus: 1\n",
+                "  memory:\n",
+                "    gpu:\n",
+                "      usage_limit_bytes: \"8GiB\"\n",
+                "      reservation_limit_fraction: 1.0\n",
+                "    host:\n",
+                "      capacity_bytes: \"12GiB\"\n",
+                "  telemetry:\n",
+                "    output_directory: \".cn1/telemetry\"\n",
+            )
+        );
+    }
+
+    /// Full-document snapshot with a socket pinning, pinned against the C++ schema: the keys are
+    /// `sirius.executor.{scan_manager,task_creator,downgrade}.cpu_affinity`, each a *sequence*
+    /// (`sirius_config.cpp` reads them into `thread_pool_config::cpu_affinity_list`, and
+    /// `yaml_reader.hpp` throws "expected a sequence" for anything else).
+    #[test]
+    fn full_document_snapshot_with_cpu_affinity() {
+        let yaml = derive_sirius_config_yaml(
+            Some("8GiB"),
+            None,
+            Some("12GiB"),
+            Path::new(".cn1"),
+            Some(&[0, 1, 2, 3]),
+        )
+        .unwrap();
+        assert_eq!(
+            yaml,
+            concat!(
+                "sirius:\n",
+                "  topology:\n",
+                "    num_gpus: 1\n",
+                "  memory:\n",
+                "    gpu:\n",
+                "      usage_limit_bytes: \"8GiB\"\n",
+                "      reservation_limit_fraction: 1.0\n",
+                "    host:\n",
+                "      capacity_bytes: \"12GiB\"\n",
+                "  executor:\n",
+                "    scan_manager:\n",
+                "      cpu_affinity: [0, 1, 2, 3]\n",
+                "    task_creator:\n",
+                "      cpu_affinity: [0, 1, 2, 3]\n",
+                "    downgrade:\n",
+                "      cpu_affinity: [0, 1, 2, 3]\n",
+                "  telemetry:\n",
+                "    output_directory: \".cn1/telemetry\"\n",
+            )
+        );
+    }
+
+    /// No affinity means no `executor:` block at all — the pre-existing shape, byte for byte.
+    #[test]
+    fn absent_affinity_emits_no_executor_block() {
+        let yaml =
+            derive_sirius_config_yaml(Some("8GiB"), None, Some("12GiB"), Path::new(".cn1"), None)
+                .unwrap();
+        assert!(!yaml.contains("executor:"), "{yaml}");
+        assert!(!yaml.contains("cpu_affinity"), "{yaml}");
+    }
+
+    /// The GPU pipeline pool must never be emitted: `task_scheduler.cpp` overwrites its affinity
+    /// from the discovered GPU topology, so a YAML value there would be dead config.
+    #[test]
+    fn pipeline_pool_is_not_pinned_from_yaml() {
+        let yaml = derive_sirius_config_yaml(
+            Some("8GiB"),
+            None,
+            None,
+            Path::new(".cn1"),
+            Some(&[0, 1, 2, 3]),
+        )
+        .unwrap();
+        assert!(!yaml.contains("pipeline:"), "{yaml}");
+    }
+
+    /// A whole 72-core socket renders as one flow sequence; the engine's reader has no range
+    /// syntax, so every core is listed.
+    #[test]
+    fn full_socket_renders_every_core() {
+        let cpus: Vec<u32> = (0..=71).collect();
+        let yaml =
+            derive_sirius_config_yaml(Some("8GiB"), None, None, Path::new(".cn1"), Some(&cpus))
+                .unwrap();
+        assert!(yaml.contains("      cpu_affinity: [0, 1, 2,"), "{yaml}");
+        assert!(yaml.contains(", 70, 71]\n"), "{yaml}");
+        assert_eq!(yaml.matches("cpu_affinity: ").count(), 3, "{yaml}");
+    }
+
+    /// A CPU affinity alone must not conjure a config file: the caller treats `Some(yaml)` as
+    /// "use the derived config", which would silently shadow an operator's `--sirius-config`.
+    #[test]
+    fn cpu_affinity_alone_does_not_conjure_a_config() {
+        assert_eq!(
+            derive_sirius_config_yaml(None, None, None, Path::new(".cn1"), Some(&[0, 1])),
+            None
+        );
+    }
+
+    /// Without `--gpu-device` the environment is left alone, exported or not.
+    #[test]
+    fn no_gpu_device_leaves_the_environment_alone() {
+        assert_eq!(resolve_cuda_visible_devices(None, None), Ok(None));
+        assert_eq!(resolve_cuda_visible_devices(None, Some("2")), Ok(None));
+    }
+
+    /// `--gpu-device` is exported when nothing is exported yet.
+    #[test]
+    fn gpu_device_is_exported_when_unset() {
+        assert_eq!(
+            resolve_cuda_visible_devices(Some(3), None),
+            Ok(Some("3".to_string()))
+        );
+    }
+
+    /// An exported value naming the same ordinal is accepted and needs no re-export.
+    #[test]
+    fn matching_export_is_accepted() {
+        assert_eq!(resolve_cuda_visible_devices(Some(1), Some("1")), Ok(None));
+        assert_eq!(resolve_cuda_visible_devices(Some(1), Some(" 1 ")), Ok(None));
+    }
+
+    /// A different ordinal, a device list, or a UUID is refused: the launcher fix that
+    /// motivated this (N CNs collapsing onto one GPU) is exactly the case where an exported
+    /// value used to win silently.
+    #[test]
+    fn disagreeing_export_is_refused() {
+        for exported in ["0", "1,2", "GPU-0f1e2d3c", ""] {
+            let err = resolve_cuda_visible_devices(Some(1), Some(exported))
+                .expect_err(&format!("{exported:?} must be refused"));
+            assert!(err.contains("--gpu-device 1"), "{err}");
+            assert!(err.contains(exported), "{err}");
+        }
+    }
+}

--- a/experimental/starrocks/src/gpu_affinity.rs
+++ b/experimental/starrocks/src/gpu_affinity.rs
@@ -1,0 +1,272 @@
+//! GPU → CPU-socket affinity, discovered from sysfs.
+//!
+//! Each CN pins exactly one GPU, and the engine already hard-binds that CN's pinned host arena
+//! to the GPU's NUMA node (`numa_alloc_onnode`, via the `bind_cpu_to_gpu_numa` host policy).
+//! What the engine does *not* do is place most of its threads: only the GPU pipeline pool is
+//! pinned (`task_scheduler.cpp` copies the GPU's `cpu_cores` into its thread-pool config). The
+//! `scan_manager`, `task_creator` and `downgrade` pools are pinned only from YAML
+//! (`sirius_config.cpp` `cpu_affinity`), and the CN emitted none — so ~20 threads per CN floated
+//! across every CPU on the box while their memory sat on one socket.
+//!
+//! This module resolves the CPU list to put in that YAML. It reads the same sysfs attributes the
+//! engine's own topology discovery uses, so the two agree by construction.
+
+use std::path::{Path, PathBuf};
+
+use tracing::{info, warn};
+
+/// Overrides the derived affinity: a cpulist (`"0-71"`, `"0-3,8"`) to force, or an off switch
+/// (`off`/`0`/`false`/`no`/`none`) to emit no affinity at all.
+const AFFINITY_ENV: &str = "SIRIUS_CN_CPU_AFFINITY";
+
+const PCI_DEVICES: &str = "/sys/bus/pci/devices";
+const NVIDIA_VENDOR: &str = "0x10de";
+
+/// The CPU socket a GPU hangs off: its NUMA node and that node's CPU ordinals.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GpuSocket {
+    /// NUMA node of the GPU's PCI device — always a CPU-bearing node, never an HBM domain
+    /// (a GPU's `numa_node` attribute names the host bridge's socket, not its own memory).
+    pub numa_node: u32,
+    /// The node's CPU ordinals, from the device's `local_cpulist`.
+    pub cpus: Vec<u32>,
+}
+
+/// Resolves the CPU cores this CN's threads should be confined to, or `None` when the answer
+/// cannot be established — in which case the caller must emit no affinity and leave the pools
+/// free-floating, which is the historical behaviour.
+///
+/// Order of precedence: the `SIRIUS_CN_CPU_AFFINITY` override, then sysfs discovery from the
+/// effective GPU ordinal. A wrong pinning is worse than none, so every step that cannot be
+/// resolved with certainty gives up rather than guessing.
+pub fn cpu_affinity_for_gpu(gpu_device: Option<u32>) -> Option<Vec<u32>> {
+    if let Some(raw) = std::env::var_os(AFFINITY_ENV) {
+        let raw = raw.to_string_lossy().trim().to_ascii_lowercase();
+        if matches!(raw.as_str(), "off" | "0" | "false" | "no" | "none") {
+            info!("{AFFINITY_ENV}={raw}: emitting no CPU affinity for the engine thread pools");
+            return None;
+        }
+        match parse_cpulist(&raw) {
+            Some(cpus) if !cpus.is_empty() => {
+                info!(
+                    cpus = cpus.len(),
+                    "{AFFINITY_ENV} override: pinning to '{raw}'"
+                );
+                return Some(cpus);
+            }
+            _ => {
+                warn!("{AFFINITY_ENV}='{raw}' is not a cpulist or an off switch; ignoring it");
+            }
+        }
+    }
+
+    let ordinal = effective_gpu_ordinal(gpu_device)?;
+    match gpu_socket(ordinal) {
+        Some(socket) => {
+            info!(
+                gpu = ordinal,
+                numa_node = socket.numa_node,
+                cpus = socket.cpus.len(),
+                "pinning the engine thread pools to the GPU's socket"
+            );
+            Some(socket.cpus)
+        }
+        None => {
+            warn!(
+                gpu = ordinal,
+                "could not resolve the GPU's NUMA socket from {PCI_DEVICES}; \
+                 leaving the engine thread pools unpinned"
+            );
+            None
+        }
+    }
+}
+
+/// The physical GPU ordinal this process will actually run on.
+///
+/// Mirrors `engine.rs`: an exported `CUDA_VISIBLE_DEVICES` is what the driver honours, and
+/// bring-up refuses to start when it disagrees with `--gpu-device`, so whenever the variable is
+/// present it is the effective ordinal. A non-numeric entry (`GPU-<uuid>`, `MIG-<uuid>`) is not
+/// resolvable to a PCI slot here, so it yields `None`.
+fn effective_gpu_ordinal(gpu_device: Option<u32>) -> Option<u32> {
+    match std::env::var("CUDA_VISIBLE_DEVICES") {
+        Ok(visible) => visible.split(',').next()?.trim().parse::<u32>().ok(),
+        Err(_) => gpu_device,
+    }
+}
+
+/// Looks up the socket of the `ordinal`-th NVIDIA GPU on the system.
+pub fn gpu_socket(ordinal: u32) -> Option<GpuSocket> {
+    gpu_socket_in(Path::new(PCI_DEVICES), ordinal)
+}
+
+fn gpu_socket_in(pci_root: &Path, ordinal: u32) -> Option<GpuSocket> {
+    let dir = pci_root.join(nvidia_gpu_bdfs(pci_root).get(ordinal as usize)?);
+
+    // `numa_node` is -1 when the platform exposes no proximity domain for the device.
+    let numa_node = u32::try_from(read_attr(&dir, "numa_node")?.parse::<i32>().ok()?).ok()?;
+    let cpus = parse_cpulist(&read_attr(&dir, "local_cpulist")?)?;
+    // A cpuless proximity domain (on this box: the GPU-HBM nodes) has an empty cpulist. Binding
+    // threads or memory there would be catastrophic, so treat it as "unknown" instead.
+    if cpus.is_empty() {
+        return None;
+    }
+    Some(GpuSocket { numa_node, cpus })
+}
+
+/// The PCI addresses of every NVIDIA display/3D device, ordered the way CUDA enumerates them.
+///
+/// CUDA orders devices by `CUDA_DEVICE_ORDER`, whose default (`FASTEST_FIRST`) breaks ties by
+/// PCI bus id — so on a homogeneous box like this one it is PCI order, same as `PCI_BUS_ID`.
+/// Sorting the addresses as strings is sorting them numerically: sysfs always renders them
+/// fixed-width as `dddd:bb:dd.f`.
+fn nvidia_gpu_bdfs(pci_root: &Path) -> Vec<PathBuf> {
+    let mut bdfs: Vec<PathBuf> = std::fs::read_dir(pci_root)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|entry| {
+            let dir = entry.path();
+            if read_attr(&dir, "vendor").as_deref() != Some(NVIDIA_VENDOR) {
+                return false;
+            }
+            // Class 0x0300xx (VGA) / 0x0302xx (3D controller) are the GPUs; the NVIDIA-vendored
+            // host bridges and switches on this platform are 0x0604xx and must not be counted.
+            read_attr(&dir, "class")
+                .is_some_and(|class| class.starts_with("0x0300") || class.starts_with("0x0302"))
+        })
+        .map(|entry| PathBuf::from(entry.file_name()))
+        .collect();
+    bdfs.sort();
+    bdfs
+}
+
+fn read_attr(dir: &Path, name: &str) -> Option<String> {
+    std::fs::read_to_string(dir.join(name))
+        .ok()
+        .map(|s| s.trim().to_string())
+}
+
+/// Parses a Linux cpulist (`"0-71"`, `"0-3,8,12-15"`, `""`) into CPU ordinals.
+///
+/// Returns `None` on anything malformed rather than a partial list: a truncated affinity mask
+/// would silently over-constrain the pools.
+fn parse_cpulist(list: &str) -> Option<Vec<u32>> {
+    let mut cpus = Vec::new();
+    for range in list.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        match range.split_once('-') {
+            Some((lo, hi)) => {
+                let (lo, hi) = (
+                    lo.trim().parse::<u32>().ok()?,
+                    hi.trim().parse::<u32>().ok()?,
+                );
+                if lo > hi {
+                    return None;
+                }
+                cpus.extend(lo..=hi);
+            }
+            None => cpus.push(range.parse::<u32>().ok()?),
+        }
+    }
+    Some(cpus)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a fake `/sys/bus/pci/devices` tree: `(bdf, vendor, class, numa_node, cpulist)`.
+    fn fake_pci_root(devices: &[(&str, &str, &str, &str, &str)]) -> tempfile::TempDir {
+        let root = tempfile::tempdir().unwrap();
+        for (bdf, vendor, class, numa_node, cpulist) in devices {
+            let dir = root.path().join(bdf);
+            std::fs::create_dir_all(&dir).unwrap();
+            for (name, value) in [
+                ("vendor", *vendor),
+                ("class", *class),
+                ("numa_node", *numa_node),
+                ("local_cpulist", *cpulist),
+            ] {
+                std::fs::write(dir.join(name), format!("{value}\n")).unwrap();
+            }
+        }
+        root
+    }
+
+    /// The 4x GB200 layout of this box: GPU0/1 on socket 0, GPU2/3 on socket 1, with the
+    /// NVIDIA-vendored host bridges interleaved so the class filter is exercised.
+    fn gb200_root() -> tempfile::TempDir {
+        fake_pci_root(&[
+            ("0008:00:00.0", "0x10de", "0x060400", "0", "0-71"),
+            ("0008:01:00.0", "0x10de", "0x030200", "0", "0-71"),
+            ("0009:00:00.0", "0x10de", "0x060400", "0", "0-71"),
+            ("0009:01:00.0", "0x10de", "0x030200", "0", "0-71"),
+            ("0018:00:00.0", "0x10de", "0x060400", "1", "72-143"),
+            ("0018:01:00.0", "0x10de", "0x030200", "1", "72-143"),
+            ("0019:00:00.0", "0x10de", "0x060400", "1", "72-143"),
+            ("0019:01:00.0", "0x10de", "0x030200", "1", "72-143"),
+        ])
+    }
+
+    /// GPU ordinals map to sockets the way the 4x GB200 box lays them out: 0,1 → node 0
+    /// (CPUs 0-71), 2,3 → node 1 (CPUs 72-143). The NVIDIA host bridges must not shift the
+    /// ordinals.
+    #[test]
+    fn gb200_gpu_ordinals_map_to_their_socket() {
+        let root = gb200_root();
+        for ordinal in [0, 1] {
+            let socket = gpu_socket_in(root.path(), ordinal).unwrap();
+            assert_eq!(socket.numa_node, 0, "gpu {ordinal}");
+            assert_eq!(socket.cpus, (0..=71).collect::<Vec<_>>(), "gpu {ordinal}");
+        }
+        for ordinal in [2, 3] {
+            let socket = gpu_socket_in(root.path(), ordinal).unwrap();
+            assert_eq!(socket.numa_node, 1, "gpu {ordinal}");
+            assert_eq!(socket.cpus, (72..=143).collect::<Vec<_>>(), "gpu {ordinal}");
+        }
+    }
+
+    /// An ordinal past the last GPU resolves to nothing rather than wrapping onto another GPU.
+    #[test]
+    fn ordinal_out_of_range_is_unresolved() {
+        let root = gb200_root();
+        assert_eq!(gpu_socket_in(root.path(), 4), None);
+    }
+
+    /// A cpuless proximity domain — the shape of this box's four GPU-HBM NUMA nodes — must never
+    /// be turned into an affinity list.
+    #[test]
+    fn cpuless_domain_is_rejected() {
+        let root = fake_pci_root(&[("0008:01:00.0", "0x10de", "0x030200", "2", "")]);
+        assert_eq!(gpu_socket_in(root.path(), 0), None);
+    }
+
+    /// `numa_node = -1` (no proximity domain exposed) is unresolved, not node 4294967295.
+    #[test]
+    fn unknown_numa_node_is_rejected() {
+        let root = fake_pci_root(&[("0008:01:00.0", "0x10de", "0x030200", "-1", "0-71")]);
+        assert_eq!(gpu_socket_in(root.path(), 0), None);
+    }
+
+    /// Non-NVIDIA devices are skipped even when they sit at a lower PCI address.
+    #[test]
+    fn other_vendors_do_not_shift_ordinals() {
+        let root = fake_pci_root(&[
+            ("0001:01:00.0", "0x1000", "0x030200", "1", "72-143"),
+            ("0008:01:00.0", "0x10de", "0x030200", "0", "0-71"),
+        ]);
+        let socket = gpu_socket_in(root.path(), 0).unwrap();
+        assert_eq!(socket.numa_node, 0);
+    }
+
+    #[test]
+    fn cpulist_forms() {
+        assert_eq!(parse_cpulist("0-3"), Some(vec![0, 1, 2, 3]));
+        assert_eq!(parse_cpulist("5"), Some(vec![5]));
+        assert_eq!(parse_cpulist("0-1,4,6-7"), Some(vec![0, 1, 4, 6, 7]));
+        assert_eq!(parse_cpulist(""), Some(vec![]));
+        assert_eq!(parse_cpulist("3-1"), None);
+        assert_eq!(parse_cpulist("0-x"), None);
+        assert_eq!(parse_cpulist("garbage"), None);
+    }
+}

--- a/experimental/starrocks/src/lib.rs
+++ b/experimental/starrocks/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
+    io::{Read, Write},
     net::{
         IpAddr, Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, TcpListener, TcpStream, ToSocketAddrs,
     },
@@ -48,8 +49,10 @@ mod brpc;
 mod compute_node_service;
 #[cfg(feature = "sirius-engine")]
 mod engine;
+mod engine_settings;
 mod file_schema;
 mod fragment_executor;
+mod gpu_affinity;
 mod proto;
 mod prpc;
 mod result_encoder;
@@ -58,7 +61,16 @@ mod result_store;
 pub use brpc::BrpcServer;
 #[cfg(feature = "sirius-engine")]
 pub use engine::SiriusEngine;
+pub use engine_settings::{
+    EngineSettings, derive_sirius_config_yaml, resolve_cuda_visible_devices,
+};
 pub use fragment_executor::{FragmentExecutor, FragmentResult, StubExecutor};
+pub use gpu_affinity::{GpuSocket, cpu_affinity_for_gpu, gpu_socket};
+
+/// Serializes tests that bring up a GPU engine context: the engine keeps process-global GPU
+/// state, so at most one context may be live at a time within the test binary.
+#[cfg(all(test, feature = "sirius-engine"))]
+pub(crate) static GPU_ENGINE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 const COMPUTE_NODE_PROC_PATH: &str = "/compute_nodes";
 
@@ -317,10 +329,55 @@ impl Default for SharedHeartbeatState {
     }
 }
 
+/// Whether the GPU engine has finished initializing and this CN can actually execute a fragment.
+///
+/// The CN binds its listeners BEFORE building the engine, because engine start-up reserves the
+/// whole RMM pool and takes ~7 s on a GB200 — and for that entire window the process existed but
+/// answered nothing. An FE that boots faster (~4 s) and remembers this node from its persisted
+/// metadata probes into that gap, the probe fails, and the node is auto-blacklisted.
+///
+/// Binding early closes the gap, but it introduces the opposite hazard: a node that answers is a
+/// node the FE will schedule work onto, and an engine that is still warming cannot run it. This
+/// flag is the interlock. Until it flips, the heartbeat is answered with an ERROR status, which
+/// leaves the FE holding the node as not-alive — so it is never scheduled, and (unlike a failed
+/// fragment RPC) a failed heartbeat does NOT add a blacklist entry.
+#[derive(Clone, Debug)]
+pub struct EngineReadiness(Arc<AtomicBool>);
+
+impl EngineReadiness {
+    /// Starts closed: the engine is not up yet. Use this in real bring-up.
+    pub fn warming() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+
+    /// Starts open. For tests and for builds with no engine to wait for.
+    pub fn ready() -> Self {
+        Self(Arc::new(AtomicBool::new(true)))
+    }
+
+    /// Opens the gate. Idempotent; call once the engine can execute fragments.
+    pub fn mark_ready(&self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+
+    /// Whether the engine can execute fragments.
+    pub fn is_ready(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+impl Default for EngineReadiness {
+    fn default() -> Self {
+        Self::ready()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ComputeNodeHeartbeatHandler {
     config: ComputeNodeConfig,
     state: SharedHeartbeatState,
+    /// Gate that keeps the FE from scheduling onto a still-warming engine. See [`EngineReadiness`].
+    readiness: EngineReadiness,
     reboot_time_secs: i64,
     hardware_cores: i32,
     // Operator-configured FE host used to validate the FE-advertised report target. The CN
@@ -335,10 +392,12 @@ impl ComputeNodeHeartbeatHandler {
         config: ComputeNodeConfig,
         state: SharedHeartbeatState,
         expected_frontend_host: Option<Host>,
+        readiness: EngineReadiness,
     ) -> Self {
         Self {
             config,
             state,
+            readiness,
             reboot_time_secs: unix_time_secs(),
             hardware_cores: std::thread::available_parallelism()
                 .map(|parallelism| parallelism.get().min(i32::MAX as usize) as i32)
@@ -495,7 +554,16 @@ impl HeartbeatServiceSyncHandler for ComputeNodeHeartbeatHandler {
             "received FE heartbeat"
         );
 
+        // Record FE identity first even while warming: the epoch/token/backend-id this carries is
+        // what later reports are addressed with, and dropping it would just move the problem.
         let status = match self.handle_master_info(&master_info) {
+            Ok(()) if !self.readiness.is_ready() => {
+                // Answer honestly rather than claiming health. An OK here would make the FE mark
+                // this node alive and schedule a fragment onto an engine that cannot run it — and
+                // THAT failure is a query-path failure, which is what auto-blacklists a node.
+                debug!("heartbeat answered NOT READY: GPU engine is still initializing");
+                error_status("compute node is still initializing its GPU engine".to_string())
+            }
             Ok(()) => ok_status(),
             Err(err) => {
                 warn!(error = %err, "rejecting FE heartbeat");
@@ -747,6 +815,9 @@ pub struct ThriftServer {
 pub type HeartbeatServer = ThriftServer;
 /// Backend service server handle.
 pub type BackendServer = ThriftServer;
+/// HTTP health listener handle. Not a thrift service, but it has the same lifecycle
+/// (bind, blocking accept loop on its own thread, wake-and-join shutdown).
+pub type HttpServer = ThriftServer;
 
 impl ThriftServer {
     /// Clones the shutdown handle so async orchestration can stop the blocking thread.
@@ -886,6 +957,7 @@ pub fn start_heartbeat_server(
     config: ComputeNodeConfig,
     state: SharedHeartbeatState,
     expected_frontend_host: Option<Host>,
+    readiness: EngineReadiness,
 ) -> Result<HeartbeatServer> {
     let listen_addr = format!("{}:{}", config.bind_host, config.heartbeat_port);
     let listener = TcpListener::bind(&listen_addr)
@@ -899,7 +971,7 @@ pub fn start_heartbeat_server(
     info!(address = %local_addr, "starting heartbeat Thrift server");
     // The generated processor owns the handler and is shared across sequential connections.
     let processor = Arc::new(HeartbeatServiceSyncProcessor::new(
-        ComputeNodeHeartbeatHandler::new(config, state, expected_frontend_host),
+        ComputeNodeHeartbeatHandler::new(config, state, expected_frontend_host, readiness),
     ));
     let join_handle =
         thread::spawn(move || run_thrift_server("heartbeat", listener, processor, server_shutdown));
@@ -941,6 +1013,81 @@ pub fn start_backend_server(config: &ComputeNodeConfig) -> Result<BackendServer>
         local_addr,
         name: "backend",
     })
+}
+
+/// Starts the HTTP listener on `--http-port`.
+///
+/// This exists because the CN ADVERTISES `http_port` in its heartbeat `TBackendInfo` but, until
+/// this listener, never bound it — and that gap is not cosmetic. The FE's blacklist eviction path
+/// (`HostBlacklist.remove` -> `NetUtils.checkAccessibleForAllPorts(host, [bePort, brpcPort,
+/// httpPort])`) opens a raw TCP connection to ALL THREE advertised ports and un-blacklists a node
+/// only when every one of them accepts. With `http_port` unbound that check could never pass, so a
+/// CN auto-blacklisted by a single transient RPC failure — including the FE-heartbeat-before-CN-ready
+/// race during cluster start-up — stayed blacklisted for the FE's entire process lifetime and
+/// silently did zero work, while still reporting `Alive = true`.
+///
+/// Measured on the 4x GB200 box before this fix: 2 of 4 CNs were auto-blacklisted ~2 s after every
+/// cluster start, and q14/SF100 ran 48.9% / 0% / 0% / 51.1% across the four CNs. With the blacklist
+/// manually cleared, the same query ran 25.6% / 24.6% / 24.7% / 25.1%.
+///
+/// The FE only needs the port to ACCEPT, so this is deliberately not a real HTTP stack: it answers
+/// anything with a fixed 200 and closes. Read/write timeouts stop one slow client from stalling the
+/// single-threaded accept loop.
+pub fn start_http_server(config: &ComputeNodeConfig) -> Result<HttpServer> {
+    let listen_addr = format!("{}:{}", config.bind_host, config.http_port);
+    let listener = TcpListener::bind(&listen_addr)
+        .with_context(|| format!("failed to bind HTTP server at {listen_addr}"))?;
+    let local_addr = listener
+        .local_addr()
+        .context("failed to read HTTP server address")?;
+    let shutdown = ThriftServerShutdown::new(listener_wake_addr(local_addr));
+    let server_shutdown = shutdown.clone();
+
+    info!(address = %local_addr, "starting HTTP health listener");
+    let join_handle = thread::spawn(move || run_http_server(listener, server_shutdown));
+
+    Ok(ThriftServer {
+        join_handle: Some(join_handle),
+        shutdown,
+        local_addr,
+        name: "http",
+    })
+}
+
+/// Accept loop for the health listener: at most one fixed response per connection, then close.
+fn run_http_server(listener: TcpListener, shutdown: ThriftServerShutdown) -> Result<()> {
+    const RESPONSE: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 3\r\nConnection: close\r\n\r\nOK\n";
+    const IO_TIMEOUT: Duration = Duration::from_secs(2);
+
+    for stream in listener.incoming() {
+        if shutdown.is_requested() {
+            break;
+        }
+
+        match stream {
+            Ok(mut stream) => {
+                if shutdown.is_requested() {
+                    break;
+                }
+                // The FE's reachability probe connects and closes without sending a byte, so every
+                // step here is best-effort: a client that vanishes mid-exchange is the normal case
+                // and must never take the listener down.
+                let _ = stream.set_read_timeout(Some(IO_TIMEOUT));
+                let _ = stream.set_write_timeout(Some(IO_TIMEOUT));
+                let mut scratch = [0_u8; 1024];
+                let _ = stream.read(&mut scratch);
+                if let Err(err) = stream.write_all(RESPONSE) {
+                    debug!(error = %err, "HTTP health client went away before the response");
+                }
+                let _ = stream.flush();
+                let _ = stream.shutdown(Shutdown::Both);
+            }
+            Err(_) if shutdown.is_requested() => break,
+            Err(err) => warn!(error = %err, "failed to accept HTTP connection"),
+        }
+    }
+
+    Ok(())
 }
 
 /// Runs one generated thrift processor behind a blocking TCP listener.
@@ -1351,7 +1498,12 @@ mod tests {
     fn handler() -> (ComputeNodeHeartbeatHandler, SharedHeartbeatState) {
         let state = SharedHeartbeatState::new();
         (
-            ComputeNodeHeartbeatHandler::new(test_config(), state.clone(), None),
+            ComputeNodeHeartbeatHandler::new(
+                test_config(),
+                state.clone(),
+                None,
+                EngineReadiness::ready(),
+            ),
             state,
         )
     }
@@ -1671,7 +1823,12 @@ mod tests {
         let mut config = test_config();
         config.bind_host = Host::local();
         config.heartbeat_port = 0;
-        let server = match start_heartbeat_server(config, SharedHeartbeatState::new(), None) {
+        let server = match start_heartbeat_server(
+            config,
+            SharedHeartbeatState::new(),
+            None,
+            EngineReadiness::ready(),
+        ) {
             Ok(server) => server,
             Err(err) if is_permission_denied(&err) => return,
             Err(err) => panic!("{err:?}"),
@@ -1683,6 +1840,119 @@ mod tests {
         drop(stream);
     }
 
+    /// The advertised `http_port` must actually accept a connection, because the FE only lifts a
+    /// node's blacklist entry once `NetUtils.checkAccessibleForAllPorts` can reach EVERY advertised
+    /// port. While this listener did not exist, a CN auto-blacklisted by one transient RPC failure
+    /// stayed blacklisted for the FE's whole lifetime and silently did zero work.
+    #[test]
+    fn http_server_accepts_and_answers_the_reachability_probe() {
+        let mut config = test_config();
+        config.bind_host = Host::local();
+        config.http_port = 0;
+        let server = match start_http_server(&config) {
+            Ok(server) => server,
+            Err(err) if is_permission_denied(&err) => return,
+            Err(err) => panic!("{err:?}"),
+        };
+
+        // The FE's probe connects and closes without writing a byte; answer it anyway so the port
+        // is useful to a human with curl. Reading to EOF also proves the server closes the socket.
+        let mut stream = TcpStream::connect(server.local_addr()).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        stream.write_all(b"GET / HTTP/1.1\r\n\r\n").unwrap();
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+        assert!(
+            response.starts_with("HTTP/1.1 200 OK"),
+            "expected a 200 status line, got {response:?}"
+        );
+
+        server.shutdown();
+        server.join().unwrap();
+    }
+
+    /// The readiness gate is the interlock that makes binding-before-engine-init safe: while the
+    /// engine is warming the port must ANSWER (so the FE does not blacklist an unreachable node)
+    /// but must NOT claim health (so the FE does not schedule a fragment onto an engine that
+    /// cannot run it). Flipping the gate must switch the answer without restarting anything.
+    #[test]
+    fn warming_heartbeat_is_answered_but_not_ok_until_the_engine_is_ready() {
+        let state = SharedHeartbeatState::new();
+        let readiness = EngineReadiness::warming();
+        let handler =
+            ComputeNodeHeartbeatHandler::new(test_config(), state.clone(), None, readiness.clone());
+
+        // Warming: answered (not a connection failure) but explicitly not OK.
+        let warming = handler.handle_heartbeat(master(7)).unwrap();
+        assert_ne!(
+            warming.status.status_code,
+            TStatusCode::OK,
+            "a warming CN must not report OK -- the FE would schedule work onto it"
+        );
+        // FE identity is still captured while warming, so the first post-ready report is addressed
+        // correctly instead of waiting for another heartbeat round trip.
+        assert_eq!(state.snapshot().epoch, Some(7));
+        assert_eq!(state.snapshot().compute_node_id, Some(10001));
+
+        readiness.mark_ready();
+
+        let ready = handler.handle_heartbeat(master(7)).unwrap();
+        assert_eq!(
+            ready.status.status_code,
+            TStatusCode::OK,
+            "once the engine is up the same handler must report OK"
+        );
+        // Same advertised ports either way -- readiness changes the STATUS, not the identity.
+        assert_eq!(ready.backend_info.be_port, warming.backend_info.be_port);
+    }
+
+    /// `mark_ready` is idempotent and `ready()` starts open, so non-engine builds and tests are
+    /// unaffected by the gate.
+    #[test]
+    fn readiness_defaults_are_open_and_marking_is_idempotent() {
+        let r = EngineReadiness::ready();
+        assert!(r.is_ready());
+        r.mark_ready();
+        assert!(r.is_ready());
+
+        let w = EngineReadiness::warming();
+        assert!(!w.is_ready());
+        let clone = w.clone();
+        w.mark_ready();
+        assert!(clone.is_ready(), "clones must share one gate, not copy it");
+    }
+
+    /// A bare connect-then-close -- exactly what the FE reachability probe does -- must not take
+    /// the accept loop down, so a later probe still succeeds.
+    #[test]
+    fn http_server_survives_a_client_that_never_reads() {
+        let mut config = test_config();
+        config.bind_host = Host::local();
+        config.http_port = 0;
+        let server = match start_http_server(&config) {
+            Ok(server) => server,
+            Err(err) if is_permission_denied(&err) => return,
+            Err(err) => panic!("{err:?}"),
+        };
+        let addr = server.local_addr();
+
+        drop(TcpStream::connect(addr).unwrap());
+        // The second probe is the assertion: it can only connect if the first one left the
+        // listener alive.
+        let mut stream = TcpStream::connect(addr).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 200 OK"), "{response:?}");
+
+        server.shutdown();
+        server.join().unwrap();
+    }
+
     /// Regression for the shutdown TOCTOU race: a client that connects but never sends a
     /// request leaves the server blocked in `processor.process()`; shutdown must still close
     /// that tracked connection and let `join()` return promptly rather than hang forever.
@@ -1691,7 +1961,12 @@ mod tests {
         let mut config = test_config();
         config.bind_host = Host::local();
         config.heartbeat_port = 0;
-        let server = match start_heartbeat_server(config, SharedHeartbeatState::new(), None) {
+        let server = match start_heartbeat_server(
+            config,
+            SharedHeartbeatState::new(),
+            None,
+            EngineReadiness::ready(),
+        ) {
             Ok(server) => server,
             Err(err) if is_permission_denied(&err) => return,
             Err(err) => panic!("{err:?}"),
@@ -1729,11 +2004,12 @@ mod tests {
         config.bind_host = Host::local();
         config.heartbeat_port = 0;
         let state = SharedHeartbeatState::new();
-        let server = match start_heartbeat_server(config, state.clone(), None) {
-            Ok(server) => server,
-            Err(err) if is_permission_denied(&err) => return,
-            Err(err) => panic!("{err:?}"),
-        };
+        let server =
+            match start_heartbeat_server(config, state.clone(), None, EngineReadiness::ready()) {
+                Ok(server) => server,
+                Err(err) if is_permission_denied(&err) => return,
+                Err(err) => panic!("{err:?}"),
+            };
         let addr = server.local_addr();
 
         let stream = TcpStream::connect(addr).unwrap();
@@ -1766,6 +2042,7 @@ mod tests {
             test_config(),
             state.clone(),
             Some(Host::new("127.0.0.1").unwrap()),
+            EngineReadiness::ready(),
         );
         // master(7) advertises a network_address of 127.0.0.1:9020 (matches) — flip the host.
         let mut hostile = master(7);
@@ -1788,6 +2065,7 @@ mod tests {
             test_config(),
             state.clone(),
             Some(Host::new("127.0.0.1").unwrap()),
+            EngineReadiness::ready(),
         );
 
         let result = handler.handle_heartbeat(master(7)).unwrap();

--- a/experimental/starrocks/src/main.rs
+++ b/experimental/starrocks/src/main.rs
@@ -3,14 +3,16 @@ use std::{num::NonZeroU32, path::PathBuf, sync::Arc, time::Duration};
 use anyhow::{Result, anyhow};
 use backon::{ExponentialBuilder, Retryable};
 use clap::Parser;
-#[cfg(feature = "sirius-engine")]
-use sirius_starrocks_cn::SiriusEngine;
 #[cfg(not(feature = "sirius-engine"))]
 use sirius_starrocks_cn::StubExecutor;
 use sirius_starrocks_cn::{
-    BackendServer, BrpcServer, ComputeNodeConfig, FeConfig, FragmentExecutor, HeartbeatServer,
-    SharedHeartbeatState, register_node, report_to_frontend_once, start_backend_server,
-    start_heartbeat_server,
+    BackendServer, BrpcServer, ComputeNodeConfig, EngineReadiness, FeConfig, FragmentExecutor,
+    HeartbeatServer, HttpServer, SharedHeartbeatState, register_node, report_to_frontend_once,
+    start_backend_server, start_heartbeat_server, start_http_server,
+};
+#[cfg(feature = "sirius-engine")]
+use sirius_starrocks_cn::{
+    EngineSettings, SiriusEngine, cpu_affinity_for_gpu, derive_sirius_config_yaml,
 };
 use tokio::task::{JoinError, JoinSet};
 use tokio_util::sync::CancellationToken;
@@ -56,41 +58,150 @@ struct RegistrationConfig {
 /// Sirius engine bring-up settings.
 struct EngineConfig {
     /// Path to a Sirius YAML config file. When unset, built-in engine defaults are used.
-    #[arg(long)]
+    /// Conflicts with the memory carve-out flags: a full config already decides memory.
+    #[arg(
+        long,
+        conflicts_with_all = ["gpu_memory_limit", "gpu_memory_fraction", "host_memory_limit"]
+    )]
     sirius_config: Option<PathBuf>,
+
+    /// GPU memory carve-out for this CN as an absolute size (e.g. `8GiB`, `0.5TiB`,
+    /// `8589934592`). Passed verbatim to the engine's byte parser (K=1000, Ki=1024).
+    #[arg(long, conflicts_with = "gpu_memory_fraction", value_parser = parse_byte_size)]
+    gpu_memory_limit: Option<String>,
+
+    /// GPU memory carve-out as a fraction of TOTAL device memory (not free); 0 < f <= 1.0.
+    #[arg(long, value_parser = parse_memory_fraction)]
+    gpu_memory_fraction: Option<f64>,
+
+    /// CUDA device ordinal to run on; exported as `CUDA_VISIBLE_DEVICES` before engine
+    /// bring-up. An already-exported `CUDA_VISIBLE_DEVICES` must name this same device, or
+    /// bring-up is refused. Unset by default: the engine sees whatever the environment exposes.
+    #[arg(long)]
+    gpu_device: Option<u32>,
+
+    /// Host (CPU) memory capacity for the engine as an absolute size (e.g. `12GiB`). Passed
+    /// verbatim to the engine's byte parser.
+    #[arg(long, value_parser = parse_byte_size)]
+    host_memory_limit: Option<String>,
+
+    /// Directory for engine artifacts (derived config, logs, telemetry). Defaults to
+    /// `sirius-cn-<brpc_port>` under the current working directory.
+    #[arg(long)]
+    engine_dir: Option<PathBuf>,
+}
+
+/// Validates the shape of a byte-size flag: `^[0-9]+(\.[0-9]+)?\s*(B|[KMGT]i?B?)?$`. Only the
+/// shape — the authoritative parser is the engine's C++ `parse_bytes`, so the accepted string
+/// is passed through verbatim.
+fn parse_byte_size(value: &str) -> Result<String, String> {
+    let invalid = || {
+        format!(
+            "invalid byte size '{value}': expected <number>[ ]<unit> where unit is \
+             B or K/M/G/T with optional 'i' (binary) and 'B' — e.g. 8GiB, 12GB, 8589934592"
+        )
+    };
+    let digits = value.len() - value.trim_start_matches(|c: char| c.is_ascii_digit()).len();
+    if digits == 0 {
+        return Err(invalid());
+    }
+    let mut rest = &value[digits..];
+    if let Some(fraction) = rest.strip_prefix('.') {
+        let fraction_digits = fraction.len()
+            - fraction
+                .trim_start_matches(|c: char| c.is_ascii_digit())
+                .len();
+        if fraction_digits == 0 {
+            return Err(invalid());
+        }
+        rest = &fraction[fraction_digits..];
+    }
+    let suffix = rest.trim_start_matches(|c: char| c.is_ascii_whitespace());
+    let suffix_valid = match suffix {
+        "" | "B" => true,
+        _ => {
+            let mut chars = suffix.chars();
+            matches!(chars.next(), Some('K' | 'M' | 'G' | 'T'))
+                && matches!(chars.as_str(), "" | "i" | "B" | "iB")
+        }
+    };
+    if suffix_valid {
+        Ok(value.to_string())
+    } else {
+        Err(invalid())
+    }
+}
+
+/// Validates a GPU memory fraction: 0 < f <= 1.0 of TOTAL device memory.
+fn parse_memory_fraction(value: &str) -> Result<f64, String> {
+    let fraction: f64 = value
+        .parse()
+        .map_err(|err| format!("invalid GPU memory fraction '{value}': {err}"))?;
+    if fraction > 0.0 && fraction <= 1.0 {
+        Ok(fraction)
+    } else {
+        Err(format!(
+            "GPU memory fraction must satisfy 0 < f <= 1.0 (fraction of TOTAL device memory), got '{value}'"
+        ))
+    }
 }
 
 impl Args {
-    /// Starts the CN listeners, registers with FE, and waits for shutdown.
+    /// Starts the CN listeners, brings up the engine, registers with FE, and waits for shutdown.
     #[instrument(name = "compute_node", skip_all)]
     async fn run(self) -> Result<()> {
-        // Build the fragment executor before serving any RPC. Compiled with the engine, this brings
-        // up the GPU engine on its dedicated thread (fail-fast: a bad config or GPU failure exits
-        // before FE can route work here); otherwise it is a stub. The handle is held for the
-        // process lifetime and torn down after the servers stop, below.
-        #[cfg(feature = "sirius-engine")]
-        let executor: Arc<dyn FragmentExecutor> = Arc::new(
-            SiriusEngine::start(self.engine.sirius_config.clone()).map_err(|err| anyhow!(err))?,
-        );
-        #[cfg(not(feature = "sirius-engine"))]
-        let executor: Arc<dyn FragmentExecutor> = {
-            warn_engine_disabled(&self.engine);
-            Arc::new(StubExecutor)
-        };
-
         let state = SharedHeartbeatState::new();
+        // Closed until the engine is up. Binding the listeners first (below) is what closes the
+        // ~7 s window in which this process existed but answered nothing; this gate is what stops
+        // that from turning into "answers, therefore gets scheduled, therefore fails a fragment".
+        let readiness = EngineReadiness::warming();
 
+        // LISTENERS FIRST, ENGINE SECOND. Engine start-up reserves the entire RMM pool and takes
+        // ~7 s on a GB200, while the FE is up in ~4 s and immediately heartbeats every compute node
+        // it remembers from its persisted metadata. Building the engine first left every port
+        // refusing connections for that whole window, and the FE auto-blacklisted the nodes it
+        // could not reach. Ordering it this way means the probe finds a listener; the readiness
+        // gate above is what keeps the answer honest until the engine can actually run work.
+        //
         // HeartbeatService tells FE this process is alive and captures FE identity. The configured
         // FE host pins the report target so a hostile heartbeat cannot redirect outbound reports.
         let heartbeat_server = start_heartbeat_server(
             self.compute_node.clone(),
             state.clone(),
             Some(self.fe.host.clone()),
+            readiness.clone(),
         )?;
         // BackendService exposes the shallow CN RPC skeleton on the normal thrift port.
         let backend_server = start_backend_server(&self.compute_node)?;
+        // The HTTP port is advertised in every heartbeat, and the FE refuses to lift a node's
+        // blacklist entry until it can open a TCP connection to it.
+        let http_server = start_http_server(&self.compute_node)?;
+
+        // Now the expensive part. Compiled with the engine, this brings up the GPU engine on its
+        // dedicated thread (fail-fast: a bad config or GPU failure exits before FE can route work
+        // here); otherwise it is a stub. The handle is held for the process lifetime and torn down
+        // after the servers stop, below. Failing here exits the process, which releases the ports
+        // bound above — the FE sees the node go away rather than being told it is healthy.
+        #[cfg(feature = "sirius-engine")]
+        let executor: Arc<dyn FragmentExecutor> = {
+            let settings = self.engine.resolve(&self.compute_node)?;
+            self.engine.ensure_gpu_unclaimed()?;
+            Arc::new(SiriusEngine::start(settings).map_err(|err| anyhow!(err))?)
+        };
+        #[cfg(not(feature = "sirius-engine"))]
+        let executor: Arc<dyn FragmentExecutor> = {
+            warn_engine_disabled(&self.engine);
+            Arc::new(StubExecutor)
+        };
         // BRPC PInternalService dispatches plan fragments on the brpc port.
         let brpc_runtime = BrpcRuntime::start(&self.compute_node, executor.clone())?;
+
+        // Everything that can execute a fragment is now up, so start answering heartbeats OK and
+        // let the FE schedule onto this node. Opening the gate before brpc bound would advertise a
+        // node whose fragment endpoint is still refusing connections.
+        readiness.mark_ready();
+        info!("compute node is READY: engine and BRPC are up");
+
         self.registration
             .register_node_with_retries(&self.fe, &self.compute_node)
             .await?;
@@ -107,6 +218,7 @@ impl Args {
         let result = RunningComputeNode {
             heartbeat_server,
             backend_server,
+            http_server,
             brpc_runtime,
             registration_task,
             report_task,
@@ -124,12 +236,142 @@ impl Args {
     }
 }
 
-/// Warns when an engine config is supplied but the engine was compiled out, so the flag is
-/// silently ignored rather than honored.
+#[cfg(feature = "sirius-engine")]
+impl EngineConfig {
+    /// Resolves the CLI flags into engine settings, writing the derived carve-out config under
+    /// the engine directory when a memory flag is set (clap forbids combining those flags with
+    /// `--sirius-config`, so the two config sources never race).
+    fn resolve(&self, compute_node: &ComputeNodeConfig) -> Result<EngineSettings> {
+        let engine_dir = self
+            .engine_dir
+            .clone()
+            .unwrap_or_else(|| PathBuf::from(format!("sirius-cn-{}", compute_node.brpc_port)));
+        // Confine the engine's otherwise-unpinned thread pools to the socket that owns both this
+        // CN's GPU and its `numa_alloc_onnode` host arena. `None` (undiscoverable, or switched
+        // off with SIRIUS_CN_CPU_AFFINITY) leaves them free-floating, as before.
+        let cpu_affinity = cpu_affinity_for_gpu(self.gpu_device);
+        let config = match derive_sirius_config_yaml(
+            self.gpu_memory_limit.as_deref(),
+            self.gpu_memory_fraction,
+            self.host_memory_limit.as_deref(),
+            &engine_dir,
+            cpu_affinity.as_deref(),
+        ) {
+            Some(yaml) => {
+                std::fs::create_dir_all(&engine_dir).map_err(|err| {
+                    anyhow!(
+                        "failed to create engine directory {}: {err}",
+                        engine_dir.display()
+                    )
+                })?;
+                let path = engine_dir.join("derived-sirius-config.yaml");
+                std::fs::write(&path, yaml).map_err(|err| {
+                    anyhow!(
+                        "failed to write derived Sirius config {}: {err}",
+                        path.display()
+                    )
+                })?;
+                info!(config = %path.display(), "wrote derived Sirius config");
+                Some(path)
+            }
+            None => self.sirius_config.clone(),
+        };
+        Ok(EngineSettings {
+            config,
+            engine_dir,
+            gpu_device: self.gpu_device,
+        })
+    }
+
+    /// Refuses a default-config bring-up while another process holds the GPU: the built-in
+    /// config primes ~0.95x of device memory, so bring-up would abort deep inside rmm instead
+    /// of failing with an actionable message. A missing or failing `nvidia-smi` only warns —
+    /// the rmm abort remains the backstop.
+    fn ensure_gpu_unclaimed(&self) -> Result<()> {
+        // A supplied config or GPU carve-out means the operator already sized this CN.
+        if self.sirius_config.is_some()
+            || self.gpu_memory_limit.is_some()
+            || self.gpu_memory_fraction.is_some()
+        {
+            return Ok(());
+        }
+        let mut command = std::process::Command::new("nvidia-smi");
+        command.args([
+            "--query-compute-apps=pid,used_memory",
+            "--format=csv,noheader",
+        ]);
+        if let Some(device) = self.gpu_device {
+            command.args(["-i", &device.to_string()]);
+        }
+        let output = match command.output() {
+            Ok(output) => output,
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    "nvidia-smi unavailable; skipping the shared-GPU preflight (an \
+                     over-committed device will still abort in rmm)"
+                );
+                return Ok(());
+            }
+        };
+        if !output.status.success() {
+            warn!(
+                status = %output.status,
+                stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+                "nvidia-smi failed; skipping the shared-GPU preflight (an over-committed \
+                 device will still abort in rmm)"
+            );
+            return Ok(());
+        }
+        // Each row is "pid, used_memory MiB" for one compute process on the device.
+        let holders: Vec<String> = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(|line| match line.split_once(',') {
+                Some((pid, used)) => format!("pid {} holds {}", pid.trim(), used.trim()),
+                None => line.to_string(),
+            })
+            .collect();
+        if holders.is_empty() {
+            return Ok(());
+        }
+        Err(anyhow!(
+            "refusing to start with the default Sirius memory config: it primes ~0.95x of \
+             device memory at bring-up, but another process already holds the GPU ({}). \
+             Bring-up would abort with the rmm OOM 'std::bad_alloc: out_of_memory: CUDA error \
+             (failed to allocate ...) cuda_async_view_memory_resource.hpp:87'. Pass \
+             --gpu-memory-limit (e.g. 8GiB) to carve out a slice of the device, or \
+             --sirius-config with an explicit memory config",
+            holders.join("; ")
+        ))
+    }
+}
+
+/// Warns when engine flags are supplied but the engine was compiled out, so the flags are
+/// loudly ignored rather than silently dropped.
 #[cfg(not(feature = "sirius-engine"))]
 fn warn_engine_disabled(engine: &EngineConfig) {
-    if engine.sirius_config.is_some() {
-        warn!("--sirius-config ignored: built without the `sirius-engine` feature");
+    let EngineConfig {
+        sirius_config,
+        gpu_memory_limit,
+        gpu_memory_fraction,
+        gpu_device,
+        host_memory_limit,
+        engine_dir,
+    } = engine;
+    if sirius_config.is_some()
+        || gpu_memory_limit.is_some()
+        || gpu_memory_fraction.is_some()
+        || gpu_device.is_some()
+        || host_memory_limit.is_some()
+        || engine_dir.is_some()
+    {
+        warn!(
+            "engine flags (--sirius-config / --gpu-memory-limit / --gpu-memory-fraction / \
+             --gpu-device / --host-memory-limit / --engine-dir) ignored: built without the \
+             `sirius-engine` feature"
+        );
     }
 }
 
@@ -291,6 +533,9 @@ struct RunningComputeNode {
     heartbeat_server: HeartbeatServer,
     /// Blocking thrift backend service server handle.
     backend_server: BackendServer,
+    /// Blocking HTTP health listener on the advertised `--http-port`. Serves no CN traffic; it
+    /// exists so the FE's blacklist-eviction reachability probe can succeed.
+    http_server: HttpServer,
     /// BRPC runtime task and shutdown token.
     brpc_runtime: BrpcRuntime,
     /// Background task that refreshes FE registration when heartbeats are stale.
@@ -305,6 +550,7 @@ impl RunningComputeNode {
     async fn wait_until_shutdown(self) -> Result<()> {
         let heartbeat_shutdown = self.heartbeat_server.shutdown_handle();
         let backend_shutdown = self.backend_server.shutdown_handle();
+        let http_shutdown = self.http_server.shutdown_handle();
         let brpc_shutdown = self.brpc_runtime.shutdown.clone();
 
         // Drive every server's join as a labelled task so the first exit can be observed in the
@@ -314,6 +560,8 @@ impl RunningComputeNode {
         servers.spawn_blocking(move || ("heartbeat", heartbeat_server.join()));
         let backend_server = self.backend_server;
         servers.spawn_blocking(move || ("backend", backend_server.join()));
+        let http_server = self.http_server;
+        servers.spawn_blocking(move || ("http", http_server.join()));
         let brpc_join = self.brpc_runtime.join;
         servers.spawn(async move {
             let result = brpc_join
@@ -356,6 +604,7 @@ impl RunningComputeNode {
         report_task.abort();
         heartbeat_shutdown.shutdown();
         backend_shutdown.shutdown();
+        http_shutdown.shutdown();
         brpc_shutdown.cancel();
 
         let mut result = outcome;
@@ -398,4 +647,96 @@ async fn main() -> Result<()> {
         .init();
 
     Args::parse().run().await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use clap::error::ErrorKind;
+    use clap::{CommandFactory, Parser};
+
+    use super::*;
+
+    /// Parses CLI arguments the way `main` would, with the binary name prepended.
+    fn parse(args: &[&str]) -> Result<Args, clap::Error> {
+        Args::try_parse_from(std::iter::once("sirius-starrocks-cn").chain(args.iter().copied()))
+    }
+
+    /// Clap's own consistency check over the whole derived command (conflict targets included).
+    #[test]
+    fn cli_definition_is_consistent() {
+        Args::command().debug_assert();
+    }
+
+    /// An absolute limit and a fraction size the same carve-out; only one may be given.
+    #[test]
+    fn gpu_memory_limit_conflicts_with_fraction() {
+        let err = parse(&["--gpu-memory-limit", "8GiB", "--gpu-memory-fraction", "0.5"])
+            .expect_err("conflicting flags must not parse");
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    /// A full config file already decides memory, so every memory flag conflicts with it.
+    #[test]
+    fn sirius_config_conflicts_with_each_memory_flag() {
+        for (flag, value) in [
+            ("--gpu-memory-limit", "8GiB"),
+            ("--gpu-memory-fraction", "0.5"),
+            ("--host-memory-limit", "12GiB"),
+        ] {
+            let err = parse(&["--sirius-config", "sirius.yaml", flag, value])
+                .expect_err("memory flags must conflict with --sirius-config");
+            assert_eq!(err.kind(), ErrorKind::ArgumentConflict, "{flag}");
+        }
+    }
+
+    /// `--gpu-device` is env-level (not a YAML key), so it composes with a config file.
+    #[test]
+    fn sirius_config_composes_with_gpu_device() {
+        let args = parse(&["--sirius-config", "sirius.yaml", "--gpu-device", "1"])
+            .expect("--gpu-device is orthogonal to --sirius-config");
+        assert_eq!(args.engine.gpu_device, Some(1));
+        assert_eq!(
+            args.engine.sirius_config.as_deref(),
+            Some(Path::new("sirius.yaml"))
+        );
+    }
+
+    /// The validator only checks shape; accepted values pass through verbatim for the C++
+    /// `parse_bytes`.
+    #[test]
+    fn byte_size_validator_accepts_supported_shapes() {
+        for value in ["8GiB", "8 GiB", "8589934592", "0.5TiB"] {
+            assert_eq!(
+                parse_byte_size(value).as_deref(),
+                Ok(value),
+                "{value:?} must be accepted verbatim"
+            );
+        }
+    }
+
+    /// Malformed sizes fail at the CLI, not deep inside engine bring-up.
+    #[test]
+    fn byte_size_validator_rejects_malformed_values() {
+        for value in ["8GBB", "-1GiB", ""] {
+            assert!(
+                parse_byte_size(value).is_err(),
+                "{value:?} must be rejected"
+            );
+        }
+    }
+
+    /// The fraction is of TOTAL device memory and must satisfy 0 < f <= 1.0.
+    #[test]
+    fn memory_fraction_validator_enforces_bounds() {
+        assert_eq!(parse_memory_fraction("0.5"), Ok(0.5));
+        assert_eq!(parse_memory_fraction("1.0"), Ok(1.0));
+        for value in ["0", "0.0", "-0.5", "1.5", "NaN", "gpu"] {
+            assert!(
+                parse_memory_fraction(value).is_err(),
+                "{value:?} must be rejected"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Description

Layer 1 of the cn stack; base dev.

Two failures measured on the source branch (`feat/pin-table-cn`) drove this. First, dev's CN cannot pick a GPU or size its memory. `SiriusEngine::start` takes only a config path and the default config primes about 0.95x of device memory, so N CNs launched on one box all primed the same default GPU pool. Second, dev builds the engine before it binds any port. Engine bring-up takes about 7 s on a GB200 and the FE is up in about 4 s, so the FE's first probe found a closed port and auto-blacklisted the node. The FE lifts a blacklist entry only when every advertised port accepts a TCP connection, and dev never bound `http_port`. On the 4x GB200 box 2 of 4 CNs were auto-blacklisted about 2 s after every cluster start, and q14 at SF100 ran 48.9/0/0/51.1 percent across the four CNs.

What changed, as one reviewable unit:

- `engine_settings.rs` (new). `EngineSettings` and `derive_sirius_config_yaml`, which turns the memory flags into the YAML `sirius_config.cpp` reads. `reservation_limit_fraction` is pinned to 1.0 so the carve-out is the whole budget: the engine may reserve all of its limit, not all of the device. `resolve_cuda_visible_devices` holds the device rule described below.
- `gpu_affinity.rs` (new). Reads the GPU's NUMA socket from sysfs and pins the engine's `scan_manager`, `task_creator` and `downgrade` pools to it through the derived YAML. `SIRIUS_CN_CPU_AFFINITY` overrides it (`off`, or a cpulist such as `0-71`). Unresolvable means unpinned, as before.
- `engine.rs`. `SiriusEngine::start(EngineSettings)` replaces `start(Option<PathBuf>)`. `configure_engine_environment` sets `SIRIUS_LOG_DIR=<engine_dir>/log` (an exported value wins) and exports `CUDA_VISIBLE_DEVICES` from `--gpu-device`. Nothing else from the source branch's engine.rs is in this layer.
- `main.rs`. The flags, `EngineConfig::resolve` (writes `<engine_dir>/derived-sirius-config.yaml`), `ensure_gpu_unclaimed`, listeners before engine, and 7 CLI tests.
- `lib.rs`. `EngineReadiness`, the heartbeat NOT READY interlock, `start_http_server`, `GPU_ENGINE_TEST_LOCK`, 4 tests.
- `.gitignore`. Engine directories (`.cn*/`, `sirius-cn-*/`).

Configuration changes. `--gpu-device <ordinal>` exports `CUDA_VISIBLE_DEVICES` before bring-up; default unset, so the engine sees whatever the environment exposes. `--gpu-memory-limit <size>` (for example `8GiB`, passed verbatim to the engine's `parse_bytes`) and `--gpu-memory-fraction <f>` (0 < f <= 1 of total device memory) are mutually exclusive GPU carve-outs. `--host-memory-limit <size>` sets `sirius.memory.host.capacity_bytes`. All three conflict with `--sirius-config`, since a full config already decides memory. `--engine-dir <path>` holds the derived config, logs and telemetry; default `sirius-cn-<brpc_port>` under the working directory. `SIRIUS_CN_CPU_AFFINITY` overrides socket discovery. `SIRIUS_CN_USE_SIRIUS_DATASOURCE=false` selects the cudf datasource in the derived YAML.

The readiness interlock. `run` binds heartbeat, backend and HTTP before the engine starts. Until `readiness.mark_ready()` fires, after the engine and BRPC are up, the heartbeat answers with an ERROR status. The FE then holds the node as not alive, schedules nothing onto it, and does not add a blacklist entry (only a failed fragment RPC does that). The HTTP listener answers everything with a fixed 200 and closes; the FE only needs the port to accept.

`ensure_gpu_unclaimed` runs only for a default-config bring-up (no `--sirius-config`, no GPU carve-out) and refuses to start when `nvidia-smi` shows another compute process on the device, with the remedy in the message. With a carve-out, sharing a GPU is intended, so the check is skipped.

The `CUDA_VISIBLE_DEVICES` rule. The source branch let an exported `CUDA_VISIBLE_DEVICES` win over `--gpu-device` with a warning. That is how a launcher that forgot to unset it put all N CNs on one GPU while the cluster kept answering queries. I made it an error unless the exported value is exactly the requested ordinal. A device list or a UUID is refused too, because it cannot be checked here. Covered by `engine_settings::tests::disagreeing_export_is_refused`.

**How I tested it.** On a GB200 box (aarch64) I ran the CI trio: cargo fmt, clippy with warnings as errors, and the CN test suite without the engine feature. 205 tests pass, 34 of them new. I also compiled the engine-linked build against the main clone's release tree, but did not run its tests.

Not handled here: the launcher scripts and BUILDING.md (docs/bench PR); the TUNABLES.md engine rows (after #1706 creates the file); the multi-fragment runtime (next layers of this stack); `SHUTDOWN_GRACE`, because the HTTP listener shuts down through the same wake-and-join path as the thrift servers and does not need it, so it belongs with the engine-teardown layer. #1706 and this PR both edit main.rs's `sirius_starrocks_cn` import line and the top of `run`, a mechanical conflict for whichever lands second.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
- Source branch: `aocsa/feat/pin-table-cn`
- #1706 (cn-transport-tunables) shares main.rs's import line and `run`