### PR TITLE
fix(compression): bring in Felipe's fixes and improvements to compression exploration

### DIFF
--- a/src/compression/simpatico_codegen/cli/simpatico_main.cpp
+++ b/src/compression/simpatico_codegen/cli/simpatico_main.cpp
@@ -851,6 +851,17 @@ void usage_explore()
     "  --weight-comp W           Compress-throughput exponent (default: 1.0)\n"
     "  --weight-decomp W         Decompress-throughput exponent (default: 1.0)\n"
     "  --rerank-top N            Number of finalists to time, selected by ratio (default: 8)\n"
+    "  --rerank-warmup N         Untimed warmup round-trips per finalist; warmup #1\n"
+    "                            absorbs the NVRTC cold compile (default: 2, min 2)\n"
+    "  --rerank-iters N          Timed iterations per finalist; the reported rate is\n"
+    "                            the median (default: 5, min 5)\n"
+    "  --decomp-floor GBPS       Pareto pick: max ratio among frontier points with\n"
+    "                            decompress >= GBPS; if none qualify, the fastest\n"
+    "                            point wins. 0 = legacy max-ratio pick (default: 0)\n"
+    "  --frontier-out PATH       Append every measured Pareto-frontier point (TSV:\n"
+    "                            column, dtype, picked, ratio, comp/decomp GB/s,\n"
+    "                            old-wall GB/s, bytes, plan) for floor re-picks\n"
+    "                            without re-measuring\n"
     "  --simplicity-slots N      Top-N completed plans per cascade-depth level\n"
     "                            injected into the rerank pool, giving lighter-weight\n"
     "                            plans a fair shot against deep cascades (default: 4)\n"
@@ -869,8 +880,29 @@ struct explore_cfg {
   std::optional<input_format> format;
   std::optional<std::string> dtype;
   int col = -1;  // -1 = all
+  std::string frontier_out;
   simpatico::exploration_config ecfg;
 };
+
+/// One frontier TSV row; the plan DSL's lines are joined with "; " (';' can't
+/// appear in the DSL grammar, so this is lossless).
+void write_frontier_row(std::ostream& os,
+                        std::string const& col_name,
+                        std::string const& dtype,
+                        bool picked,
+                        simpatico::pareto_point const& p)
+{
+  std::string flat = p.plan_dsl;
+  std::size_t pos  = 0;
+  while ((pos = flat.find('\n', pos)) != std::string::npos) {
+    flat.replace(pos, 1, "; ");
+    pos += 2;
+  }
+  os << col_name << '\t' << dtype << '\t' << (picked ? 1 : 0) << '\t' << std::fixed
+     << std::setprecision(4) << p.compression_ratio << '\t' << std::setprecision(2)
+     << p.compress_gbps << '\t' << p.decompress_gbps << '\t' << p.old_wall_compress_gbps << '\t'
+     << p.old_wall_decompress_gbps << '\t' << p.compressed_size_bytes << '\t' << flat << '\n';
+}
 
 int run_explore(int argc, char** argv)
 {
@@ -909,6 +941,16 @@ int run_explore(int argc, char** argv)
       cfg.ecfg.rerank_weights[2] = std::stod(need("--weight-decomp"));
     } else if (arg == "--rerank-top") {
       cfg.ecfg.rerank_top = static_cast<std::size_t>(std::stoul(need("--rerank-top")));
+    } else if (arg == "--rerank-warmup") {
+      cfg.ecfg.rerank_warmup =
+        std::max<std::size_t>(2, static_cast<std::size_t>(std::stoul(need("--rerank-warmup"))));
+    } else if (arg == "--rerank-iters") {
+      cfg.ecfg.rerank_iters =
+        std::max<std::size_t>(5, static_cast<std::size_t>(std::stoul(need("--rerank-iters"))));
+    } else if (arg == "--decomp-floor") {
+      cfg.ecfg.pareto_decomp_floor_gbps = std::stod(need("--decomp-floor"));
+    } else if (arg == "--frontier-out") {
+      cfg.frontier_out = need("--frontier-out");
     } else if (arg == "--simplicity-slots") {
       cfg.ecfg.simplicity_slots = static_cast<std::size_t>(std::stoul(need("--simplicity-slots")));
     } else if (arg == "--sample-rows") {
@@ -947,6 +989,20 @@ int run_explore(int argc, char** argv)
   // Keep the table_view alive for the entire loop — column() may return a
   // const-ref into it and the temporary would be destroyed otherwise.
   auto const tv = loaded.table->view();
+
+  // Appends across invocations so one file can accumulate a whole table.
+  std::ofstream frontier_os;
+  if (!cfg.frontier_out.empty()) {
+    bool const fresh = [&] {
+      std::ifstream probe(cfg.frontier_out);
+      return !probe.good() || probe.peek() == std::ifstream::traits_type::eof();
+    }();
+    frontier_os.open(cfg.frontier_out, std::ios::app);
+    if (!frontier_os) die("explore: cannot write --frontier-out: " + cfg.frontier_out);
+    if (fresh)
+      frontier_os << "column\tdtype\tpicked\tratio\tcomp_gbps\tdecomp_gbps\t"
+                     "old_wall_comp_gbps\told_wall_decomp_gbps\tcompressed_bytes\tplan\n";
+  }
 
   // Multi-column output: emit one block per column separated by ---
   bool first = true;
@@ -996,7 +1052,18 @@ int run_explore(int argc, char** argv)
       std::printf("# comp: %.2f GB/s  decomp: %.2f GB/s\n",
                   result.compress_throughput_gbps,
                   result.decompress_throughput_gbps);
+    if (result.old_wall_compress_gbps > 0.0 || result.old_wall_decompress_gbps > 0.0)
+      std::printf("# old_wall_comp: %.2f GB/s  old_wall_decomp: %.2f GB/s\n",
+                  result.old_wall_compress_gbps,
+                  result.old_wall_decompress_gbps);
     std::printf("%s\n", result.plan_dsl.c_str());
+
+    if (frontier_os.is_open()) {
+      for (auto const& p : result.pareto_frontier)
+        write_frontier_row(
+          frontier_os, col_name, dtype_name(col_view.type()), p.plan_dsl == result.plan_dsl, p);
+      frontier_os.flush();
+    }
 
     if (!result.pareto_alternates_summary.empty())
       std::fprintf(stderr, "%s\n", result.pareto_alternates_summary.c_str());

--- a/src/compression/simpatico_codegen/include/explore/compression_explorer.hpp
+++ b/src/compression/simpatico_codegen/include/explore/compression_explorer.hpp
@@ -57,11 +57,36 @@ struct exploration_config {
   /// bigger than this is trimmed to a representative row-prefix so no codec
   /// allocates buffers larger than device memory. Default 2 GiB; 0 = unlimited.
   size_t max_explore_bytes = 2ull << 30;
+
+  /// Untimed warmup round-trips per finalist; warmup #1 absorbs the plan's
+  /// NVRTC cold compile so it never pollutes the reported rates. Min 2.
+  size_t rerank_warmup = 2;
+
+  /// Timed, event-bracketed round trips per finalist; the reported throughput
+  /// is the median of these.
+  size_t rerank_iters = 5;
+
+  /// Pareto pick: when > 0, max ratio among frontier points with measured
+  /// decompress throughput >= this floor (GB/s), else fastest-decompress
+  /// wins. 0 = legacy max-ratio pick.
+  double pareto_decomp_floor_gbps = 0.0;
 };
 
 // ---------------------------------------------------------------------------
 // Result
 // ---------------------------------------------------------------------------
+
+/// One measured point of the Pareto frontier. `old_wall_*` re-expresses the
+/// pre-fix one-shot metric, kept for comparison against older plan files.
+struct pareto_point {
+  std::string plan_dsl;
+  double compression_ratio        = 1.0;
+  size_t compressed_size_bytes    = 0;
+  double compress_gbps            = 0.0;
+  double decompress_gbps          = 0.0;
+  double old_wall_compress_gbps   = 0.0;
+  double old_wall_decompress_gbps = 0.0;
+};
 
 struct exploration_result {
   std::string plan_dsl;
@@ -71,7 +96,12 @@ struct exploration_result {
   size_t cascade_depth              = 0;
   double compress_throughput_gbps   = 0.0;
   double decompress_throughput_gbps = 0.0;
+  double old_wall_compress_gbps     = 0.0;  ///< pre-fix one-shot rate, for continuity
+  double old_wall_decompress_gbps   = 0.0;
   std::string pareto_alternates_summary;
+  /// Full measured frontier (Pareto mode only); lets a caller re-pick under a
+  /// different decompress floor without re-measuring.
+  std::vector<pareto_point> pareto_frontier;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
+++ b/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
@@ -118,14 +118,6 @@ struct bfs_candidate {
   std::unordered_map<std::string, size_t> path_size;
 };
 
-struct ranked_candidate {
-  std::string plan_dsl;
-  double compression_ratio;
-  size_t compressed_size_bytes;
-  double compress_throughput_gbps;
-  double decompress_throughput_gbps;
-};
-
 // ---------------------------------------------------------------------------
 // Round-trip timing for the rerank pass
 // ---------------------------------------------------------------------------
@@ -177,6 +169,10 @@ bool measure_compressed_bytes(cudf::column_view input,
   return true;
 }
 
+// One event-bracketed compress + decompress. Cold on a JIT-cache miss (the
+// NVRTC compile lands inside the bracket), so not a throughput measure on its
+// own — round_trip_time_stats below uses it for warmup and the old_wall
+// continuity rates.
 bool round_trip_time_rr(cudf::column_view input,
                         std::string_view plan_dsl,
                         rmm::cuda_stream_view stream,
@@ -203,6 +199,90 @@ bool round_trip_time_rr(cudf::column_view input,
     if (err_out) *err_out = "decompress_column: " + err;
     return false;
   }
+  return true;
+}
+
+double median_of(std::vector<double> v)
+{
+  if (v.empty()) return 0.0;
+  std::sort(v.begin(), v.end());
+  size_t const n = v.size();
+  return (n % 2 == 1) ? v[n / 2] : 0.5 * (v[n / 2 - 1] + v[n / 2]);
+}
+
+struct rt_stats {
+  double comp_ms_median   = 0.0;  // warmed, event-bracketed, median of `iters`
+  double decomp_ms_median = 0.0;
+  double comp_ms_first    = 0.0;  // legacy one-shot (cold; includes NVRTC compile
+  double decomp_ms_first  = 0.0;  // on cache miss) — old_wall continuity metric
+  size_t compressed_bytes = 0;
+};
+
+// Fixes the two flaws the GB300 decoder audit found in the one-shot rerank
+// metric: an NVRTC cold compile landing inside the timing bracket, and
+// one-shot wall clock carrying ~2x launch/first-touch overhead on fast
+// kernels. `warmup` round trips (via round_trip_time_rr) absorb both; pass 1's
+// timing survives as the old_wall continuity metric. `iters` further timed
+// compress calls follow (median, keeping the last PlanTree), then `iters`
+// timed decompress calls of that same tree (median).
+bool round_trip_time_stats(cudf::column_view input,
+                           std::string_view plan_dsl,
+                           rmm::cuda_stream_view stream,
+                           rmm::device_async_resource_ref mr,
+                           size_t warmup,
+                           size_t iters,
+                           rt_stats& out,
+                           std::string* err_out)
+{
+  warmup = std::max<size_t>(warmup, 1);
+  iters  = std::max<size_t>(iters, 1);
+
+  std::string err;
+  for (size_t w = 0; w < warmup; ++w) {
+    double comp_ms = 0, decomp_ms = 0;
+    if (!round_trip_time_rr(
+          input, plan_dsl, stream, mr, comp_ms, decomp_ms, out.compressed_bytes, err_out))
+      return false;
+    if (w == 0) {
+      out.comp_ms_first   = comp_ms;
+      out.decomp_ms_first = decomp_ms;
+    }
+  }
+
+  std::unique_ptr<PlanTree> plan_tree;
+
+  // Timed compress iterations. Reassigning plan_tree frees the previous one.
+  std::vector<double> comp_ms;
+  comp_ms.reserve(iters);
+  for (size_t i = 0; i < iters; ++i) {
+    cudaStreamSynchronize(stream.value());  // drain, so the bracket sees only this call
+    double ms = time_cuda_ms(
+      stream.value(), [&] { plan_tree = compress_column(input, plan_dsl, stream, mr, &err); });
+    if (!plan_tree) {
+      if (err_out) *err_out = "compress_column: " + err;
+      return false;
+    }
+    comp_ms.push_back(ms);
+  }
+  out.compressed_bytes = plan_tree_compressed_bytes(*plan_tree, stream);
+
+  // Timed decompress iterations over the final tree.
+  std::vector<double> decomp_ms;
+  decomp_ms.reserve(iters);
+  for (size_t i = 0; i < iters; ++i) {
+    cudaStreamSynchronize(stream.value());
+    std::unique_ptr<cudf::column> decompressed;
+    double ms = time_cuda_ms(
+      stream.value(), [&] { decompressed = decompress_column(*plan_tree, stream, mr, &err); });
+    if (!decompressed) {
+      if (err_out) *err_out = "decompress_column: " + err;
+      return false;
+    }
+    decomp_ms.push_back(ms);
+  }
+
+  out.comp_ms_median   = median_of(std::move(comp_ms));
+  out.decomp_ms_median = median_of(std::move(decomp_ms));
   return true;
 }
 
@@ -681,9 +761,11 @@ exploration_result explore_column_compression(cudf::column_view input,
     std::string plan_dsl;
     double compression_ratio;
     size_t compressed_size_bytes;
-    double compress_throughput_gbps;
-    double decompress_throughput_gbps;
-    double decode_cost = 0.0;  // proxy for pareto_beam finalist selection
+    double compress_throughput_gbps;        // warmed median-of-N
+    double decompress_throughput_gbps;      // warmed median-of-N
+    double decode_cost              = 0.0;  // proxy for pareto_beam finalist selection
+    double old_wall_compress_gbps   = 0.0;  // legacy one-shot rates (continuity)
+    double old_wall_decompress_gbps = 0.0;
   };
   std::vector<ranked_candidate> finalists;
   auto add_finalist = [&](std::string dsl, double ratio, size_t bytes, double dc) {
@@ -803,6 +885,8 @@ exploration_result explore_column_compression(cudf::column_view input,
     cudaDeviceSynchronize();
     if (!sized.empty()) finalists = std::move(sized);
   } else if (!finalists.empty()) {
+    // Grow nvcomp/RMM scratch to its high-water mark once so the first
+    // finalist's own measurement isn't uniquely penalized.
     {
       double a, b;
       size_t c2;
@@ -810,46 +894,24 @@ exploration_result explore_column_compression(cudf::column_view input,
       cudaDeviceSynchronize();
     }
 
-    static constexpr size_t kPasses = 3;
-    struct acc_t {
-      std::string plan_dsl;
-      double best_comp_ms   = std::numeric_limits<double>::infinity();
-      double best_decomp_ms = std::numeric_limits<double>::infinity();
-      size_t bytes          = 0;
-      bool any_ok           = false;
-    };
-    std::vector<acc_t> accs;
-    for (auto const& f : finalists)
-      accs.push_back({f.plan_dsl,
-                      std::numeric_limits<double>::infinity(),
-                      std::numeric_limits<double>::infinity(),
-                      f.compressed_size_bytes,
-                      false});
-
-    for (size_t pass = 0; pass < kPasses; ++pass) {
-      for (size_t i = 0; i < finalists.size(); ++i) {
-        double comp_ms = 0, decomp_ms = 0;
-        size_t bytes = accs[i].bytes;
-        std::string err;
-        bool ok = round_trip_time_rr(
-          measure_col, finalists[i].plan_dsl, stream, mr, comp_ms, decomp_ms, bytes, &err);
-        cudaDeviceSynchronize();
-        if (!ok) continue;
-        accs[i].any_ok = true;
-        accs[i].bytes  = bytes;
-        if (comp_ms < accs[i].best_comp_ms) accs[i].best_comp_ms = comp_ms;
-        if (decomp_ms < accs[i].best_decomp_ms) accs[i].best_decomp_ms = decomp_ms;
-      }
-    }
     double const orig = (double)measure_size;
+    auto to_gbps      = [orig](double ms) { return ms > 0 ? orig / ms / 1.0e6 : 0.0; };
     std::vector<ranked_candidate> timed;
-    for (auto const& a : accs) {
-      if (!a.any_ok) continue;
-      timed.push_back({a.plan_dsl,
-                       orig / std::max<size_t>(a.bytes, 1),
-                       a.bytes,
-                       a.best_comp_ms > 0 ? orig / a.best_comp_ms / 1.0e6 : 0.0,
-                       a.best_decomp_ms > 0 ? orig / a.best_decomp_ms / 1.0e6 : 0.0});
+    for (auto const& f : finalists) {
+      rt_stats st;
+      std::string err;
+      bool ok = round_trip_time_stats(
+        measure_col, f.plan_dsl, stream, mr, config.rerank_warmup, config.rerank_iters, st, &err);
+      cudaDeviceSynchronize();
+      if (!ok) continue;
+      timed.push_back({f.plan_dsl,
+                       orig / std::max<size_t>(st.compressed_bytes, 1),
+                       st.compressed_bytes,
+                       to_gbps(st.comp_ms_median),
+                       to_gbps(st.decomp_ms_median),
+                       0.0,
+                       to_gbps(st.comp_ms_first),
+                       to_gbps(st.decomp_ms_first)});
     }
     if (!timed.empty()) finalists = std::move(timed);
   }
@@ -866,15 +928,20 @@ exploration_result explore_column_compression(cudf::column_view input,
     auto measure_dsl = [&](std::string const& dsl, ranked_candidate& out) -> bool {
       size_t bytes      = 0;
       double const orig = (double)measure_size;
+      auto to_gbps      = [orig](double ms) { return ms > 0 ? orig / ms / 1.0e6 : 0.0; };
       if (need_throughput) {
-        double cms = 0, dms = 0;
-        if (!round_trip_time_rr(measure_col, dsl, stream, mr, cms, dms, bytes, nullptr))
+        rt_stats st;
+        if (!round_trip_time_stats(
+              measure_col, dsl, stream, mr, config.rerank_warmup, config.rerank_iters, st, nullptr))
           return false;
         out = {dsl,
-               orig / std::max<size_t>(bytes, 1),
-               bytes,
-               cms > 0 ? orig / cms / 1.0e6 : 0.0,
-               dms > 0 ? orig / dms / 1.0e6 : 0.0};
+               orig / std::max<size_t>(st.compressed_bytes, 1),
+               st.compressed_bytes,
+               to_gbps(st.comp_ms_median),
+               to_gbps(st.decomp_ms_median),
+               0.0,
+               to_gbps(st.comp_ms_first),
+               to_gbps(st.decomp_ms_first)};
       } else {
         if (!measure_compressed_bytes(measure_col, dsl, stream, mr, bytes, nullptr)) return false;
         out = {dsl, orig / std::max<size_t>(bytes, 1), bytes, 0.0, 0.0};
@@ -1043,16 +1110,45 @@ exploration_result explore_column_compression(cudf::column_view input,
       pool.begin(), pool.end(), [&](ranked_candidate const& a, ranked_candidate const& b) {
         return pick_score(a) < pick_score(b);
       });
+    // Pareto pick with a decompress floor: max ratio among frontier points at
+    // or above the floor; if nothing clears it, the fastest-decompress point.
+    if (use_pareto && need_throughput && config.pareto_decomp_floor_gbps > 0.0) {
+      auto floor_it = pool.end();
+      for (auto it = pool.begin(); it != pool.end(); ++it) {
+        if (it->decompress_throughput_gbps < config.pareto_decomp_floor_gbps) continue;
+        if (floor_it == pool.end() || it->compression_ratio > floor_it->compression_ratio)
+          floor_it = it;
+      }
+      if (floor_it == pool.end()) {
+        floor_it = std::max_element(
+          pool.begin(), pool.end(), [](ranked_candidate const& a, ranked_candidate const& b) {
+            return a.decompress_throughput_gbps < b.decompress_throughput_gbps;
+          });
+      }
+      best_it = floor_it;
+    }
     result.plan_dsl                   = best_it->plan_dsl;
     result.compression_ratio          = best_it->compression_ratio;
     result.compressed_size_bytes      = best_it->compressed_size_bytes;
     result.compress_throughput_gbps   = best_it->compress_throughput_gbps;
     result.decompress_throughput_gbps = best_it->decompress_throughput_gbps;
+    result.old_wall_compress_gbps     = best_it->old_wall_compress_gbps;
+    result.old_wall_decompress_gbps   = best_it->old_wall_decompress_gbps;
     // Derive depth from the actual winning plan's line count, not from the
     // BFS ratio-tracking variable (which reflects when the beam last improved).
     result.cascade_depth =
       static_cast<size_t>(std::count(result.plan_dsl.begin(), result.plan_dsl.end(), '\n') + 1);
     if (use_pareto && need_throughput) {
+      result.pareto_frontier.reserve(frontier.size());
+      for (auto const& c2 : frontier) {
+        result.pareto_frontier.push_back({c2.plan_dsl,
+                                          c2.compression_ratio,
+                                          c2.compressed_size_bytes,
+                                          c2.compress_throughput_gbps,
+                                          c2.decompress_throughput_gbps,
+                                          c2.old_wall_compress_gbps,
+                                          c2.old_wall_decompress_gbps});
+      }
       std::ostringstream os;
       size_t alt_n = 0;
       for (auto const& c2 : frontier)


### PR DESCRIPTION
## Description
This PR brings in the changes from Felipe's late-mat branch #1391 to fix and improve simpatico's explore function.
It includes excluding JIT costs from the evaluation, and outputting all pareto-optimal points so we can change the throughput floor without re-measuring.

## Checklist
- [x] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [x] Cover changes with new or existing tests
- [x] Document configuration changes in code and summarize in the description above
- [x] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References