### PR TITLE
fix(ci): support cudf nightly stream API

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -108,7 +108,7 @@ jobs:
             build-type: release
             environment: default
             cudf-channel: nightly
-            run-on-pr: true
+            run-on-pr: false
         exclude:
           # On PRs, drop rows marked merge/dev-only; on merge_group/dev, match nothing.
           - build:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -108,7 +108,7 @@ jobs:
             build-type: release
             environment: default
             cudf-channel: nightly
-            run-on-pr: false
+            run-on-pr: true
         exclude:
           # On PRs, drop rows marked merge/dev-only; on merge_group/dev, match nothing.
           - build:

--- a/src/compression/simpatico_codegen/tests/test_compressed_table_io.cpp
+++ b/src/compression/simpatico_codegen/tests/test_compressed_table_io.cpp
@@ -16,6 +16,8 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
+#include <rmm/cuda_stream_view.hpp>
+
 #include <unistd.h>
 
 #include <algorithm>
@@ -73,7 +75,7 @@ void io_roundtrip(char const* label,
                   std::string const& dsl,
                   std::vector<std::string> column_names = {})
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
 
   // Compress.
   simpatico::compressed_table ct1 = simpatico::compress_with_plan(
@@ -130,8 +132,8 @@ void io_roundtrip(char const* label,
 // through the same fetch seam pin_table uses.
 void memory_roundtrip(char const* label, cudf::table_view input, std::string const& dsl)
 {
-  auto stream = cudf::get_default_stream();
-  auto mr     = rmm::mr::get_current_device_resource_ref();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = rmm::mr::get_current_device_resource_ref();
 
   simpatico::compressed_table ct = simpatico::compress_with_plan(input, dsl, stream, mr);
 
@@ -337,16 +339,16 @@ void test_multi_column()
 // column. Exercise all three overload families.
 void test_selective_decompression()
 {
-  auto stream = cudf::get_default_stream();
-  auto mr     = rmm::mr::get_current_device_resource_ref();
-  auto t      = make_int32_table(3, 2048, 29);
-  auto ct     = simpatico::compress_with_plan(t->view(),
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = rmm::mr::get_current_device_resource_ref();
+  auto t                       = make_int32_table(3, 2048, 29);
+  auto ct                      = simpatico::compress_with_plan(t->view(),
                                           "input -> for -> deltas, references\n"
-                                              "---\n"
-                                              "input -> delta -> differences\n"
-                                              "delta.differences -> bitpack\n"
-                                              "---\n"
-                                              "input -> bitpack\n",
+                                                               "---\n"
+                                                               "input -> delta -> differences\n"
+                                                               "delta.differences -> bitpack\n"
+                                                               "---\n"
+                                                               "input -> bitpack\n",
                                           stream,
                                           mr);
 
@@ -391,19 +393,19 @@ void test_selective_decompression()
 // in addition to metadata, order, duplicate, empty, and error behavior.
 void test_memory_subset_read()
 {
-  auto stream = cudf::get_default_stream();
-  auto mr     = rmm::mr::get_current_device_resource_ref();
-  auto t      = make_int32_table(3, 2048, 37);
-  auto ct     = simpatico::compress_with_plan(t->view(),
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = rmm::mr::get_current_device_resource_ref();
+  auto t                       = make_int32_table(3, 2048, 37);
+  auto ct                      = simpatico::compress_with_plan(t->view(),
                                           "input -> for -> deltas, references\n"
-                                              "---\n"
-                                              "input -> delta -> differences\n"
-                                              "delta.differences -> bitpack\n"
-                                              "---\n"
-                                              "input -> bitpack\n",
+                                                               "---\n"
+                                                               "input -> delta -> differences\n"
+                                                               "delta.differences -> bitpack\n"
+                                                               "---\n"
+                                                               "input -> bitpack\n",
                                           stream,
                                           mr,
-                                              {"first", "second", "third"});
+                                                               {"first", "second", "third"});
 
   std::vector<std::uint8_t> header;
   std::vector<simpatico::payload_buffer_ref> buffers;
@@ -578,8 +580,8 @@ void test_error_bad_version()
 // file (both the file path and the in-memory pin path).
 void test_identity_string_roundtrip()
 {
-  auto stream = cudf::get_default_stream();
-  auto input  = make_string_table(128, stream);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto input                   = make_string_table(128, stream);
   io_roundtrip("identity_string", input->view(), "input -> identity\n");
   memory_roundtrip("identity_string_mem", input->view(), "input -> identity\n");
 }
@@ -591,7 +593,7 @@ void test_identity_string_roundtrip()
 // rerouted sf1000 plans serialize in production.
 void test_str_split_plan_shapes_roundtrip()
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
 
   std::vector<std::string> addresses;
   std::vector<std::string> phones;

--- a/test/cpp/debug/test_debug_utils.cpp
+++ b/test/cpp/debug/test_debug_utils.cpp
@@ -27,6 +27,7 @@
 #include <cudf/utilities/bit.hpp>
 #include <cudf/utilities/default_stream.hpp>
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 
 #include <cuda_runtime.h>
@@ -51,8 +52,8 @@ TEST_CASE("debug_schema produces output without throwing", "[debug_utils]")
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
 
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create INT32 column (5 rows)
   std::vector<int32_t> vals_a{10, 20, 30, 40, 50};
@@ -86,8 +87,8 @@ TEST_CASE("debug_schema with no column names uses defaults", "[debug_utils]")
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
 
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   std::vector<int32_t> vals_a{1, 2, 3, 4, 5};
   auto col_a =
@@ -120,8 +121,8 @@ TEST_CASE("debug_nulls produces output without throwing", "[debug_utils]")
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
 
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   std::vector<int32_t> vals_a{10, 20, 30, 40, 50};
   auto col_a =
@@ -153,8 +154,8 @@ TEST_CASE("debug_schema handles empty batch (0 rows)", "[debug_utils]")
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
 
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create two columns with 0 rows
   auto col_a = cudf::make_numeric_column(
@@ -184,8 +185,8 @@ TEST_CASE("debug_nulls reports correct null counts for columns with nulls", "[de
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
 
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   constexpr cudf::size_type num_rows = 5;
 
@@ -239,8 +240,8 @@ TEST_CASE("copy_null_mask_to_host returns correct null positions", "[debug_utils
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
 
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   constexpr cudf::size_type num_rows = 8;
 
@@ -294,8 +295,8 @@ TEST_CASE("copy_null_mask_to_host returns has_nulls=false for non-null column", 
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
 
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create a column with no nulls (UNALLOCATED mask)
   auto col = cudf::make_numeric_column(
@@ -341,8 +342,8 @@ TEST_CASE("debug_head on multi-type numeric batch (ALIGNED)", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   auto col_i32 = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
     {10, 20, 30}, stream, mr);
@@ -379,8 +380,8 @@ TEST_CASE("debug_head CSV format produces output without throwing", "[debug_util
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   auto col_a = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
     {1, 2, 3, 4, 5}, stream, mr);
@@ -408,8 +409,8 @@ TEST_CASE("debug_head clamps N to row count without throwing", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   auto col = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
     {10, 20, 30}, stream, mr);
@@ -434,8 +435,8 @@ TEST_CASE("debug_head on empty batch prints note without throwing", "[debug_util
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   auto col = cudf::make_numeric_column(
     cudf::data_type{cudf::type_id::INT32}, 0, cudf::mask_state::UNALLOCATED, stream, mr);
@@ -459,8 +460,8 @@ TEST_CASE("debug_head shows NULL for null positions", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   constexpr cudf::size_type num_rows = 5;
   auto col                           = cudf::make_numeric_column(
@@ -513,8 +514,8 @@ TEST_CASE("debug_stats on numeric columns produces output without throwing", "[d
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   auto col_i32 = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
     {10, 20, 30}, stream, mr);
@@ -547,8 +548,8 @@ TEST_CASE("debug_stats skips BOOL column as non-numeric", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   auto col_i32 = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
     {10, 20, 30}, stream, mr);
@@ -575,8 +576,8 @@ TEST_CASE("debug_stats on all-NULL numeric column shows NULL", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   constexpr cudf::size_type num_rows = 5;
   auto col                           = cudf::make_numeric_column(
@@ -602,8 +603,8 @@ TEST_CASE("debug_stats on empty batch prints note without throwing", "[debug_uti
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   auto col = cudf::make_numeric_column(
     cudf::data_type{cudf::type_id::INT32}, 0, cudf::mask_state::UNALLOCATED, stream, mr);
@@ -641,8 +642,8 @@ TEST_CASE("debug_head on STRING column shows string values", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   auto col =
     sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<test_utils::string_tag>>(
@@ -667,8 +668,8 @@ TEST_CASE("debug_head on STRING column truncates with max_string_len", "[debug_u
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   auto col =
     sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<test_utils::string_tag>>(
@@ -694,8 +695,8 @@ TEST_CASE("debug_head on DECIMAL64 column shows scaled values", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // decimal64_tag: scale=-2, values {12345, -100, 5} represent 123.45, -1.00, 0.05
   auto col =
@@ -721,8 +722,8 @@ TEST_CASE("debug_head on TIMESTAMP_MICROSECONDS column shows calendar format", "
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // 1705305000000000 us = 2024-01-15 08:30:00 UTC
   // 0 = 1970-01-01 00:00:00
@@ -750,8 +751,8 @@ TEST_CASE("debug_head on DATE column shows date format", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // 19738 days since epoch = 2024-01-15
   // 0 = 1970-01-01
@@ -779,8 +780,8 @@ TEST_CASE("debug_head on mixed batch with all supported types", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   auto col_int = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
     {10, 20, 30}, stream, mr);
@@ -821,8 +822,8 @@ TEST_CASE("debug_head on STRING column with nulls shows NULL", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create string column with 3 rows
   auto col =
@@ -863,8 +864,8 @@ TEST_CASE("debug_checksum on numeric column produces output without throwing", "
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   auto col = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
     {10, 20, 30}, stream, mr);
@@ -888,8 +889,8 @@ TEST_CASE("debug_checksum on multi-type batch produces per-column output", "[deb
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   auto col_i32 = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
     {10, 20, 30}, stream, mr);
@@ -921,8 +922,8 @@ TEST_CASE("debug_checksum on empty batch prints note without throwing", "[debug_
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create empty INT32 column (0 rows)
   auto col = cudf::make_empty_column(cudf::data_type{cudf::type_id::INT32});
@@ -946,8 +947,8 @@ TEST_CASE("debug_checksum on all-NULL column produces zero checksum", "[debug_ut
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create INT32 column with 5 rows, all NULL
   constexpr cudf::size_type num_rows = 5;
@@ -987,8 +988,8 @@ TEST_CASE("debug_diff identical batches reports no diffs", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create two identical batches: INT32 + INT64, 5 rows each
   auto make_batch = [&]() {
@@ -1021,8 +1022,8 @@ TEST_CASE("debug_diff column count mismatch logs schema mismatch", "[debug_utils
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // batch_a: 2 columns (INT32, INT64)
   auto col_a1 = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
@@ -1061,8 +1062,8 @@ TEST_CASE("debug_diff column type mismatch logs schema mismatch", "[debug_utils]
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // batch_a: 1 column (INT32, values {1,2,3})
   auto col_a = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
@@ -1098,8 +1099,8 @@ TEST_CASE("debug_diff row count mismatch logs row count mismatch", "[debug_utils
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // batch_a: 1 column (INT32, 3 rows)
   auto col_a = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
@@ -1135,8 +1136,8 @@ TEST_CASE("debug_diff value differences reports per-column diff counts", "[debug
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // batch_a: 1 column (INT32, 5 rows: {1, 2, 3, 4, 5})
   auto col_a = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
@@ -1172,8 +1173,8 @@ TEST_CASE("debug_diff with null differences detects null position diffs", "[debu
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   constexpr cudf::size_type num_rows = 5;
 
@@ -1249,8 +1250,8 @@ TEST_CASE("debug_diff row limit guard skips comparison for large batches", "[deb
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create a small batch (5 rows) but pass max_rows=2 to trigger the guard
   auto make_batch = [&]() {
@@ -1282,8 +1283,8 @@ TEST_CASE("debug_diff empty batches handles gracefully", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create two empty batches (0 rows, 1 INT32 column each)
   auto make_empty_batch = [&]() {
@@ -1317,8 +1318,8 @@ TEST_CASE("debug_sample basic operation with named columns", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create a batch with 2 columns (INT32, INT64), 10 rows
   auto col_a = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
@@ -1348,8 +1349,8 @@ TEST_CASE("debug_sample with fixed seed is reproducible", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create a batch with 1 column (INT32, 20 rows: {0..19})
   std::vector<int32_t> vals(20);
@@ -1382,8 +1383,8 @@ TEST_CASE("debug_sample N > num_rows clamps silently", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create a batch with 1 column (INT32, 3 rows)
   auto col = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
@@ -1410,8 +1411,8 @@ TEST_CASE("debug_sample CSV format produces output without throwing", "[debug_ut
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create a batch with 2 columns (INT32, FLOAT64), 5 rows
   auto col_a = sirius::test::vector_to_cudf_column<test_utils::gpu_type_traits<int32_t>>(
@@ -1441,8 +1442,8 @@ TEST_CASE("debug_sample empty batch handles gracefully", "[debug_utils]")
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create an empty batch (0 rows, 1 INT32 column)
   auto col = cudf::make_numeric_column(
@@ -1468,8 +1469,8 @@ TEST_CASE("debug_sample with STRING columns extracts values correctly", "[debug_
   auto memory_manager = test_utils::initialize_memory_manager();
   auto* space         = memory_manager->get_memory_space(cucascade::memory::Tier::GPU, 0);
   REQUIRE(space != nullptr);
-  auto stream = cudf::get_default_stream();
-  auto mr     = test_utils::get_resource_ref(*space);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto mr                      = test_utils::get_resource_ref(*space);
 
   // Create a STRING column following established pattern from test case 20
   auto col =

--- a/test/cpp/expression_evaluator/test_like_multiliteral.cpp
+++ b/test/cpp/expression_evaluator/test_like_multiliteral.cpp
@@ -43,6 +43,7 @@
 // rmm
 #include <rmm/device_buffer.hpp>
 
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 // standard library
@@ -64,9 +65,9 @@ std::unique_ptr<cudf::column> make_strings(std::vector<std::string> const& rows,
                                            std::vector<bool> const& valids = {},
                                            bool int64_offsets              = false)
 {
-  auto stream  = cudf::get_default_stream();
-  auto mr      = cudf::get_current_device_resource_ref();
-  auto const n = static_cast<cudf::size_type>(rows.size());
+  cuda::stream_ref const stream = cudf::get_default_stream();
+  auto mr                       = cudf::get_current_device_resource_ref();
+  auto const n                  = static_cast<cudf::size_type>(rows.size());
 
   std::string chars;
   std::vector<int64_t> offsets(rows.size() + 1, 0);
@@ -84,7 +85,7 @@ std::unique_ptr<cudf::column> make_strings(std::vector<std::string> const& rows,
                     offsets.data(),
                     offsets.size() * sizeof(int64_t),
                     cudaMemcpyHostToDevice,
-                    stream.value());
+                    stream.get());
   } else {
     std::vector<int32_t> offsets32(offsets.begin(), offsets.end());
     offsets_col = cudf::make_numeric_column(
@@ -93,8 +94,8 @@ std::unique_ptr<cudf::column> make_strings(std::vector<std::string> const& rows,
                     offsets32.data(),
                     offsets32.size() * sizeof(int32_t),
                     cudaMemcpyHostToDevice,
-                    stream.value());
-    stream.synchronize();  // offsets32 goes out of scope here
+                    stream.get());
+    stream.sync();  // offsets32 goes out of scope here
   }
 
   rmm::device_buffer mask_buf{};
@@ -116,7 +117,7 @@ std::unique_ptr<cudf::column> make_strings(std::vector<std::string> const& rows,
 
   auto col = cudf::make_strings_column(
     n, std::move(offsets_col), std::move(chars_buf), null_count, std::move(mask_buf));
-  stream.synchronize();  // host vectors go out of scope
+  stream.sync();  // host vectors go out of scope
   return col;
 }
 
@@ -146,9 +147,9 @@ std::vector<bool> to_host_validity(cudf::column_view const& col)
 /// (values on valid rows, validity everywhere) for both LIKE and NOT LIKE.
 void require_matches_cudf(cudf::column_view const& view, std::string const& pattern)
 {
-  auto stream = cudf::get_default_stream();
-  auto mr     = cudf::get_current_device_resource_ref();
-  auto scv    = cudf::strings_column_view(view);
+  cuda::stream_ref const stream = cudf::get_default_stream();
+  auto mr                       = cudf::get_current_device_resource_ref();
+  auto scv                      = cudf::strings_column_view(view);
 
   auto const parsed = classify_like_multiliteral(pattern, {});
   REQUIRE(parsed.has_value());
@@ -470,15 +471,15 @@ TEST_CASE("like_multiliteral handles column-layout edges",
                     chars.data(),
                     chars.size(),
                     cudaMemcpyHostToDevice,
-                    stream.value());
+                    stream.get());
     auto offsets_col = cudf::make_numeric_column(
       cudf::data_type{cudf::type_id::INT32}, n + 1, cudf::mask_state::UNALLOCATED, stream, mr);
     cudaMemcpyAsync(offsets_col->mutable_view().data<int32_t>(),
                     offsets.data(),
                     offsets.size() * sizeof(int32_t),
                     cudaMemcpyHostToDevice,
-                    stream.value());
-    stream.synchronize();
+                    stream.get());
+    stream.sync();
 
     cudf::column_view const strings_view(cudf::data_type{cudf::type_id::STRING},
                                          n,

--- a/test/cpp/expression_evaluator/test_like_multiliteral.cpp
+++ b/test/cpp/expression_evaluator/test_like_multiliteral.cpp
@@ -417,8 +417,8 @@ TEST_CASE("like_multiliteral matches cudf on seeded random near-miss data",
 TEST_CASE("like_multiliteral handles column-layout edges",
           "[expression_evaluator][like_multiliteral]")
 {
-  auto stream = cudf::get_default_stream();
-  auto mr     = cudf::get_current_device_resource_ref();
+  cuda::stream_ref const stream = cudf::get_default_stream();
+  auto mr                       = cudf::get_current_device_resource_ref();
 
   SECTION("INT64 offsets (large-strings layout) execute the int64 kernel instantiation")
   {

--- a/test/cpp/helper/test_numeric_narrowing.cpp
+++ b/test/cpp/helper/test_numeric_narrowing.cpp
@@ -27,6 +27,7 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cstdint>
@@ -94,7 +95,8 @@ template <typename T>
 std::vector<T> copy_values_to_host(cudf::column_view const& column)
 {
   std::vector<T> values(static_cast<std::size_t>(column.size()));
-  cudf::get_default_stream().synchronize();
+  cuda::stream_ref const stream = cudf::get_default_stream();
+  stream.sync();
   if (!values.empty() && cudaMemcpy(values.data(),
                                     column.data<T>(),
                                     values.size() * sizeof(T),
@@ -111,7 +113,8 @@ std::vector<bool> copy_valids_to_host(cudf::column_view const& column)
 
   auto const words = cudf::num_bitmask_words(column.offset() + column.size());
   std::vector<cudf::bitmask_type> mask(static_cast<std::size_t>(words));
-  cudf::get_default_stream().synchronize();
+  cuda::stream_ref const stream = cudf::get_default_stream();
+  stream.sync();
   if (cudaMemcpy(mask.data(),
                  column.null_mask(),
                  mask.size() * sizeof(cudf::bitmask_type),

--- a/test/cpp/operator/test_physical_dense_count_join.cpp
+++ b/test/cpp/operator/test_physical_dense_count_join.cpp
@@ -19,6 +19,8 @@
 
 #include <rmm/cuda_stream.hpp>
 
+#include <cuda/stream>
+
 #include <catch.hpp>
 #include <op/aggregate/dense_count_join_impl.hpp>
 #include <op/sirius_physical_dense_count_join.hpp>
@@ -626,7 +628,8 @@ TEST_CASE("dense_count_join: retained multi-batch extrema merge on a non-default
 
   // The direct operator-test path does not run task input preparation, so order batch creation
   // before deliberately executing the operator on another stream.
-  cudf::get_default_stream().synchronize();
+  cuda::stream_ref const default_stream = cudf::get_default_stream();
+  default_stream.sync();
   rmm::cuda_stream stream;
   auto rows = run_dense_count_join<int32_t>(*space,
                                             duckdb::LogicalTypeId::INTEGER,

--- a/test/cpp/operator/test_physical_projection.cpp
+++ b/test/cpp/operator/test_physical_projection.cpp
@@ -18,6 +18,8 @@
 #include "operator_test_utils.hpp"
 #include "operator_type_traits.hpp"
 
+#include <cuda/stream>
+
 #include <catch.hpp>
 #include <duckdb/common/types/value.hpp>
 #include <duckdb/planner/expression/bound_constant_expression.hpp>
@@ -252,7 +254,8 @@ TEST_CASE("sirius_physical_projection mixes evaluated and passthrough columns (p
   // alive even after the input variable disappears.
   inputs.clear();
   input_batch.reset();
-  REQUIRE(cudaStreamSynchronize(cudf::get_default_stream().value()) == cudaSuccess);
+  cuda::stream_ref const stream = cudf::get_default_stream();
+  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
 
   auto out_view = sirius::get_cudf_table_view(*out_batch);
   REQUIRE(out_view.num_columns() == 3);
@@ -300,7 +303,8 @@ TEST_CASE("sirius_physical_projection passthrough output outlives input batch ha
   // output owner's read-only lock keeps the data alive.
   inputs.clear();
   input_batch.reset();
-  REQUIRE(cudaStreamSynchronize(cudf::get_default_stream().value()) == cudaSuccess);
+  cuda::stream_ref const stream = cudf::get_default_stream();
+  REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
 
   auto out_view = sirius::get_cudf_table_view(*out_batch);
   REQUIRE(out_view.num_columns() == 2);

--- a/test/cpp/operator/test_physical_projection.cpp
+++ b/test/cpp/operator/test_physical_projection.cpp
@@ -254,7 +254,7 @@ TEST_CASE("sirius_physical_projection mixes evaluated and passthrough columns (p
   // alive even after the input variable disappears.
   inputs.clear();
   input_batch.reset();
-  cuda::stream_ref const stream = cudf::get_default_stream();
+  ::cuda::stream_ref const stream = cudf::get_default_stream();
   REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
 
   auto out_view = sirius::get_cudf_table_view(*out_batch);
@@ -303,7 +303,7 @@ TEST_CASE("sirius_physical_projection passthrough output outlives input batch ha
   // output owner's read-only lock keeps the data alive.
   inputs.clear();
   input_batch.reset();
-  cuda::stream_ref const stream = cudf::get_default_stream();
+  ::cuda::stream_ref const stream = cudf::get_default_stream();
   REQUIRE(cudaStreamSynchronize(stream.get()) == cudaSuccess);
 
   auto out_view = sirius::get_cudf_table_view(*out_batch);

--- a/test/cpp/operator/test_sirius_dynamic_filter_mgpu.cpp
+++ b/test/cpp/operator/test_sirius_dynamic_filter_mgpu.cpp
@@ -34,6 +34,7 @@
 
 #include <rmm/aligned.hpp>
 #include <rmm/cuda_device.hpp>
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 
 #include <cuda_runtime.h>
@@ -189,7 +190,7 @@ TEST_CASE("IN-list replica built on GPU 0 computes an exact mask on GPU 1",
     // explicit replication, a GPU 1 caller skips the optional filter and never touches GPU 0's set.
     {
       rmm::cuda_set_device_raii const probe_device{rmm::cuda_device_id{kProbeDevice}};
-      auto const probe_stream = cudf::get_default_stream();
+      rmm::cuda_stream_view const probe_stream = cudf::get_default_stream();
       auto early_probe =
         make_values<std::int64_t>({2, 7}, cudf::data_type{cudf::type_id::INT64}, probe_stream);
       auto early_mask = filter->compute_mask(
@@ -206,7 +207,7 @@ TEST_CASE("IN-list replica built on GPU 0 computes an exact mask on GPU 1",
 
   {
     rmm::cuda_set_device_raii const probe_device{rmm::cuda_device_id{kProbeDevice}};
-    auto const stream = cudf::get_default_stream();
+    rmm::cuda_stream_view const stream = cudf::get_default_stream();
     auto probe =
       make_values<std::int64_t>({1, 2, 3, 4, 6, 9}, cudf::data_type{cudf::type_id::INT64}, stream);
     auto mask = filter->compute_mask(
@@ -434,7 +435,7 @@ TEST_CASE("Bloom replica built on GPU 0 has no false negatives on GPU 1",
 
   {
     rmm::cuda_set_device_raii const probe_device{rmm::cuda_device_id{kProbeDevice}};
-    auto const stream = cudf::get_default_stream();
+    rmm::cuda_stream_view const stream = cudf::get_default_stream();
     // Positions 0, 2, and 4 are build keys. Misses may be Bloom false positives, so only the
     // no-false-negative contract is asserted for them.
     auto probe = make_values<std::int64_t>(
@@ -482,8 +483,8 @@ TEST_CASE("zone-map replica built on GPU 0 lowers and evaluates its AST on GPU 1
 
   {
     rmm::cuda_set_device_raii const probe_device{rmm::cuda_device_id{kProbeDevice}};
-    auto const stream = cudf::get_default_stream();
-    auto probe        = cudf::sequence(10,
+    rmm::cuda_stream_view const stream = cudf::get_default_stream();
+    auto probe                         = cudf::sequence(10,
                                 cudf::numeric_scalar<std::int64_t>(0, true, stream),
                                 cudf::numeric_scalar<std::int64_t>(1, true, stream),
                                 stream,
@@ -537,7 +538,7 @@ TEST_CASE("small IN-list replica built on GPU 0 computes an exact mask on GPU 1"
     // published; it must never dereference the source GPU's buffer.
     {
       rmm::cuda_set_device_raii const probe_device{rmm::cuda_device_id{kProbeDevice}};
-      auto const probe_stream = cudf::get_default_stream();
+      rmm::cuda_stream_view const probe_stream = cudf::get_default_stream();
       auto early_probe =
         make_values<std::int64_t>({2, 7}, cudf::data_type{cudf::type_id::INT64}, probe_stream);
       auto early_mask = filter->compute_mask(
@@ -554,7 +555,7 @@ TEST_CASE("small IN-list replica built on GPU 0 computes an exact mask on GPU 1"
 
   {
     rmm::cuda_set_device_raii const probe_device{rmm::cuda_device_id{kProbeDevice}};
-    auto const stream = cudf::get_default_stream();
+    rmm::cuda_stream_view const stream = cudf::get_default_stream();
     auto probe =
       make_values<std::int64_t>({1, 2, 3, 4, 6, 9}, cudf::data_type{cudf::type_id::INT64}, stream);
     auto mask = filter->compute_mask(

--- a/test/cpp/scan/test_dynamic_filter_merge.cpp
+++ b/test/cpp/scan/test_dynamic_filter_merge.cpp
@@ -36,6 +36,8 @@
 #include <cudf/utilities/default_stream.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
+#include <rmm/cuda_stream_view.hpp>
+
 #include <cuda_runtime.h>
 
 #include <catch.hpp>
@@ -324,8 +326,8 @@ std::shared_ptr<sirius_dynamic_zone_map_filter> make_zone_map_from_reduce(
 TEST_CASE("apply_dynamic_filters_to_view drops rows outside the zone",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
-  auto table  = make_sequence_table(10, stream);  // [0..9]
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto table                   = make_sequence_table(10, stream);  // [0..9]
 
   sirius_dynamic_filter_set filters;
   filters.push_filter(0, make_zone_map(3, 6));  // inclusive [3,6] keeps 3,4,5,6
@@ -343,8 +345,8 @@ TEST_CASE("apply_dynamic_filters_to_view drops rows outside the zone",
 TEST_CASE("apply_dynamic_filters_to_view honors an exclusive upper bound [lo, hi)",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
-  auto table  = make_sequence_table(10, stream);  // [0..9]
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto table                   = make_sequence_table(10, stream);  // [0..9]
 
   sirius_dynamic_filter_set filters;
   // [3,6): inclusive_min, exclusive_max -> GREATER_EQUAL(3) AND LESS(6) -> {3,4,5}
@@ -360,8 +362,8 @@ TEST_CASE("apply_dynamic_filters_to_view honors an exclusive upper bound [lo, hi
 TEST_CASE("apply_dynamic_filters_to_view honors an exclusive lower bound (lo, hi]",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
-  auto table  = make_sequence_table(10, stream);  // [0..9]
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto table                   = make_sequence_table(10, stream);  // [0..9]
 
   sirius_dynamic_filter_set filters;
   // (3,6]: exclusive_min, inclusive_max -> GREATER(3) AND LESS_EQUAL(6) -> {4,5,6}
@@ -377,7 +379,7 @@ TEST_CASE("apply_dynamic_filters_to_view honors an exclusive lower bound (lo, hi
 TEST_CASE("zone-map-only filter from a device reduce keeps a correct superset (no false negative)",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
 
   // Build keys spanning [100, 200] — the producer reduces these to min=100, max=200 and, with no
   // membership filter, publishes a zone-map alone. Probe [0..299]: only [100..200] can possibly
@@ -402,8 +404,8 @@ TEST_CASE("zone-map-only filter from a device reduce keeps a correct superset (n
 TEST_CASE("apply_dynamic_filters_to_view returns nullptr for an empty channel",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
-  auto table  = make_sequence_table(10, stream);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto table                   = make_sequence_table(10, stream);
 
   sirius_dynamic_filter_set filters;  // empty
 
@@ -432,8 +434,8 @@ TEST_CASE("sirius_dynamic_filter_set ignore_columns drops filters for ignored co
 TEST_CASE("apply_dynamic_filters_to_view AND-conjoins multiple zone filters on a column",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
-  auto table  = make_sequence_table(10, stream);  // [0..9]
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto table                   = make_sequence_table(10, stream);  // [0..9]
 
   sirius_dynamic_filter_set filters;
   filters.push_filter(0, make_zone_map(2, 8));  // keeps 2..8
@@ -499,7 +501,7 @@ std::vector<int64_t> to_host_int64(cudf::column_view const& col, rmm::cuda_strea
 TEST_CASE("sirius_dynamic_in_list_filter keeps exactly the rows whose key is a build key",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   // Build key set {0,1,2,3,4}; probe table [0..9]. Exact membership keeps the first five.
   auto keys = cudf::sequence(5,
                              cudf::numeric_scalar<int64_t>(0, true, stream),
@@ -521,12 +523,12 @@ TEST_CASE("sirius_dynamic_in_list_filter keeps exactly the rows whose key is a b
 TEST_CASE("sirius_dynamic_in_list_filter INT64 path uses a persistent set and probes repeatedly",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
-  auto keys   = cudf::sequence(5,
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto keys                    = cudf::sequence(5,
                              cudf::numeric_scalar<int64_t>(0, true, stream),
                              cudf::numeric_scalar<int64_t>(1, true, stream),
                              stream);
-  auto filter = std::make_shared<sirius::op::sirius_dynamic_in_list_filter>(
+  auto filter                  = std::make_shared<sirius::op::sirius_dynamic_in_list_filter>(
     keys->view(), stream, cudf::get_current_device_resource_ref());
   REQUIRE(filter->has_persistent_set());  // INT64, non-null keys → fast path
 
@@ -547,8 +549,8 @@ TEST_CASE("sirius_dynamic_in_list_filter INT64 path uses a persistent set and pr
 TEST_CASE("sirius_dynamic_bloom_filter never drops a true match (no false negatives)",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
-  auto keys   = cudf::sequence(5,
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto keys                    = cudf::sequence(5,
                              cudf::numeric_scalar<int64_t>(0, true, stream),
                              cudf::numeric_scalar<int64_t>(1, true, stream),
                              stream);
@@ -571,7 +573,7 @@ TEST_CASE("sirius_dynamic_bloom_filter never drops a true match (no false negati
 TEST_CASE("sirius_dynamic_in_list_filter supports INT32 keys exactly",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   // INT32 build key set {0,1,2,3,4}; INT32 probe [0..9]. Exact membership keeps exactly
   // {0,1,2,3,4}.
   auto keys   = cudf::sequence(5,
@@ -595,8 +597,8 @@ TEST_CASE("sirius_dynamic_in_list_filter supports INT32 keys exactly",
 TEST_CASE("sirius_dynamic_bloom_filter supports INT32 keys with no false negatives",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
-  auto keys   = cudf::sequence(5,
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto keys                    = cudf::sequence(5,
                              cudf::numeric_scalar<int32_t>(0, true, stream),
                              cudf::numeric_scalar<int32_t>(1, true, stream),
                              stream);
@@ -621,7 +623,7 @@ TEST_CASE("sirius_dynamic_bloom_filter supports INT32 keys with no false negativ
 TEST_CASE("sirius_dynamic_bloom_filter excludes null build slots from the key set",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
 
   // Build keys [0,1,2,3,4,999] with the 999 slot nulled: only {0..4} may enter the set.
   std::vector<int64_t> const key_values{0, 1, 2, 3, 4, 999};
@@ -676,8 +678,8 @@ TEST_CASE("sirius_dynamic_bloom_filter excludes null build slots from the key se
 TEST_CASE("sirius_dynamic_in_list_filter keeps a build key equal to the INT64 sentinel",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream      = cudf::get_default_stream();
-  auto const dtype = cudf::data_type{cudf::type_id::INT64};
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto const dtype             = cudf::data_type{cudf::type_id::INT64};
   // Build keys include INT64_MIN — the cuco empty-slot sentinel that static_set never inserts.
   auto keys =
     make_values_table<int64_t>({std::numeric_limits<int64_t>::min(), 0, 1, 2}, dtype, stream);
@@ -701,8 +703,8 @@ TEST_CASE("sirius_dynamic_in_list_filter keeps a build key equal to the INT64 se
 TEST_CASE("sirius_dynamic_in_list_filter keeps a build key equal to the INT32 sentinel",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream      = cudf::get_default_stream();
-  auto const dtype = cudf::data_type{cudf::type_id::INT32};
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto const dtype             = cudf::data_type{cudf::type_id::INT32};
   auto keys =
     make_values_table<int32_t>({std::numeric_limits<int32_t>::min(), 0, 1, 2}, dtype, stream);
   auto filter = std::make_shared<sirius::op::sirius_dynamic_in_list_filter>(
@@ -724,7 +726,7 @@ TEST_CASE("sirius_dynamic_in_list_filter keeps a build key equal to the INT32 se
 TEST_CASE("sirius_dynamic_small_in_list_filter keeps exactly the rows whose key is a build key",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   // Small build key set {0,1,2,3,4}; probe [0..9]. The brute-force scan keeps the first five.
   auto keys = cudf::sequence(5,
                              cudf::numeric_scalar<int64_t>(0, true, stream),
@@ -746,8 +748,8 @@ TEST_CASE("sirius_dynamic_small_in_list_filter keeps exactly the rows whose key 
 TEST_CASE("sirius_dynamic_small_in_list_filter supports INT32 keys exactly",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
-  auto keys   = cudf::sequence(5,
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto keys                    = cudf::sequence(5,
                              cudf::numeric_scalar<int32_t>(0, true, stream),
                              cudf::numeric_scalar<int32_t>(1, true, stream),
                              stream);
@@ -766,8 +768,8 @@ TEST_CASE("sirius_dynamic_small_in_list_filter supports INT32 keys exactly",
 TEST_CASE("sirius_dynamic_small_in_list_filter matches a key equal to INT32_MIN (cuco's sentinel)",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream      = cudf::get_default_stream();
-  auto const dtype = cudf::data_type{cudf::type_id::INT32};
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto const dtype             = cudf::data_type{cudf::type_id::INT32};
   // Single build key {INT32_MIN} — the value cuco::static_set reserves as its empty slot and never
   // stores. The brute-force scan has no reserved value, so INT32_MIN is a valid needle: this filter
   // prunes non-matches exactly, where sirius_dynamic_in_list_filter would (harmlessly) keep them.
@@ -793,9 +795,9 @@ TEST_CASE("sirius_dynamic_small_in_list_filter matches a key equal to INT32_MIN 
 TEST_CASE("sirius_dynamic_small_in_list_filter: kind, size, capabilities, and supports gate",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream   = cudf::get_default_stream();
-  auto const mr = cudf::get_current_device_resource_ref();
-  using F       = sirius::op::sirius_dynamic_small_in_list_filter;
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto const mr                = cudf::get_current_device_resource_ref();
+  using F                      = sirius::op::sirius_dynamic_small_in_list_filter;
 
   auto one_i32       = cudf::sequence(1,
                                 cudf::numeric_scalar<int32_t>(0, true, stream),
@@ -890,8 +892,8 @@ class counting_in_list_filter final : public sirius_dynamic_filter,
 TEST_CASE("apply_dynamic_filters_to_view returns nullptr when no filter contributes",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
-  auto table  = make_int64_sequence_table(10, stream);
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto table                   = make_int64_sequence_table(10, stream);
 
   sirius_dynamic_filter_set filters;  // empty
 
@@ -903,8 +905,8 @@ TEST_CASE("apply_dynamic_filters_to_view returns nullptr when no filter contribu
 TEST_CASE("apply_dynamic_filters_to_view gathers survivors without consuming the input",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
-  auto table  = make_int64_sequence_table(10, stream);  // [0..9]
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  auto table                   = make_int64_sequence_table(10, stream);  // [0..9]
 
   sirius_dynamic_filter_set filters;
   filters.push_filter(0, make_in_list_prefix(2, stream));  // keeps 0,1
@@ -932,7 +934,7 @@ TEST_CASE("dynamic_filter_gate is not applicable before any filter publishes",
 TEST_CASE("dynamic_filter_gate disables after an unselective first split",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   sirius::op::scan::dynamic_filter_gate gate;
 
   sirius_dynamic_filter_set filters;
@@ -956,7 +958,7 @@ TEST_CASE("dynamic_filter_gate disables after an unselective first split",
 TEST_CASE("dynamic_filter_gate ignores a device with no local replica",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   sirius::op::scan::dynamic_filter_gate gate;
 
   sirius_dynamic_filter_set filters;
@@ -986,7 +988,7 @@ TEST_CASE("dynamic_filter_gate ignores a device with no local replica",
 TEST_CASE("dynamic_filter_gate re-arms when a filter publishes after the disable decision",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   sirius::op::scan::dynamic_filter_gate gate;
 
   // Unselective filter publishes first and disables the gate (the Q8 supplier hazard).
@@ -1014,7 +1016,7 @@ TEST_CASE("dynamic_filter_gate re-arms when a filter publishes after the disable
 TEST_CASE("dynamic_filter_gate stays active once a selective split proves the filter useful",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   sirius::op::scan::dynamic_filter_gate gate;
 
   sirius_dynamic_filter_set filters;
@@ -1097,7 +1099,7 @@ TEST_CASE("dynamic_filter_gate serializes concurrent stale and re-armed decision
 TEST_CASE("cascaded membership filters produce the conjunction of all filters",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
 
   sirius_dynamic_filter_set filters;
   filters.push_filter(0, make_in_list_prefix(7, stream));  // keeps 0..6
@@ -1113,7 +1115,7 @@ TEST_CASE("cascaded membership filters produce the conjunction of all filters",
 TEST_CASE("per-filter gate measures marginal keep and skips a useless filter on later splits",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   sirius::op::scan::dynamic_filter_gate gate;
 
   auto useless   = make_in_list_prefix(10, stream);  // covers the whole domain — keep 1.0
@@ -1149,7 +1151,7 @@ TEST_CASE("per-filter gate measures marginal keep and skips a useless filter on 
 TEST_CASE("per-filter gate keeps a dead verdict when the channel grows",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   sirius::op::scan::dynamic_filter_gate gate;
 
   auto useless = make_in_list_prefix(10, stream);  // covers the whole domain -- keep 1.0
@@ -1177,7 +1179,7 @@ TEST_CASE("per-filter gate keeps a dead verdict when the channel grows",
 TEST_CASE("per-filter gate excludes a dead filter from the re-armed apply without re-running it",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   sirius::op::scan::dynamic_filter_gate gate;
 
   // The only filter covers the whole domain: the first split disables the scan-level gate and
@@ -1220,7 +1222,7 @@ TEST_CASE("per-filter gate excludes a dead filter from the re-armed apply withou
 TEST_CASE("per-filter gate stales a selective verdict when the channel grows",
           "[dynamic_filter][scan_merge]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   sirius::op::scan::dynamic_filter_gate gate;
 
   auto selective = make_in_list_prefix(2, stream);  // keeps 20%

--- a/test/cpp/vss/test_brute_force_search.cpp
+++ b/test/cpp/vss/test_brute_force_search.cpp
@@ -31,6 +31,7 @@
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/device_resources.hpp>
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 
@@ -91,7 +92,7 @@ std::vector<T> to_host(cudf::column_view const& col)
 
 TEST_CASE("brute_force_knn returns the exact nearest rows in order", "[vss]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   raft::device_resources res{stream};
 
   // Dataset row i is [i, i, i]; query is the origin, so distances grow with i and
@@ -135,7 +136,7 @@ TEST_CASE("brute_force_knn returns the exact nearest rows in order", "[vss]")
 
 TEST_CASE("brute_force_knn cosine orders by angle, not magnitude", "[vss]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   raft::device_resources res{stream};
 
   constexpr cudf::size_type dim = 2;
@@ -174,7 +175,7 @@ TEST_CASE("brute_force_knn cosine orders by angle, not magnitude", "[vss]")
 
 TEST_CASE("brute_force_knn rejects out-of-range k and mismatched dims", "[vss]")
 {
-  auto stream = cudf::get_default_stream();
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
   raft::device_resources res{stream};
 
   constexpr cudf::size_type n_rows = 4;


### PR DESCRIPTION
Update default-stream handling for compatibility with stable cuDF 26.06 and nightly cuDF 26.10.

Nightly now returns `cuda::stream_ref` from `cudf::get_default_stream()`, which uses `.get()`/`.sync()` instead of RMM’s `.value()`/`.synchronize()`.

Fixes the errors seen in [this failing nightly job](https://github.com/sirius-db/sirius/actions/runs/33692545416/job/100454276952).