### PR TITLE
feat(scan): serve pinned parquet tables to file-subset scans

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -743,6 +743,7 @@ set(TEST_SOURCES
     test/cpp/integration/test_pin_table_host_streaming.cpp
     test/cpp/integration/test_pin_table_merge_columns.cpp
     test/cpp/integration/test_pin_table_column_order.cpp
+    test/cpp/integration/test_pin_table_file_subset.cpp
     test/cpp/integration/test_pin_table_mvcc_delete.cpp
     test/cpp/integration/test_pin_table_mvcc_foundation.cpp
     test/cpp/integration/test_pin_table_mvcc_insert.cpp

--- a/src/include/op/scan/parquet_gpu_ingestible.hpp
+++ b/src/include/op/scan/parquet_gpu_ingestible.hpp
@@ -89,7 +89,14 @@ class parquet_ingestible_table_info : public ingestible_table_info {
   /// only by parquet_batch_coalescer when it bundles files / chunks row groups —
   /// the ingestible's metadata scan operates one file at a time and does no batching.
   std::size_t approximate_batch_size = sirius::config::DEFAULT_SCAN_TASK_BATCH_SIZE;
-  std::size_t scan_output_arity      = 0;
+  /// When true the coalescer never bundles row groups of different files into one
+  /// split: each emitted split holds slices of exactly one file (a large file still
+  /// splits under approximate_batch_size). The pin path sets this so every pinned
+  /// chunk has single-file provenance and a scan over a subset of the pinned files
+  /// can be served by selecting whole chunks. The query read path keeps fused
+  /// batches (false).
+  bool batch_within_file_boundaries = false;
+  std::size_t scan_output_arity     = 0;
 
   parquet_ingestible_table_info() = default;
 
@@ -110,8 +117,9 @@ class parquet_ingestible_table_info : public ingestible_table_info {
 };
 
 /// Canonical identity form for a parquet file path so pinned-cache matching
-/// (@ref cache_entry_info::can_serve_with_columns, a raw set-equality on
-/// resolved_file_paths) is independent of spelling: relative vs absolute,
+/// (@ref cache_entry_info::matches_parquet_file_set: exact set equality, or a
+/// strict subset of the pinned files, over resolved_file_paths) and per-chunk
+/// provenance are independent of spelling: relative vs absolute,
 /// redundant '/', './..', 'file://', and symlinks all collapse. Remote URIs
 /// (scheme://) pass through. Apply ONLY at the cache-identity boundary
 /// (cache_entry_info): resolved_file_paths on the bind info stay as bound, so

--- a/src/include/pin_table.hpp
+++ b/src/include/pin_table.hpp
@@ -119,6 +119,12 @@ using pinned_column_storage_matrix = std::vector<std::vector<pinned_column_stora
 struct materialized_pin {
   std::vector<std::unique_ptr<cudf::table>> tables;
   std::vector<cucascade::memory::memory_space*> chunk_memory_spaces;
+  /// Canonicalized, sorted, deduplicated source files of each chunk, in emission
+  /// order (parallel to @c tables). Inner vectors are empty for duckdb-native
+  /// pins (no file provenance); the whole vector is what
+  /// @c sirius_scan_manager::insert_pinned_entry stores as chunk provenance to
+  /// let a scan over a subset of the pinned files be served per chunk.
+  std::vector<std::vector<std::string>> chunk_file_paths;
   /// Chunk-major stored-column metadata, parallel to @c tables and their columns.
   pinned_column_storage_matrix column_storage;
   /// Row count of each materialized chunk (parallel to @c tables). For duckdb-native
@@ -207,6 +213,8 @@ materialized_pin materialize_all_batches(
 /// compressed_host_representation; both derive from @c cucascade::idata_representation.
 struct host_pin_result {
   std::vector<std::shared_ptr<cucascade::idata_representation>> chunks;
+  /// Per-chunk source-file provenance; see @ref materialized_pin::chunk_file_paths.
+  std::vector<std::vector<std::string>> chunk_file_paths;
   /// Chunk-major stored-column metadata, recorded from each GPU table right before it is
   /// compressed or converted to host storage. Parallel to @c chunks and their columns.
   pinned_column_storage_matrix column_storage;
@@ -257,6 +265,8 @@ struct device_pin_chunk {
 /// chunks may be interleaved within a single pin.
 struct device_pin_result {
   std::vector<device_pin_chunk> chunks;
+  /// Per-chunk source-file provenance; see @ref materialized_pin::chunk_file_paths.
+  std::vector<std::vector<std::string>> chunk_file_paths;
   /// Chunk-major stored-column metadata, recorded from each GPU table right before it is
   /// compressed or split into device columns. Parallel to @c chunks and their columns.
   pinned_column_storage_matrix column_storage;

--- a/src/include/scan_manager/sirius_scan_manager.hpp
+++ b/src/include/scan_manager/sirius_scan_manager.hpp
@@ -127,10 +127,18 @@ class cache_entry_info {
   [[nodiscard]] static cache_entry_info from(const op::scan::ingestible_table_info& info);
 
   /// Gather projection (positions into @c column_ids) that lets this cached entry
-  /// serve @p other — matching identity (same parquet file set / same duckdb
-  /// catalog.schema.table) AND a superset of @p other's requested columns. The projection
-  /// reproduces @p other's requested column order. Empty when this entry cannot
-  /// serve @p other (different format, identity, or a missing column).
+  /// serve @p other: matching identity AND a superset of @p other's requested
+  /// columns. Parquet identity is the exact pinned file set OR a strict subset of
+  /// it (see @ref matches_parquet_file_set); duckdb identity is the same
+  /// catalog.schema.table. The projection reproduces @p other's requested column
+  /// order. Empty on a different format, a file-set miss, a byte-range scan on
+  /// either side, or a missing column.
+  ///
+  /// A non-empty result on the strict-subset branch is necessary but not
+  /// sufficient: this descriptor does not know which chunks hold which files, so
+  /// the caller must also confirm @c pinned_entry::chunk_file_paths is non-empty
+  /// before serving (try_match_cached_entry and
+  /// find_pinned_entry_for_parquet_files both do).
   [[nodiscard]] std::vector<std::size_t> can_serve_with_columns(
     const op::scan::ingestible_table_info& other) const;
 
@@ -141,11 +149,34 @@ class cache_entry_info {
                                           std::string_view schema,
                                           std::string_view table) const;
 
-  /// Parquet-identity check shared by can_serve_with_columns and the plan-time
-  /// residency gate — one matcher, so the probe and prepare can never disagree.
-  /// Same file set irrespective of order (both sides sorted, byte-exact compare).
-  /// False for duckdb entries (empty resolved_file_paths) and for an empty @p files.
+  /// Exact-match convenience wrapper over @ref matches_parquet_file_set: true only
+  /// for @c parquet_file_match::exact. Same file set irrespective of order (both
+  /// sides canonicalized and sorted, byte-exact compare). False for duckdb
+  /// entries (empty resolved_file_paths), for an empty @p files, and for a strict
+  /// subset. No production caller; the serve and plan-time paths call
+  /// matches_parquet_file_set directly.
   [[nodiscard]] bool matches_parquet_files(std::span<std::string const> files) const;
+
+  /// How a scan's file set relates to this entry's pinned file set.
+  enum class parquet_file_match : std::uint8_t {
+    miss,    ///< different files (or duckdb entry / empty probe)
+    exact,   ///< same file set — every pinned chunk may serve
+    subset,  ///< strict subset — servable only from chunks whose provenance is covered
+  };
+
+  /// Parquet-identity matcher shared by can_serve_with_columns and the plan-time
+  /// residency gate (find_pinned_entry_for_parquet_files): one matcher, so the
+  /// probe and prepare can never disagree. Classifies @p files as an exact
+  /// match, a strict subset of the pinned set, or a miss. Subset holds only
+  /// when BOTH canonical sets are duplicate-free — a duplicated pinned path means
+  /// the pin materialized that file's chunks more than once, and serving them to
+  /// a scan that lists the file once would double its rows (exact matching is
+  /// duplicate-symmetric, so `exact` keeps today's semantics). When non-null,
+  /// @p canonical_scan_files receives the canonicalized, sorted probe set for
+  /// the caller's per-chunk provenance filter.
+  [[nodiscard]] parquet_file_match matches_parquet_file_set(
+    std::span<std::string const> files,
+    std::vector<std::string>* canonical_scan_files = nullptr) const;
 
   /// Column-superset gather over @p requested_ids (requested order): for each
   /// requested column, its position within the cached @c column_ids. Empty
@@ -182,6 +213,14 @@ struct pinned_entry {
   /// share the same memory_space because they came from the same
   /// coalesced batch.
   std::vector<cucascade::memory::memory_space*> chunk_memory_spaces;
+  /// Per-chunk source-file provenance (canonical, sorted, deduplicated), in
+  /// emission order and parallel to whichever chunk storage backs this entry.
+  /// Lets a scan over a strict SUBSET of the pinned file set be served by
+  /// selecting only the chunks whose files the scan covers. Empty (or an empty
+  /// inner vector for a chunk) means provenance unknown — such entries/chunks
+  /// serve exact-file-set scans only, which is every pre-provenance pin's and
+  /// every duckdb-native pin's behavior.
+  std::vector<std::vector<std::string>> chunk_file_paths;
   /// HOST-tier storage: one chunk per emitted batch in emission order, each
   /// holding all pinned columns. Every element is either a
   /// cucascade::host_data_representation (uncompressed) or a
@@ -400,11 +439,19 @@ std::unique_ptr<databatch_provider> make_provider_for_pinned_entry(
  * @brief Build the survivor plan for serving @p entry to a scan into @p requiested_column_ids with
  * @p table_filters applied. A chunk is pruned when any usable filter proves it empty against the
  * pinned entry's zone-map statistics.
+ *
+ * @p allowed_chunks, when non-null, restricts the plan to those chunk indices (sorted,
+ * deduplicated) BEFORE zone-map pruning — the file-subset serve path passes the chunks whose
+ * provenance the scan's file set covers, so the all-pruned sentinel below can only ever pick an
+ * allowed chunk (a disallowed sentinel chunk would return another file's rows). An empty allowed
+ * set yields an empty plan (no survivors, nothing pruned); the caller must treat that as a cache
+ * miss rather than serve it — a zero-split scan hangs pipeline completion.
  */
 [[nodiscard]] cached_scan_plan build_cached_scan_plan(
   pinned_entry const& entry,
   duckdb::TableFilterSet const* table_filters,
-  duckdb::vector<duckdb::ColumnIndex> const* requested_column_ids);
+  duckdb::vector<duckdb::ColumnIndex> const* requested_column_ids,
+  std::vector<std::size_t> const* allowed_chunks = nullptr);
 
 /**
  * @brief Bind-time result of @ref sirius_scan_manager::describe_parquet.
@@ -530,6 +577,11 @@ class sirius_scan_manager {
   /// \param column_storage        Chunk-major stored-column metadata as the pin driver
   ///                              recorded it; must cover every chunk and cached column. A
   ///                              recorded carrier that contradicts a stored column type throws.
+  /// \param chunk_file_paths      Per-chunk source-file provenance (canonical, sorted,
+  ///                              deduplicated), parallel to @p data_tables; empty means unknown
+  ///                              (the entry then serves exact-file-set scans only). On the
+  ///                              merge path an entry without provenance adopts it and an entry
+  ///                              whose provenance disagrees throws.
   /// \return The names of the columns whose data this call actually STORED. On the replace
   ///         path that is every column; on the merge path it is only the newly added ones —
   ///         a column already cached keeps its previous chunks and the incoming ones are
@@ -543,7 +595,8 @@ class sirius_scan_manager {
     std::vector<cucascade::memory::memory_space*> chunk_memory_spaces,
     duckdb::vector<duckdb::LogicalType> column_types,
     std::vector<std::vector<duckdb::unique_ptr<duckdb::BaseStatistics>>> chunk_stats,
-    sirius::pinned_column_storage_matrix column_storage);
+    sirius::pinned_column_storage_matrix column_storage,
+    std::vector<std::vector<std::string>> chunk_file_paths = {});
 
   /// \brief Pin the host-tier entry for a table.
   ///
@@ -576,6 +629,8 @@ class sirius_scan_manager {
   ///                      must cover every chunk and cached column. A recorded carrier that
   ///                      contradicts an uncompressed chunk's stored type throws; a compressed
   ///                      chunk's types are unreadable here, so its cells are trusted.
+  /// \param chunk_file_paths Per-chunk source-file provenance, parallel to @p host_chunks;
+  ///                      empty means unknown (exact-file-set serving only).
   void insert_pinned_entry_host(
     const std::string& name,
     cache_entry_info cache_info,
@@ -583,7 +638,8 @@ class sirius_scan_manager {
     cucascade::memory::memory_space& memory_space,
     duckdb::vector<duckdb::LogicalType> column_types,
     std::vector<std::vector<duckdb::unique_ptr<duckdb::BaseStatistics>>> chunk_stats,
-    sirius::pinned_column_storage_matrix column_storage);
+    sirius::pinned_column_storage_matrix column_storage,
+    std::vector<std::vector<std::string>> chunk_file_paths = {});
 
   /// \brief Pin the entry for a table on the GPU tier from a compression-enabled pin.
   ///
@@ -603,11 +659,14 @@ class sirius_scan_manager {
   ///                      must cover every chunk and cached column. A recorded carrier that
   ///                      contradicts an uncompressed chunk's stored type throws; a compressed
   ///                      chunk's types are unreadable here, so its cells are trusted.
+  /// \param chunk_file_paths Per-chunk source-file provenance, parallel to @p chunks; empty
+  ///                      means unknown (exact-file-set serving only).
   void insert_pinned_entry_device(const std::string& name,
                                   cache_entry_info cache_info,
                                   std::vector<sirius::device_pin_chunk> chunks,
                                   cucascade::memory::memory_space& memory_space,
-                                  sirius::pinned_column_storage_matrix column_storage);
+                                  sirius::pinned_column_storage_matrix column_storage,
+                                  std::vector<std::vector<std::string>> chunk_file_paths = {});
 
   /// \brief Attach MVCC snapshot metadata to the pinned entry for @p name.
   ///
@@ -667,10 +726,13 @@ class sirius_scan_manager {
     duckdb::vector<duckdb::LogicalType> const* returned_types = nullptr) const;
 
   /// The pinned entry whose parquet identity matches @p resolved_file_paths
-  /// (cache_entry_info::matches_parquet_files), or nullptr. Non-owning; obtain
-  /// and read it inside one slot-scoped window, and never hold it across a pin
-  /// or unpin. First match wins if one file set was pinned under two names.
-  /// Read by the plan-time compressed-materialization residency gate.
+  /// (cache_entry_info::matches_parquet_file_set) — exactly, or as a strict
+  /// subset when the entry carries chunk provenance (the same condition the
+  /// serve path requires, keeping the one-matcher invariant) — or nullptr.
+  /// Non-owning; obtain and read it inside one slot-scoped window, and never
+  /// hold it across a pin or unpin. First match wins if one file set was pinned
+  /// under two names. Read by the plan-time compressed-materialization
+  /// residency gate.
   [[nodiscard]] pinned_entry const* find_pinned_entry_for_parquet_files(
     std::span<std::string const> resolved_file_paths) const;
 

--- a/src/op/scan/parquet_gpu_ingestible.cpp
+++ b/src/op/scan/parquet_gpu_ingestible.cpp
@@ -241,11 +241,13 @@ class parquet_batch_coalescer : public batch_coalescer {
  public:
   parquet_batch_coalescer(std::size_t cap,
                           std::shared_ptr<cudf::io::parquet_reader_options> reader_options,
-                          std::shared_ptr<scan_plan const> plan)
+                          std::shared_ptr<scan_plan const> plan,
+                          bool file_boundaries = false)
     : _cap(cap),
       _reader_options(std::move(reader_options)),
       _plan(std::move(plan)),
-      _needs_assembly(needs_output_assembly(*_plan))
+      _needs_assembly(needs_output_assembly(*_plan)),
+      _file_boundaries(file_boundaries)
   {
   }
 
@@ -326,6 +328,9 @@ class parquet_batch_coalescer : public batch_coalescer {
       cur_rows += rg.num_rows;
     }
     seal_file();
+    // File-boundary mode: emit at each file's end so no split ever bundles two
+    // files' row groups — every split's provenance is exactly one file.
+    if (_file_boundaries && !_slices.empty()) { emitted.push_back(emit_current()); }
     return emitted;
   }
 
@@ -375,6 +380,7 @@ class parquet_batch_coalescer : public batch_coalescer {
   std::shared_ptr<cudf::io::parquet_reader_options> _reader_options;
   std::shared_ptr<scan_plan const> _plan;
   const bool _needs_assembly;
+  const bool _file_boundaries = false;
 
   std::vector<row_group_slice> _slices;
   std::size_t _acc_working_bytes = 0;
@@ -628,7 +634,7 @@ parquet_gpu_ingestible::~parquet_gpu_ingestible() = default;
 std::unique_ptr<batch_coalescer> parquet_gpu_ingestible::create_batch_coalescer() const
 {
   return std::make_unique<parquet_batch_coalescer>(
-    _info->approximate_batch_size, _reader_options, _plan);
+    _info->approximate_batch_size, _reader_options, _plan, _info->batch_within_file_boundaries);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/pin_table.cpp
+++ b/src/pin_table.cpp
@@ -27,6 +27,7 @@
 #include "log/logging.hpp"
 #include "op/scan/duckdb_native_gpu_ingestible.hpp"
 #include "op/scan/gpu_ingestible.hpp"
+#include "op/scan/parquet_gpu_ingestible.hpp"
 #include "scan_manager/pinned_chunk_stats.hpp"
 #include "scan_manager/round_robin_strategy.hpp"
 
@@ -170,7 +171,8 @@ using pin_batch_sink =
                      cucascade::memory::memory_space* target,
                      rmm::cuda_stream_view stream,
                      std::vector<pinned_column_storage_meta> column_storage,
-                     std::vector<duckdb::unique_ptr<duckdb::BaseStatistics>> chunk_stats)>;
+                     std::vector<duckdb::unique_ptr<duckdb::BaseStatistics>> chunk_stats,
+                     std::vector<std::string> batch_files)>;
 
 struct narrowed_pin_chunk {
   std::unique_ptr<cudf::table> table;
@@ -311,6 +313,19 @@ std::vector<late_mat::unique_verdict> materialize_pin_batches(
     auto materialized     = ingestible.materialize_metadata_to_table(*batch, *target, stream);
     auto tbl              = materialized.table.release(stream, target->get_default_allocator());
     auto const chunk_rows = static_cast<std::size_t>(tbl->num_rows());
+    // Chunk provenance: the source files this batch decodes, canonicalized so
+    // they compare against cache_entry_info's canonical file set. Empty for
+    // duckdb-native batches (no file identity) — such chunks serve exact-set
+    // scans only.
+    std::vector<std::string> batch_files;
+    if (auto const* split = dynamic_cast<op::scan::parquet_split_info const*>(batch.get())) {
+      batch_files.reserve(split->rg_slices.size());
+      for (auto const& slice : split->rg_slices) {
+        batch_files.push_back(op::scan::canonical_scan_file_path(slice.file_path));
+      }
+      std::ranges::sort(batch_files);
+      batch_files.erase(std::unique(batch_files.begin(), batch_files.end()), batch_files.end());
+    }
     validate_duckdb_pin_chunk(*batch, chunk_rows, rows_materialized);
     rows_materialized += chunk_rows;
     // Zone-map capture, while the decode device guard + stream are active and the
@@ -378,7 +393,12 @@ std::vector<late_mat::unique_verdict> materialize_pin_batches(
                                 narrowed_columns[static_cast<std::size_t>(i)],
                                 native_types[static_cast<std::size_t>(i)]});
     }
-    on_batch(std::move(tbl), target, stream, std::move(column_storage), std::move(chunk_stats));
+    on_batch(std::move(tbl),
+             target,
+             stream,
+             std::move(column_storage),
+             std::move(chunk_stats),
+             std::move(batch_files));
   };
 
   while (!ingestible.has_processed_all_metadata()) {
@@ -576,13 +596,16 @@ materialized_pin materialize_all_batches(
         cucascade::memory::memory_space* target,
         rmm::cuda_stream_view stream,
         std::vector<pinned_column_storage_meta> column_storage,
-        std::vector<duckdb::unique_ptr<duckdb::BaseStatistics>> chunk_stats) {
+        std::vector<duckdb::unique_ptr<duckdb::BaseStatistics>> chunk_stats,
+        std::vector<std::string> batch_files) {
       // Cached GPU batches are stored with a null writer stream, so the data
       // must be fully resident before it can be served or host-converted.
       stream.synchronize();
       out.base_row_count_per_chunk.push_back(static_cast<std::size_t>(tbl->num_rows()));
       out.tables.emplace_back(std::move(tbl));
       out.chunk_memory_spaces.push_back(target);
+      // Unconditional (unlike chunk_stats): provenance must stay parallel to tables.
+      out.chunk_file_paths.emplace_back(std::move(batch_files));
       out.column_storage.emplace_back(std::move(column_storage));
       if (!chunk_stats.empty()) { out.chunk_stats.emplace_back(std::move(chunk_stats)); }
     });
@@ -612,10 +635,12 @@ host_pin_result materialize_pin_to_host(
         cucascade::memory::memory_space* src_space,
         rmm::cuda_stream_view stream,
         std::vector<pinned_column_storage_meta> column_storage,
-        std::vector<duckdb::unique_ptr<duckdb::BaseStatistics>> chunk_stats) {
+        std::vector<duckdb::unique_ptr<duckdb::BaseStatistics>> chunk_stats,
+        std::vector<std::string> batch_files) {
       auto* target_host_space    = host_space_by_gpu.at(src_space->get_device_id());
       bool compressed_this_chunk = false;
       out.base_row_count_per_chunk.push_back(static_cast<std::size_t>(tbl->num_rows()));
+      out.chunk_file_paths.emplace_back(std::move(batch_files));
       out.column_storage.emplace_back(std::move(column_storage));
       if (!chunk_stats.empty()) { out.chunk_stats.emplace_back(std::move(chunk_stats)); }
 
@@ -724,10 +749,12 @@ device_pin_result materialize_all_batches_compressed(
         cucascade::memory::memory_space* src_space,
         rmm::cuda_stream_view stream,
         std::vector<pinned_column_storage_meta> column_storage,
-        std::vector<duckdb::unique_ptr<duckdb::BaseStatistics>> /*chunk_stats*/) {
+        std::vector<duckdb::unique_ptr<duckdb::BaseStatistics>> /*chunk_stats*/,
+        std::vector<std::string> batch_files) {
       std::shared_ptr<sirius::compressed_device_representation> compressed_chunk;
       const std::int64_t chunk_rows = tbl->num_rows();
       out.base_row_count_per_chunk.push_back(static_cast<std::size_t>(chunk_rows));
+      out.chunk_file_paths.emplace_back(std::move(batch_files));
       out.column_storage.emplace_back(std::move(column_storage));
 
       if (compression.enabled && !compression_failed && tbl && !compression.plan_dsl.empty()) {

--- a/src/scan_manager/sirius_scan_manager.cpp
+++ b/src/scan_manager/sirius_scan_manager.cpp
@@ -1919,7 +1919,10 @@ std::vector<std::size_t> cache_entry_info::can_serve_with_columns(
     // A byte-range split scan reads a subset of each file's row groups, so it can neither be
     // served by a whole-file pin (extra rows) nor produce a pin that serves anyone else.
     if (has_byte_ranges || p->has_byte_ranges()) { return {}; }
-    if (!matches_parquet_files(p->resolved_file_paths)) { return {}; }
+    // Exact match or strict file subset both pass here; the serve path
+    // (try_match_cached_entry) additionally requires chunk provenance before it
+    // serves a subset, because only provenance says which chunks hold which files.
+    if (matches_parquet_file_set(p->resolved_file_paths) == parquet_file_match::miss) { return {}; }
     return column_projection_for(p->column_ids);
   }
   if (auto const* d = dynamic_cast<op::scan::duckdb_native_ingestible_table_info const*>(&other)) {
@@ -1945,8 +1948,14 @@ bool cache_entry_info::matches_duckdb_table(std::string_view catalog,
 
 bool cache_entry_info::matches_parquet_files(std::span<std::string const> files) const
 {
-  if (files.empty() || resolved_file_paths.empty()) { return false; }
-  if (files.size() != resolved_file_paths.size()) { return false; }
+  return matches_parquet_file_set(files) == parquet_file_match::exact;
+}
+
+cache_entry_info::parquet_file_match cache_entry_info::matches_parquet_file_set(
+  std::span<std::string const> files, std::vector<std::string>* canonical_scan_files) const
+{
+  if (files.empty() || resolved_file_paths.empty()) { return parquet_file_match::miss; }
+  if (files.size() > resolved_file_paths.size()) { return parquet_file_match::miss; }
   // `this` is a stored entry (already canonical via cache_entry_info::from);
   // `files` arrives from a fresh bind whose paths are still as-bound, so
   // canonicalize the comparison copy to match. Every parquet identity check —
@@ -1957,7 +1966,26 @@ bool cache_entry_info::matches_parquet_files(std::span<std::string const> files)
   op::scan::canonicalize_scan_file_paths(those_files);
   std::ranges::sort(these_files);
   std::ranges::sort(those_files);
-  return these_files == those_files;
+  auto const record_scan_files = [&]() {
+    if (canonical_scan_files != nullptr) { *canonical_scan_files = std::move(those_files); }
+  };
+  if (these_files.size() == those_files.size()) {
+    if (these_files != those_files) { return parquet_file_match::miss; }
+    record_scan_files();
+    return parquet_file_match::exact;
+  }
+  // Strict subset. Duplicates poison it on either side: a duplicated pinned path
+  // means that file's rows were materialized into chunks twice (serving them to a
+  // scan that lists the file once doubles its rows), and a duplicated scan path
+  // expects the file's rows twice while the chunk filter serves them once. Exact
+  // matching above stays duplicate-symmetric, preserving today's behavior.
+  auto const has_dup = [](std::vector<std::string> const& sorted) {
+    return std::adjacent_find(sorted.begin(), sorted.end()) != sorted.end();
+  };
+  if (has_dup(these_files) || has_dup(those_files)) { return parquet_file_match::miss; }
+  if (!std::ranges::includes(these_files, those_files)) { return parquet_file_match::miss; }
+  record_scan_files();
+  return parquet_file_match::subset;
 }
 
 std::vector<std::size_t> cache_entry_info::column_projection_for(
@@ -1981,7 +2009,8 @@ std::vector<std::string> sirius_scan_manager::insert_pinned_entry(
   std::vector<cucascade::memory::memory_space*> chunk_memory_spaces,
   duckdb::vector<duckdb::LogicalType> column_types,
   std::vector<std::vector<duckdb::unique_ptr<duckdb::BaseStatistics>>> chunk_stats,
-  sirius::pinned_column_storage_matrix column_storage)
+  sirius::pinned_column_storage_matrix column_storage,
+  std::vector<std::vector<std::string>> chunk_file_paths)
 {
   // chunk_memory_spaces is parallel to data_tables — the caller
   // (PinTableFunction) emits one memory_space* per coalesced batch, and
@@ -1992,6 +2021,14 @@ std::vector<std::string> sirius_scan_manager::insert_pinned_entry(
     throw std::invalid_argument(
       "[sirius_scan_manager::insert_pinned_entry] chunk_memory_spaces.size() (" +
       std::to_string(chunk_memory_spaces.size()) + ") must equal data_tables.size() (" +
+      std::to_string(data_tables.size()) + ")");
+  }
+  // Provenance is empty (unknown — exact-match-only serving) or parallel to the
+  // chunks, like column_storage's allow_empty contract.
+  if (!chunk_file_paths.empty() && chunk_file_paths.size() != data_tables.size()) {
+    throw std::invalid_argument(
+      "[sirius_scan_manager::insert_pinned_entry] chunk_file_paths.size() (" +
+      std::to_string(chunk_file_paths.size()) + ") must be empty or equal data_tables.size() (" +
       std::to_string(data_tables.size()) + ")");
   }
 
@@ -2112,6 +2149,20 @@ std::vector<std::string> sirius_scan_manager::insert_pinned_entry(
                                     entry.cache_info.column_ids.size(),
                                     "[sirius_scan_manager::insert_pinned_entry existing entry]",
                                     /*allow_empty=*/false);
+      // Chunk provenance rides the same boundaries the guards above just proved
+      // identical: adopt it when the entry has none (re-pin recovery, mirroring
+      // the statless zone-map adoption below), and reject a disagreement loudly —
+      // same-boundary chunks naming different files means one side's recorder is
+      // wrong, and serving on it would return the wrong files' rows.
+      if (!chunk_file_paths.empty()) {
+        if (entry.chunk_file_paths.empty()) {
+          entry.chunk_file_paths = std::move(chunk_file_paths);
+        } else if (entry.chunk_file_paths != chunk_file_paths) {
+          throw std::runtime_error(
+            "[sirius_scan_manager::insert_pinned_entry] merge mismatch — per-chunk file "
+            "provenance differs between the existing entry and the new materialization");
+        }
+      }
       // Same row count → merge unique columns into the existing entry.
       // Decide which column INDICES are new BEFORE iterating chunks. Doing
       // the contains() check per-chunk would let chunk 0 install a new
@@ -2211,6 +2262,7 @@ std::vector<std::string> sirius_scan_manager::insert_pinned_entry(
   pinned_entry entry;
   entry.cache_info          = std::move(cache_info);
   entry.chunk_memory_spaces = std::move(chunk_memory_spaces);
+  entry.chunk_file_paths    = std::move(chunk_file_paths);
   entry.tier                = cucascade::memory::Tier::GPU;
   entry.column_storage      = std::move(column_storage);
   entry.num_rows            = new_num_rows;
@@ -2266,12 +2318,18 @@ void sirius_scan_manager::insert_pinned_entry_host(
   cucascade::memory::memory_space& memory_space,
   duckdb::vector<duckdb::LogicalType> column_types,
   std::vector<std::vector<duckdb::unique_ptr<duckdb::BaseStatistics>>> chunk_stats,
-  sirius::pinned_column_storage_matrix column_storage)
+  sirius::pinned_column_storage_matrix column_storage,
+  std::vector<std::vector<std::string>> chunk_file_paths)
 {
   // The host-tier path captures one chunk per emitted batch; each chunk holds every
   // pinned column (compressed or uncompressed). Re-insert always replaces — there is
   // no per-column merge analog to the GPU path because the chunk-vs-column dimensions
   // are flipped.
+  if (!chunk_file_paths.empty() && chunk_file_paths.size() != host_chunks.size()) {
+    throw std::invalid_argument(
+      "[sirius_scan_manager::insert_pinned_entry_host] chunk_file_paths must be empty or "
+      "parallel to host_chunks");
+  }
   std::size_t new_num_rows = 0;
   for (auto const& chunk : host_chunks) {
     if (!chunk) { continue; }
@@ -2326,13 +2384,14 @@ void sirius_scan_manager::insert_pinned_entry_host(
   }
 
   pinned_entry entry;
-  entry.cache_info     = std::move(cache_info);
-  entry.tier           = cucascade::memory::Tier::HOST;
-  entry.memory_space   = &memory_space;
-  entry.num_rows       = new_num_rows;
-  entry.host_chunks    = std::move(host_chunks);
-  entry.column_storage = std::move(column_storage);
-  entry.zone_maps      = std::move(pin_zone_maps);
+  entry.cache_info       = std::move(cache_info);
+  entry.tier             = cucascade::memory::Tier::HOST;
+  entry.memory_space     = &memory_space;
+  entry.num_rows         = new_num_rows;
+  entry.host_chunks      = std::move(host_chunks);
+  entry.chunk_file_paths = std::move(chunk_file_paths);
+  entry.column_storage   = std::move(column_storage);
+  entry.zone_maps        = std::move(pin_zone_maps);
 
   // Assigning over an existing name destroys that entry in place, so its
   // handle has to be invalidated FIRST — afterwards the entry is gone but the
@@ -2348,8 +2407,14 @@ void sirius_scan_manager::insert_pinned_entry_device(
   cache_entry_info cache_info,
   std::vector<sirius::device_pin_chunk> chunks,
   cucascade::memory::memory_space& memory_space,
-  sirius::pinned_column_storage_matrix column_storage)
+  sirius::pinned_column_storage_matrix column_storage,
+  std::vector<std::vector<std::string>> chunk_file_paths)
 {
+  if (!chunk_file_paths.empty() && chunk_file_paths.size() != chunks.size()) {
+    throw std::invalid_argument(
+      "[sirius_scan_manager::insert_pinned_entry_device] chunk_file_paths must be empty or "
+      "parallel to chunks");
+  }
   std::size_t new_num_rows = 0;
   for (auto const& chunk : chunks) {
     if (chunk.compressed) {
@@ -2379,12 +2444,13 @@ void sirius_scan_manager::insert_pinned_entry_device(
     });
 
   pinned_entry entry;
-  entry.cache_info     = std::move(cache_info);
-  entry.tier           = cucascade::memory::Tier::GPU;
-  entry.memory_space   = &memory_space;
-  entry.num_rows       = new_num_rows;
-  entry.device_chunks  = std::move(chunks);
-  entry.column_storage = std::move(column_storage);
+  entry.cache_info       = std::move(cache_info);
+  entry.tier             = cucascade::memory::Tier::GPU;
+  entry.memory_space     = &memory_space;
+  entry.num_rows         = new_num_rows;
+  entry.device_chunks    = std::move(chunks);
+  entry.chunk_file_paths = std::move(chunk_file_paths);
+  entry.column_storage   = std::move(column_storage);
 
   SIRIUS_LOG_DEBUG("[sirius_scan_manager::insert_pinned_entry_device] '{}' chunks={} rows={}",
                    name,
@@ -2527,7 +2593,16 @@ pinned_entry const* sirius_scan_manager::find_pinned_entry_for_parquet_files(
   std::span<std::string const> resolved_file_paths) const
 {
   for (auto const& [name, entry] : _pinned_entries) {
-    if (entry.cache_info.matches_parquet_files(resolved_file_paths)) { return &entry; }
+    switch (entry.cache_info.matches_parquet_file_set(resolved_file_paths)) {
+      case cache_entry_info::parquet_file_match::exact: return &entry;
+      case cache_entry_info::parquet_file_match::subset:
+        // Mirror the serve path's condition: a subset scan is only served from
+        // an entry with chunk provenance (one matcher — the plan-time residency
+        // gate must see the same hits serving will).
+        if (!entry.chunk_file_paths.empty()) { return &entry; }
+        break;
+      case cache_entry_info::parquet_file_match::miss: break;
+    }
   }
   return nullptr;
 }
@@ -2702,7 +2777,8 @@ std::unique_ptr<databatch_provider> make_provider_for_pinned_entry(
 
 cached_scan_plan build_cached_scan_plan(pinned_entry const& entry,
                                         duckdb::TableFilterSet const* table_filters,
-                                        duckdb::vector<duckdb::ColumnIndex> const* column_ids)
+                                        duckdb::vector<duckdb::ColumnIndex> const* column_ids,
+                                        std::vector<std::size_t> const* allowed_chunks)
 {
   std::size_t n_chunks = 0;
   if (entry.tier == cucascade::memory::Tier::GPU) {
@@ -2720,13 +2796,27 @@ cached_scan_plan build_cached_scan_plan(pinned_entry const& entry,
     n_chunks = entry.host_chunks.size();
   }
 
-  // Identity plan (serve everything) until proven otherwise.
-  cached_scan_plan plan;
-  plan.survivor_chunk_indices.reserve(n_chunks);
-  for (std::size_t c = 0; c < n_chunks; ++c) {
-    plan.survivor_chunk_indices.push_back(c);
+  // The chunks this plan may serve: everything, or the caller's file-subset
+  // selection. The restriction applies BEFORE zone-map pruning so the all-pruned
+  // sentinel below can only pick an allowed chunk — a disallowed sentinel would
+  // return another file's rows.
+  std::vector<std::size_t> candidates;
+  if (allowed_chunks != nullptr) {
+    candidates.reserve(allowed_chunks->size());
+    for (auto const c : *allowed_chunks) {
+      if (c < n_chunks) { candidates.push_back(c); }
+    }
+  } else {
+    candidates.reserve(n_chunks);
+    for (std::size_t c = 0; c < n_chunks; ++c) {
+      candidates.push_back(c);
+    }
   }
-  if (n_chunks == 0 || !entry.zone_maps.has_stats() || table_filters == nullptr ||
+
+  // Identity plan (serve every candidate) until proven otherwise.
+  cached_scan_plan plan;
+  plan.survivor_chunk_indices = candidates;
+  if (candidates.empty() || !entry.zone_maps.has_stats() || table_filters == nullptr ||
       table_filters->filters.empty() || column_ids == nullptr) {
     return plan;
   }
@@ -2764,7 +2854,7 @@ cached_scan_plan build_cached_scan_plan(pinned_entry const& entry,
   if (usable.empty()) { return plan; }
 
   plan.survivor_chunk_indices.clear();
-  for (std::size_t c = 0; c < n_chunks; ++c) {
+  for (auto const c : candidates) {
     bool pruned = false;
     for (auto const& uf : usable) {
       auto const* cell = entry.zone_maps.cell(uf.entry_pos, c);
@@ -2775,14 +2865,16 @@ cached_scan_plan build_cached_scan_plan(pinned_entry const& entry,
     }
     if (!pruned) { plan.survivor_chunk_indices.push_back(c); }
   }
-  plan.pruned = n_chunks - plan.survivor_chunk_indices.size();
+  plan.pruned = candidates.size() - plan.survivor_chunk_indices.size();
 
   // Sentinel chunk: an all-pruned scan must not become a zero-batch scan (zero
   // splits => zero tasks => pipeline completion never fires — the hazard both
-  // disk paths guard against). Keep chunk 0; the GPU filter empties it.
+  // disk paths guard against). Keep the first ALLOWED chunk; the GPU filter
+  // empties it. (A chunk outside the candidate set would return another file's
+  // rows on the file-subset serve path.)
   if (plan.survivor_chunk_indices.empty()) {
-    plan.survivor_chunk_indices.push_back(0);
-    plan.pruned = n_chunks - 1;
+    plan.survivor_chunk_indices.push_back(candidates.front());
+    plan.pruned = candidates.size() - 1;
   }
   return plan;
 }
@@ -2831,6 +2923,64 @@ std::optional<sirius_scan_manager::cached_assignment> sirius_scan_manager::try_m
     // Identity + serviceability gate: empty when this cache cannot serve the scan
     // (wrong format / file-set / table, or missing a requested column).
     if (entry.cache_info.can_serve_with_columns(table_info).empty()) { continue; }
+    // File-subset serving (parquet only): when the scan's file set is a strict
+    // subset of the pinned set, serve only the chunks whose recorded provenance
+    // the scan covers. Entries without provenance (pre-provenance or duckdb
+    // pins) keep exact-set-only semantics.
+    std::vector<std::size_t> subset_chunks;
+    std::vector<std::size_t> const* allowed_chunks = nullptr;
+    if (auto const* parquet_info =
+          dynamic_cast<op::scan::parquet_ingestible_table_info const*>(&table_info)) {
+      std::vector<std::string> scan_files;
+      auto const match =
+        entry.cache_info.matches_parquet_file_set(parquet_info->resolved_file_paths, &scan_files);
+      if (match == cache_entry_info::parquet_file_match::subset) {
+        if (entry.chunk_file_paths.empty()) {
+          SIRIUS_LOG_DEBUG(
+            "[sirius_scan_manager] pinned entry '{}' covers a superset of operator '{}''s files "
+            "but records no chunk provenance; treating as a cache miss",
+            pinned_name,
+            op->get_operator_id());
+          continue;
+        }
+        // scan_files is canonical + sorted; a chunk serves iff every one of its
+        // files is in the scan set. A chunk with unknown provenance (empty inner
+        // vector) can never be proven covered, so it is excluded.
+        for (std::size_t c = 0; c < entry.chunk_file_paths.size(); ++c) {
+          auto const& chunk_files = entry.chunk_file_paths[c];
+          if (chunk_files.empty()) { continue; }
+          bool covered = true;
+          for (auto const& file : chunk_files) {
+            if (!std::ranges::binary_search(scan_files, file)) {
+              covered = false;
+              break;
+            }
+          }
+          if (covered) { subset_chunks.push_back(c); }
+        }
+        if (subset_chunks.empty()) {
+          // Every scan file landed in no chunk (e.g. zero-row files produce no
+          // chunk at pin time). Legal to fall through — parquet pins are never
+          // mvcc-strict — and the disk read stays correct.
+          SIRIUS_LOG_INFO(
+            "[sirius_scan_manager] pinned entry '{}' covers operator '{}''s file subset but no "
+            "pinned chunk is covered by it; falling back to the disk read",
+            pinned_name,
+            op->get_operator_id());
+          continue;
+        }
+        allowed_chunks = &subset_chunks;
+        SIRIUS_LOG_INFO(
+          "[sirius_scan_manager] pinned entry '{}' serves operator '{}' as a file subset: {}/{} "
+          "files, {}/{} chunks",
+          pinned_name,
+          op->get_operator_id(),
+          scan_files.size(),
+          entry.cache_info.resolved_file_paths.size(),
+          subset_chunks.size(),
+          entry.chunk_file_paths.size());
+      }
+    }
     // Check native types before strict MVCC handling so a type-mismatched pin is a clean cache
     // miss rather than an MVCC error or a hit under the wrong type.
     if (auto const* native_info =
@@ -2863,7 +3013,8 @@ std::optional<sirius_scan_manager::cached_assignment> sirius_scan_manager::try_m
       // Zone-map survivor plan
       auto const filter_view =
         _pruning_enabled ? extract_scan_filters(table_info) : scan_filter_view{};
-      auto plan = build_cached_scan_plan(entry, filter_view.table_filters, filter_view.column_ids);
+      auto plan = build_cached_scan_plan(
+        entry, filter_view.table_filters, filter_view.column_ids, allowed_chunks);
       auto const total_chunks = plan.survivor_chunk_indices.size() + plan.pruned;
       if (plan.pruned > 0) {
         SIRIUS_LOG_INFO(

--- a/src/sirius_extension.cpp
+++ b/src/sirius_extension.cpp
@@ -1001,6 +1001,10 @@ std::unique_ptr<sirius::op::scan::parquet_ingestible_table_info> build_parquet_p
   }
   info->scan_output_arity      = keep.size();
   info->approximate_batch_size = batch_size;
+  // Pin-only: never bundle two files' row groups into one chunk, so every pinned
+  // chunk has single-file provenance and a scan over a SUBSET of the pinned files
+  // can be served by whole-chunk selection.
+  info->batch_within_file_boundaries = true;
   return info;
 }
 
@@ -1520,7 +1524,8 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
                                       *representative_host_space,
                                       std::move(pinned_column_types),
                                       std::move(host_result.chunk_stats),
-                                      std::move(host_result.column_storage));
+                                      std::move(host_result.column_storage),
+                                      std::move(host_result.chunk_file_paths));
     // The host path always REPLACES, so every pinned column holds this
     // materialization's values.
     attach_proven_unique(host_result.unique_verdicts, pinned_column_names);
@@ -1546,7 +1551,8 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
                                         std::move(cache_info),
                                         std::move(dev_result.chunks),
                                         *gpu_spaces_mut[0],
-                                        std::move(dev_result.column_storage));
+                                        std::move(dev_result.column_storage),
+                                        std::move(dev_result.chunk_file_paths));
     // The compressed device path always REPLACES, as above.
     attach_proven_unique(dev_result.unique_verdicts, pinned_column_names);
     attach_duckdb_mvcc_metadata(std::move(dev_result.base_row_count_per_chunk));
@@ -1569,7 +1575,8 @@ void SiriusExtension::PinTableFunction(ClientContext& context,
                                                      std::move(mat.chunk_memory_spaces),
                                                      std::move(pinned_column_types),
                                                      std::move(mat.chunk_stats),
-                                                     std::move(mat.column_storage));
+                                                     std::move(mat.column_storage),
+                                                     std::move(mat.chunk_file_paths));
     attach_proven_unique(mat.unique_verdicts, stored);
     attach_duckdb_mvcc_metadata(std::move(base_row_count_per_chunk));
   }

--- a/test/cpp/integration/test_pin_table_file_subset.cpp
+++ b/test/cpp/integration/test_pin_table_file_subset.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2026, Sirius Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// End-to-end file-subset serving of a pinned parquet glob (HOST + GPU tiers).
+// A pin over three files must serve a scan that names only some of them: the
+// pin path coalesces within file boundaries and records which file each chunk
+// came from, and try_match_cached_entry serves exactly the chunks the scan's
+// files cover. The test asserts the recorded provenance (one file per chunk,
+// the pinned set exactly), that two-file and one-file scans return the same
+// rows as the unpinned read and log the subset hit, that the exact set is still
+// served without the subset path, that a scan naming a file outside the pin is
+// a miss that stays correct, and that zone-map pruning and the all-pruned
+// sentinel respect the allowed-chunk restriction.
+
+#include "sirius_context.hpp"
+
+#include <catch.hpp>
+#include <cucascade/memory/memory_space.hpp>
+#include <duckdb.hpp>
+#include <op/scan/parquet_gpu_ingestible.hpp>
+#include <scan_manager/sirius_scan_manager.hpp>
+#include <utils/log_test_utils.hpp>
+#include <utils/parquet_fixture_utils.hpp>
+#include <utils/sirius_test_env.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// File i holds k in [i*N, (i+1)*N) with v = 2k: 200k rows x 2 int64 -> ~3 MiB per
+// file, far under the scan batch, so every file is exactly one chunk.
+constexpr std::int64_t kRowsPerFile = 200'000;
+constexpr int kFiles                = 3;
+
+void require_ok(duckdb::unique_ptr<duckdb::MaterializedQueryResult> const& r, char const* what)
+{
+  REQUIRE(r);
+  if (r->HasError()) { UNSCOPED_INFO(what << " error: " << r->GetError()); }
+  REQUIRE_FALSE(r->HasError());
+}
+
+void generate_parquet(fs::path const& path, int file_index)
+{
+  sirius::test::scoped_sirius_disable disable_sirius;
+  duckdb::DuckDB gen_db(nullptr);
+  duckdb::Connection gen(gen_db);
+  auto const lo = static_cast<std::int64_t>(file_index) * kRowsPerFile;
+  auto r = gen.Query("COPY (SELECT range AS k, range * 2 AS v FROM range(" + std::to_string(lo) +
+                     ", " + std::to_string(lo + kRowsPerFile) + ") ORDER BY k) TO " +
+                     sirius::test::sql_literal(path.string()) + " (FORMAT PARQUET);");
+  REQUIRE(r);
+  REQUIRE_FALSE(r->HasError());
+}
+
+void write_config(fs::path const& yaml_path)
+{
+  std::ofstream f(yaml_path);
+  f << "sirius:\n"
+       "  topology:\n"
+       "    num_gpus: 1\n"
+       "  memory:\n"
+       "    gpu:\n"
+       "      usage_limit_bytes: "
+    << (2ull << 30)
+    << "\n"
+       "      reservation_limit_fraction: 1.0\n"
+       "    host:\n"
+       "      capacity_bytes: 32000000000\n"
+       "      initial_number_pools: 10\n"
+       "      pool_size: 512\n"
+       "      block_size: 1048576\n"
+       "  executor:\n"
+       "    pipeline:\n"
+       "      num_threads: 4\n"
+       "    task_creator:\n"
+       "      num_threads: 2\n"
+       "    downgrade:\n"
+       "      num_threads: 1\n"
+       "      monitor_period: 10ms\n"
+       "  operator_params:\n"
+       "    scan_task_batch_size: 100000000\n"
+       "    max_sort_partition_bytes: 0\n"
+       "    hash_partition_bytes: 100000000\n"
+       "    concat_batch_bytes: 100000000\n"
+       "    max_build_hash_table_bytes: 90000000\n";
+}
+
+void pause_shared_envs()
+{
+  if (sirius::test::g_shared_env && sirius::test::g_shared_env->is_active()) {
+    sirius::test::g_shared_env->pause();
+  }
+  if (sirius::test::g_integration_env && sirius::test::g_integration_env->is_active()) {
+    sirius::test::g_integration_env->pause();
+  }
+  if (sirius::test::g_integration_env_2gpu && sirius::test::g_integration_env_2gpu->is_active()) {
+    sirius::test::g_integration_env_2gpu->pause();
+  }
+}
+
+sirius::scan_manager::pinned_entry const* find_entry(duckdb::SiriusContext& sirius_ctx,
+                                                     std::string_view entry_name)
+{
+  sirius::scan_manager::pinned_entry const* entry_ptr = nullptr;
+  sirius_ctx.get_scan_manager().visit_pinned_entries(
+    [&entry_ptr, entry_name](std::string_view name, auto const& e) {
+      if (name == entry_name) {
+        entry_ptr = &e;
+        return true;
+      }
+      return false;
+    });
+  return entry_ptr;
+}
+
+std::size_t entry_chunk_count(sirius::scan_manager::pinned_entry const& e)
+{
+  if (e.tier == cucascade::memory::Tier::HOST) { return e.host_chunks.size(); }
+  if (!e.device_chunks.empty()) { return e.device_chunks.size(); }
+  return e.data_batches_by_column.empty() ? 0 : e.data_batches_by_column.begin()->second.size();
+}
+
+/// `read_parquet([...])` over @p paths, quote-safe.
+std::string read_parquet_list(std::vector<std::string> const& paths)
+{
+  std::string sql = "read_parquet([";
+  for (std::size_t i = 0; i < paths.size(); ++i) {
+    if (i > 0) { sql += ", "; }
+    sql += sirius::test::sql_literal(paths[i]);
+  }
+  sql += "])";
+  return sql;
+}
+
+/// (count(*), sum(v)) of @p relation under @p where, as printed strings.
+std::pair<std::string, std::string> query_agg(duckdb::Connection& con,
+                                              std::string const& relation,
+                                              std::string const& where = "")
+{
+  auto r = con.Query("SELECT count(*), sum(v) FROM " + relation + " " + where + ";");
+  require_ok(r, "aggregate query");
+  return {r->GetValue(0, 0).ToString(), r->GetValue(1, 0).ToString()};
+}
+
+/// True when the serve path logged that 'subset_t' served a scan as a file
+/// subset with the given "N/M files, K/L chunks" tail.
+bool logged_subset_hit(sirius::test::recording_log_sink const& sink, std::string const& shape)
+{
+  for (auto const& record : sink.records()) {
+    if (record.message.find("pinned entry 'subset_t' serves operator") != std::string::npos &&
+        record.message.find("as a file subset: " + shape) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool logged_any_serve(sirius::test::recording_log_sink const& sink)
+{
+  for (auto const& record : sink.records()) {
+    if (record.message.find("pinned entry 'subset_t' serves operator") != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+// NB: no [integration]/[shared_context] tag — this TEST_CASE builds its own
+// SiriusContext and manages (pauses) the shared envs itself, mirroring the other
+// isolated-context pin tests.
+TEST_CASE("gpu_execution - a pinned parquet glob serves scans over a subset of its files",
+          "[gpu_execution][parquet][pin_table_file_subset]")
+{
+  pause_shared_envs();
+
+  sirius::test::scratch_dir scratch{"pin_file_subset"};
+  auto const& tmp = scratch.path();
+
+  std::vector<std::string> files;
+  for (int i = 0; i < kFiles; ++i) {
+    auto const path = tmp / ("part_" + std::to_string(i) + ".parquet");
+    generate_parquet(path, i);
+    files.push_back(path.string());
+  }
+  // Never pinned: a scan that adds it is a superset of the pin and must miss.
+  auto const extra = tmp / "extra.parquet";
+  generate_parquet(extra, kFiles);
+
+  auto yaml_path = tmp / "pin_file_subset.yaml";
+  write_config(yaml_path);
+  REQUIRE(fs::exists(yaml_path));
+
+  auto const glob        = (tmp / "part_*.parquet").string();
+  auto const rel_two     = read_parquet_list({files[0], files[2]});
+  auto const rel_one     = read_parquet_list({files[1]});
+  auto const rel_all     = "read_parquet(" + sirius::test::sql_literal(glob) + ")";
+  auto const rel_super   = read_parquet_list({files[0], files[1], files[2], extra.string()});
+  auto const where_file2 = "WHERE k >= " + std::to_string(2 * kRowsPerFile);
+
+  {
+    sirius::test::shared_test_env local_env(yaml_path);
+    auto con = local_env.make_connection();
+
+    require_ok(con.Query("SET enable_duckdb_fallback = false;"), "disable fallback");
+
+    auto sirius_ctx = con.context->registered_state->Get<duckdb::SiriusContext>("sirius_state");
+    REQUIRE(sirius_ctx);
+
+    // Unpinned oracle from the same engine, before any pin exists.
+    auto const two_disk       = query_agg(con, rel_two);
+    auto const one_disk       = query_agg(con, rel_one);
+    auto const all_disk       = query_agg(con, rel_all);
+    auto const super_disk     = query_agg(con, rel_super);
+    auto const two_file2_disk = query_agg(con, rel_two, where_file2);
+    REQUIRE(two_disk.first == std::to_string(2 * kRowsPerFile));
+    REQUIRE(one_disk.first == std::to_string(kRowsPerFile));
+    REQUIRE(all_disk.first == std::to_string(kFiles * kRowsPerFile));
+    REQUIRE(super_disk.first == std::to_string((kFiles + 1) * kRowsPerFile));
+    REQUIRE(two_file2_disk.first == std::to_string(kRowsPerFile));
+
+    for (auto const* tier : {"gpu", "host"}) {
+      DYNAMIC_SECTION("tier = " << tier)
+      {
+        require_ok(con.Query("CALL pin_table(" + sirius::test::sql_literal(glob) + ", tier='" +
+                             std::string(tier) + "', name='subset_t');"),
+                   "pin_table");
+
+        // Provenance: one chunk per file, each naming exactly that file.
+        auto const* entry = find_entry(*sirius_ctx, "subset_t");
+        REQUIRE(entry != nullptr);
+        REQUIRE(entry->cache_info.resolved_file_paths.size() == static_cast<std::size_t>(kFiles));
+        auto const n_chunks = entry_chunk_count(*entry);
+        REQUIRE(n_chunks == static_cast<std::size_t>(kFiles));
+        REQUIRE(entry->chunk_file_paths.size() == n_chunks);
+        std::set<std::string> recorded;
+        for (auto const& chunk_files : entry->chunk_file_paths) {
+          REQUIRE(chunk_files.size() == 1);
+          recorded.insert(chunk_files.front());
+        }
+        std::set<std::string> expected;
+        for (auto const& f : files) {
+          expected.insert(sirius::op::scan::canonical_scan_file_path(f));
+        }
+        REQUIRE(recorded == expected);
+
+        {
+          sirius::test::scoped_recording_log_sink logs{"info"};
+          REQUIRE(query_agg(con, rel_two) == two_disk);
+          REQUIRE(logged_subset_hit(logs.sink(), "2/3 files, 2/3 chunks"));
+        }
+        {
+          sirius::test::scoped_recording_log_sink logs{"info"};
+          REQUIRE(query_agg(con, rel_one) == one_disk);
+          REQUIRE(logged_subset_hit(logs.sink(), "1/3 files, 1/3 chunks"));
+        }
+        {
+          // The exact set is served as before, not through the subset path.
+          sirius::test::scoped_recording_log_sink logs{"info"};
+          REQUIRE(query_agg(con, rel_all) == all_disk);
+          REQUIRE_FALSE(logged_any_serve(logs.sink()));
+        }
+        {
+          // A superset names a file the pin cannot provide: a miss, still correct.
+          sirius::test::scoped_recording_log_sink logs{"info"};
+          REQUIRE(query_agg(con, rel_super) == super_disk);
+          REQUIRE_FALSE(logged_any_serve(logs.sink()));
+        }
+        {
+          // Zone maps prune file 0's chunk out of the two-file subset; the
+          // selects-nothing filter leaves only the sentinel, which must be one of
+          // the allowed chunks (the GPU filter then empties it).
+          sirius::test::scoped_recording_log_sink logs{"info"};
+          REQUIRE(query_agg(con, rel_two, where_file2) == two_file2_disk);
+          REQUIRE(logged_subset_hit(logs.sink(), "2/3 files, 2/3 chunks"));
+          auto none = con.Query("SELECT count(*) FROM " + rel_two + " WHERE k < 0;");
+          require_ok(none, "selects-nothing subset query");
+          REQUIRE(none->GetValue(0, 0).ToString() == "0");
+        }
+
+        require_ok(con.Query("CALL unpin_table('subset_t');"), "unpin");
+      }
+    }
+  }
+}

--- a/test/cpp/scan/test_can_serve_with_columns.cpp
+++ b/test/cpp/scan/test_can_serve_with_columns.cpp
@@ -183,6 +183,47 @@ TEST_CASE("cache_entry_info: a byte-range split scan neither serves nor is serve
   REQUIRE(whole_file_pin.can_serve_with_columns(unranged_scan) == std::vector<std::size_t>{0});
 }
 
+TEST_CASE("cache_entry_info: matches_parquet_file_set classifies exact, subset, and miss",
+          "[scan][can_serve]")
+{
+  using match = sirius::scan_manager::cache_entry_info::parquet_file_match;
+  auto cache  = parquet_cache({"a.parquet", "b.parquet", "c.parquet"}, {0});
+
+  std::vector<std::string> canonical;
+  REQUIRE(cache.matches_parquet_file_set(
+            std::vector<std::string>{"c.parquet", "a.parquet", "b.parquet"}, &canonical) ==
+          match::exact);
+  REQUIRE(canonical == std::vector<std::string>{"a.parquet", "b.parquet", "c.parquet"});
+
+  canonical.clear();
+  REQUIRE(cache.matches_parquet_file_set(std::vector<std::string>{"c.parquet", "a.parquet"},
+                                         &canonical) == match::subset);
+  REQUIRE(canonical == std::vector<std::string>{"a.parquet", "c.parquet"});
+
+  // A probe naming a file outside the pinned set misses even when others overlap.
+  REQUIRE(cache.matches_parquet_file_set(std::vector<std::string>{"a.parquet", "d.parquet"}) ==
+          match::miss);
+  // A superset of the pinned set misses (the pin cannot provide the extra file).
+  REQUIRE(cache.matches_parquet_file_set(std::vector<std::string>{
+            "a.parquet", "b.parquet", "c.parquet", "d.parquet"}) == match::miss);
+  REQUIRE(cache.matches_parquet_file_set(std::vector<std::string>{}) == match::miss);
+
+  // Duplicates on either side poison subset matching (a duplicated pinned path
+  // means the file's chunks were materialized twice; serving them once/twice
+  // would return the wrong row count) — but exact stays duplicate-symmetric.
+  auto dup_cache = parquet_cache({"a.parquet", "a.parquet", "b.parquet"}, {0});
+  REQUIRE(dup_cache.matches_parquet_file_set(std::vector<std::string>{"a.parquet"}) == match::miss);
+  REQUIRE(dup_cache.matches_parquet_file_set(
+            std::vector<std::string>{"a.parquet", "a.parquet", "b.parquet"}) == match::exact);
+  REQUIRE(cache.matches_parquet_file_set(std::vector<std::string>{"a.parquet", "a.parquet"}) ==
+          match::miss);
+
+  // A duckdb-identity entry never matches any parquet probe.
+  auto duckdb_entry = duckdb_cache("db", "main", "t", {0});
+  REQUIRE(duckdb_entry.matches_parquet_file_set(std::vector<std::string>{"a.parquet"}) ==
+          match::miss);
+}
+
 TEST_CASE("cache_entry_info: duckdb same-table subset request hits with a gather projection",
           "[scan][can_serve]")
 {
@@ -250,7 +291,7 @@ TEST_CASE("cache_entry_info: matches_duckdb_table is the shared identity matcher
   REQUIRE_FALSE(parquet.matches_duckdb_table("", "", ""));  // parquet identity never matches
 }
 
-TEST_CASE("cache_entry_info: matches_parquet_files is the shared parquet identity matcher",
+TEST_CASE("cache_entry_info: matches_parquet_files is exact set equality over the canonical paths",
           "[scan][can_serve]")
 {
   auto cache = parquet_cache({"a.parquet", "b.parquet"}, {0});

--- a/test/cpp/scan/test_parquet_scan_sizing.cpp
+++ b/test/cpp/scan/test_parquet_scan_sizing.cpp
@@ -23,6 +23,8 @@
 
 #include <filesystem>
 #include <memory>
+#include <set>
+#include <string>
 #include <vector>
 
 namespace {
@@ -146,6 +148,36 @@ duckdb::vector<duckdb::HivePartitioningIndex> year_partition()
   return {duckdb::HivePartitioningIndex("2024", 4)};
 }
 
+std::unique_ptr<scan::parquet_file_scan_info> one_row_group_file(std::string path)
+{
+  auto file       = std::make_unique<scan::parquet_file_scan_info>();
+  file->file_path = std::move(path);
+  file->row_groups.push_back({0, 20, 60, 10, 1});
+  return file;
+}
+
+// Three one-row-group files through a coalescer whose byte budget never fills, so
+// the only reason to split is the file-boundary mode under test.
+std::vector<std::unique_ptr<scan::scan_info>> coalesce_three_files(bool file_boundaries)
+{
+  auto info                          = std::make_unique<scan::parquet_ingestible_table_info>();
+  info->approximate_batch_size       = std::size_t{1} << 30;
+  info->batch_within_file_boundaries = file_boundaries;
+  scan::parquet_gpu_ingestible ingestible{std::move(info)};
+  auto coalescer = ingestible.create_batch_coalescer();
+
+  std::vector<std::unique_ptr<scan::scan_info>> batches;
+  for (auto const* path : {"f0.parquet", "f1.parquet", "f2.parquet"}) {
+    for (auto& batch : coalescer->push(one_row_group_file(path))) {
+      batches.push_back(std::move(batch));
+    }
+  }
+  for (auto& batch : coalescer->flush()) {
+    batches.push_back(std::move(batch));
+  }
+  return batches;
+}
+
 }  // namespace
 
 TEST_CASE("parquet scans without a prefetch cache skip advisory ranges",
@@ -203,6 +235,38 @@ TEST_CASE("parquet batches are capped by decode working set", "[scan][parquet][s
   masked.mvcc_keep_mask = sirius::scan_manager::mvcc_chunk_mask{{words, words->data()}, rows};
   CHECK(masked.get_estimated_working_set_size_in_bytes() ==
         2 * 60 + rows + masked.mvcc_keep_mask.view().size_bytes());
+}
+
+TEST_CASE("parquet coalescer file-boundary mode never bundles two files into one split",
+          "[scan][parquet][sizing][pin_table]")
+{
+  SECTION("bundling across files stays the default")
+  {
+    auto batches = coalesce_three_files(false);
+    REQUIRE(batches.size() == 1);
+    auto* split = dynamic_cast<scan::parquet_split_info*>(batches.front().get());
+    REQUIRE(split);
+    REQUIRE(split->rg_slices.size() == 3);
+  }
+
+  SECTION("batch_within_file_boundaries emits one single-file split per file")
+  {
+    auto batches = coalesce_three_files(true);
+    REQUIRE(batches.size() == 3);
+    std::set<std::string> seen;
+    for (auto const& batch : batches) {
+      auto* split = dynamic_cast<scan::parquet_split_info*>(batch.get());
+      REQUIRE(split);
+      REQUIRE_FALSE(split->rg_slices.empty());
+      std::set<std::string> files;
+      for (auto const& slice : split->rg_slices) {
+        files.insert(slice.file_path);
+      }
+      REQUIRE(files.size() == 1);
+      seen.insert(*files.begin());
+    }
+    REQUIRE(seen == std::set<std::string>{"f0.parquet", "f1.parquet", "f2.parquet"});
+  }
 }
 
 TEST_CASE("parquet synthetic filter-only columns only increase the decode working set",

--- a/test/cpp/scan_manager/test_cached_serving_hardening.cpp
+++ b/test/cpp/scan_manager/test_cached_serving_hardening.cpp
@@ -60,8 +60,10 @@
 #include <cucascade/cudf/host_data_representation.hpp>
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/memory/memory_space.hpp>
+#include <cucascade/memory/topology_discovery.hpp>
 #include <data/data_batch_utils.hpp>
 #include <data/sirius_converter_registry.hpp>
+#include <memory/topology_index.hpp>
 #include <op/scan/gpu_ingestible.hpp>
 #include <op/scan/sirius_gpu_scan_operator_data.hpp>
 #include <scan_manager/load_balancing_scan_batch_coalescer.hpp>
@@ -81,9 +83,12 @@
 #include <vector>
 
 using sirius::scan_manager::build_cached_scan_plan;
+using sirius::scan_manager::cache_entry_info;
 using sirius::scan_manager::databatch_provider;
 using sirius::scan_manager::load_balancing_scan_batch_coalescer;
 using sirius::scan_manager::pinned_entry;
+using sirius::scan_manager::scan_manager_config;
+using sirius::scan_manager::sirius_scan_manager;
 using sirius::scan_manager::split_connector;
 using sirius::scan_manager::validate_pinned_entry_for_serving;
 
@@ -1213,6 +1218,171 @@ TEST_CASE("build_cached_scan_plan counts device_chunks for a compression-enabled
   auto entry = make_device_chunks_entry(*e.gpu_space, 5, 4);
   auto plan  = build_cached_scan_plan(entry, /*table_filters=*/nullptr, /*column_ids=*/nullptr);
   REQUIRE(plan.survivor_chunk_indices.size() == 5);
+}
+
+// File-subset serving restricts the plan to the chunks whose provenance the scan
+// covers; the restriction applies before zone-map pruning so the all-pruned
+// sentinel can only pick an allowed chunk.
+TEST_CASE("build_cached_scan_plan honors an allowed-chunks restriction",
+          "[cached_serving][scan_manager]")
+{
+  auto& e    = env();
+  auto entry = make_device_chunks_entry(*e.gpu_space, 5, 4);
+
+  SECTION("identity plan over the allowed set only")
+  {
+    std::vector<std::size_t> const allowed{1, 3};
+    auto plan = build_cached_scan_plan(entry, nullptr, nullptr, &allowed);
+    REQUIRE(plan.survivor_chunk_indices == allowed);
+    REQUIRE(plan.pruned == 0);
+  }
+
+  SECTION("out-of-range allowed indices are dropped, not served")
+  {
+    std::vector<std::size_t> const allowed{2, 99};
+    auto plan = build_cached_scan_plan(entry, nullptr, nullptr, &allowed);
+    REQUIRE(plan.survivor_chunk_indices == std::vector<std::size_t>{2});
+  }
+
+  SECTION("empty allowed set yields an empty plan (caller must treat as a miss)")
+  {
+    std::vector<std::size_t> const allowed{};
+    auto plan = build_cached_scan_plan(entry, nullptr, nullptr, &allowed);
+    REQUIRE(plan.survivor_chunk_indices.empty());
+    REQUIRE(plan.pruned == 0);
+  }
+}
+
+namespace {
+
+std::shared_ptr<const sirius::memory::topology_index> single_gpu_index()
+{
+  cucascade::memory::system_topology_info topology;
+  topology.num_gpus = 1;
+  cucascade::memory::gpu_topology_info gpu;
+  gpu.id        = 0;
+  gpu.numa_node = 0;
+  topology.gpus.push_back(std::move(gpu));
+  return std::make_shared<sirius::memory::topology_index>(std::move(topology), std::vector<int>{0});
+}
+
+/// Parquet identity over {a, b} with one cached INT32 column 'k'. Paths are
+/// relative and nonexistent so canonicalization leaves them as spelled.
+cache_entry_info two_file_cache_info()
+{
+  cache_entry_info info;
+  info.resolved_file_paths = {"a.parquet", "b.parquet"};
+  info.column_ids.emplace_back(0);
+  info.names = {"k"};
+  return info;
+}
+
+/// @p n_chunks single-column INT32 tables of 4 rows each, owned outright so
+/// insert_pinned_entry can release them.
+std::vector<std::unique_ptr<cudf::table>> int32_chunks(test_env& e, std::size_t n_chunks)
+{
+  std::vector<std::unique_ptr<cudf::table>> tables;
+  for (std::size_t c = 0; c < n_chunks; ++c) {
+    auto shared = make_gpu_column(*e.gpu_space, {1, 2, 3, 4});
+    std::vector<std::unique_ptr<cudf::column>> cols;
+    cols.push_back(std::make_unique<cudf::column>(
+      shared->view(), e.stream(), e.gpu_space->get_default_allocator()));
+    tables.push_back(std::make_unique<cudf::table>(std::move(cols)));
+  }
+  e.stream().synchronize();
+  return tables;
+}
+
+sirius::pinned_column_storage_matrix int32_storage(std::size_t n_chunks)
+{
+  return sirius::pinned_column_storage_matrix(n_chunks,
+                                              {native_meta(cudf::data_type{cudf::type_id::INT32})});
+}
+
+/// Two-chunk GPU pin of 'k' under @p name; a repeat with the same name takes the
+/// same-row-count merge path (identical boundaries and placement).
+void insert_two_chunk_pin(sirius_scan_manager& manager,
+                          test_env& e,
+                          std::string const& name,
+                          std::vector<std::vector<std::string>> provenance)
+{
+  auto const stored = manager.insert_pinned_entry(name,
+                                                  two_file_cache_info(),
+                                                  int32_chunks(e, 2),
+                                                  {e.gpu_space, e.gpu_space},
+                                                  {},
+                                                  {},
+                                                  int32_storage(2),
+                                                  std::move(provenance));
+  (void)stored;
+}
+
+}  // namespace
+
+// Provenance rides the chunk vector: every insert path rejects a length that is
+// neither empty nor parallel, and the GPU merge path adopts provenance an
+// existing entry lacks but refuses one that disagrees.
+TEST_CASE("insert_pinned_entry validates and merges per-chunk file provenance",
+          "[cached_serving][scan_manager]")
+{
+  auto& e = env();
+  sirius_scan_manager manager{scan_manager_config{}, *e.mgr, single_gpu_index()};
+
+  std::vector<std::vector<std::string>> const one_chunk{std::vector<std::string>{"a.parquet"}};
+  std::vector<std::vector<std::string>> const two_chunks{std::vector<std::string>{"a.parquet"},
+                                                         std::vector<std::string>{"b.parquet"}};
+  std::vector<std::string> const probe_a{"a.parquet"};
+  std::vector<std::string> const probe_ab{"a.parquet", "b.parquet"};
+
+  SECTION("provenance must be empty or parallel to the chunks")
+  {
+    REQUIRE_THROWS_AS(insert_two_chunk_pin(manager, e, "arity", one_chunk), std::invalid_argument);
+
+    sirius::device_pin_chunk chunk;
+    chunk.memory_space = e.gpu_space;
+    chunk.columns.push_back(make_gpu_column(*e.gpu_space, {1, 2, 3, 4}));
+    std::vector<sirius::device_pin_chunk> chunks;
+    chunks.push_back(std::move(chunk));
+    REQUIRE_THROWS_AS(manager.insert_pinned_entry_device("arity_device",
+                                                         two_file_cache_info(),
+                                                         std::move(chunks),
+                                                         *e.gpu_space,
+                                                         int32_storage(1),
+                                                         two_chunks),
+                      std::invalid_argument);
+
+    REQUIRE_THROWS_AS(
+      manager.insert_pinned_entry_host(
+        "arity_host", two_file_cache_info(), {}, *e.host_space, {}, {}, {}, one_chunk),
+      std::invalid_argument);
+
+    REQUIRE(manager.find_pinned_entry_for_parquet_files(probe_ab) == nullptr);
+  }
+
+  SECTION("a merge adopts provenance the existing entry lacks")
+  {
+    insert_two_chunk_pin(manager, e, "adopt", {});
+    // Without provenance the entry is an exact-set hit only: the plan-time
+    // residency gate must not report a subset scan as resident.
+    REQUIRE(manager.find_pinned_entry_for_parquet_files(probe_ab) != nullptr);
+    REQUIRE(manager.find_pinned_entry_for_parquet_files(probe_a) == nullptr);
+
+    insert_two_chunk_pin(manager, e, "adopt", two_chunks);
+    auto const* entry = manager.find_pinned_entry_for_parquet_files(probe_a);
+    REQUIRE(entry != nullptr);
+    REQUIRE(entry->chunk_file_paths == two_chunks);
+  }
+
+  SECTION("a merge whose provenance disagrees throws and leaves the entry intact")
+  {
+    insert_two_chunk_pin(manager, e, "mismatch", two_chunks);
+    std::vector<std::vector<std::string>> const swapped{std::vector<std::string>{"b.parquet"},
+                                                        std::vector<std::string>{"a.parquet"}};
+    REQUIRE_THROWS_AS(insert_two_chunk_pin(manager, e, "mismatch", swapped), std::runtime_error);
+    auto const* entry = manager.find_pinned_entry_for_parquet_files(probe_a);
+    REQUIRE(entry != nullptr);
+    REQUIRE(entry->chunk_file_paths == two_chunks);
+  }
 }
 
 TEST_CASE("validate_pinned_entry_for_serving refuses malformed entries",


### PR DESCRIPTION
## Description

A pinned parquet table only served a scan whose resolved file set equaled the pinned set. StarRocks hands each compute node a per-query subset of a table's files, so a whole-glob pin on each CN never matched and served nothing while still holding the memory. The plain DuckDB path has the same gap. Pin a glob, query two of its three files, and the read falls through to disk.

This PR makes a pin serve any strict subset of its files. It is one unit from pin time to serve time.

Pin time. `build_parquet_pin_info` turns on a new coalescer mode, `batch_within_file_boundaries`, so no pinned chunk bundles two files. `materialize_pin_batches` records each chunk's source files (canonicalized, sorted, deduplicated) and the three sinks push that vector unconditionally so it stays parallel to the chunks. The three `insert_pinned_entry*` paths store it as `pinned_entry::chunk_file_paths` and throw on a length mismatch. The GPU merge path adopts provenance an existing entry lacks and throws when the two disagree.

Serve time. `cache_entry_info::matches_parquet_file_set` classifies a scan as exact, strict subset, or miss. It is now the one parquet matcher behind both `can_serve_with_columns` and the plan-time residency gate; `matches_parquet_files` stays as an exact-only wrapper with no production caller. `try_match_cached_entry` selects the chunks whose provenance the scan covers and hands them to `build_cached_scan_plan` as `allowed_chunks`. I apply that restriction before zone-map pruning so the all-pruned sentinel can only pick an allowed chunk; a sentinel outside the set would return another file's rows. `find_pinned_entry_for_parquet_files` accepts a subset under the same provenance condition, so the plan-time residency gate and the serve path agree. The header doc on `can_serve_with_columns` spells out that a non-empty projection on the subset branch is necessary but not sufficient; the caller still has to check `chunk_file_paths`.

Subset matching requires duplicate-free canonical sets on both sides. A duplicated pinned path means that file's chunks were materialized twice, and serving them to a scan that names the file once would double its rows. Exact matching stays duplicate-symmetric, so existing pins behave as before. Entries without provenance (pins made before this change, duckdb-native pins) keep exact-only matching. Byte-range scans never serve or get served; the guard from #1700 in `can_serve_with_columns` stays above the new check.

Tests added, all Catch2:
- `test/cpp/scan/test_can_serve_with_columns.cpp`: `matches_parquet_file_set` over exact, subset, miss, superset, empty, duplicate poisoning, and a duckdb entry.
- `test/cpp/scan_manager/test_cached_serving_hardening.cpp`: `build_cached_scan_plan` with an allowed-chunks restriction (identity, out-of-range indices dropped, empty set); `insert_pinned_entry` provenance on all three insert paths (arity throws `std::invalid_argument`, merge adopts, merge mismatch throws `std::runtime_error` and leaves the entry intact), plus the residency gate refusing a subset probe until provenance exists.
- `test/cpp/scan/test_parquet_scan_sizing.cpp`: the coalescer bundles three files into one split by default and emits three single-file splits with `batch_within_file_boundaries`.
- `test/cpp/integration/test_pin_table_file_subset.cpp` (new, registered in `CMakeLists.txt`): pins a three-file glob on the gpu and host tiers, checks one file per chunk in the recorded provenance, then runs two-file, one-file, exact, superset, filtered, and selects-nothing scans against the unpinned read and asserts the `serves operator ... as a file subset` log line where a subset was served.

**How I tested it.** On a GB200 box (aarch64) I did a full release build in a worktree, then ran the scan, cache and pin_table Catch2 suites on a GPU, plus the new end-to-end test. Everything passes and pre-commit is clean. These are GPU tests that CI does not run.

The source branch measured this on 2x RTX PRO 6000, SF100 lineitem, 2 CNs, q06 shape, at 0.63 s unpinned and 0.09 s pinned, byte-identical to the DuckDB oracle. I did not re-measure here.

Not handled. A superset scan is a miss. Duckdb-native pins record no provenance. A pin over many tiny files now yields at least one chunk per file. The FE lever (`files_query_whole_file_ranges`), the FFI `pin_table`, and the CN admin channel are later PRs in this series.

Layer 3 of the scan stack; base stacked/scan-byte-range-ingestible (#1700).

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References
- Supersedes the file-subset part of #1686 (closed umbrella).
- Refs #1547, #1555 (merged neighbours in the same functions).