### PR TITLE
fix(cuda): replace deprecated stream header

### DIFF
--- a/src/cuda/sirius_dynamic_bloom_filter.cu
+++ b/src/cuda/sirius_dynamic_bloom_filter.cu
@@ -29,7 +29,7 @@
 #include <cuda/std/bit>
 #include <cuda/std/cstddef>
 #include <cuda/std/limits>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cucascade/memory/memory_space.hpp>
 #include <log/logging.hpp>

--- a/src/cuda/sirius_dynamic_in_list_filter.cu
+++ b/src/cuda/sirius_dynamic_in_list_filter.cu
@@ -34,7 +34,7 @@
 #include <cuda/sirius_rmm_cuco_allocator.cuh>
 #include <cuda/std/functional>
 #include <cuda/std/limits>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 // cucascade
 #include <cucascade/memory/memory_space.hpp>

--- a/src/include/cuda/sirius_rmm_cuco_allocator.cuh
+++ b/src/include/cuda/sirius_rmm_cuco_allocator.cuh
@@ -20,7 +20,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 

--- a/src/include/io/sirius_datasource.hpp
+++ b/src/include/io/sirius_datasource.hpp
@@ -25,7 +25,7 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <span>
 

--- a/src/include/memory/numa_small_pinned_mr.hpp
+++ b/src/include/memory/numa_small_pinned_mr.hpp
@@ -19,7 +19,7 @@
 #include "memory/topology_index.hpp"
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <cucascade/memory/small_pinned_host_memory_resource.hpp>


### PR DESCRIPTION
Replace deprecated `<cuda/stream_ref>` with `<cuda/stream>` to fix some include warnings.