### PR TITLE
perf(compression): Add simpatico factor operator, improve ALP

### DIFF
--- a/src/compression/simpatico_codegen/include/codegen/jit/fused_tree.hpp
+++ b/src/compression/simpatico_codegen/include/codegen/jit/fused_tree.hpp
@@ -27,7 +27,7 @@
 
 namespace codegen {
 
-enum class OpKind : int { Bitpack, For, Delta, Rle, Raw, Zigzag, None };
+enum class OpKind : int { Bitpack, For, Delta, Rle, Raw, Zigzag, Factor, None };
 
 inline constexpr int kChunkSize = 1024;
 inline constexpr int kTBSize    = 128;
@@ -80,6 +80,7 @@ inline std::string op_kind_name(OpKind op)
     case OpKind::Rle: return "RLE";
     case OpKind::Raw: return "RAW";
     case OpKind::Zigzag: return "ZIGZAG";
+    case OpKind::Factor: return "FACTOR";
     case OpKind::None: return "NONE";
   }
   return "UNKNOWN";

--- a/src/compression/simpatico_codegen/include/codegen/jit/render_util.hpp
+++ b/src/compression/simpatico_codegen/include/codegen/jit/render_util.hpp
@@ -49,6 +49,7 @@ inline void append_op_segment(std::ostringstream& oss, const FusedTree& node)
     case OpKind::Raw: oss << "rw"; break;
     case OpKind::For: oss << "fr"; break;
     case OpKind::Zigzag: oss << "zz"; break;
+    case OpKind::Factor: oss << "fc"; break;
     default: oss << "un"; break;
   }
   for (const auto& [k, child] : node.children) {

--- a/src/compression/simpatico_codegen/include/codegen/plan/operator_registry.hpp
+++ b/src/compression/simpatico_codegen/include/codegen/plan/operator_registry.hpp
@@ -33,6 +33,7 @@ enum class OpId : std::uint8_t {
   Alp            = 13,
   AlpRd          = 14,
   Zigzag         = 15,
+  Factor         = 18,
   // Structural / pre-processing ops — not serialised as leaf tags.
   Bitextract = 16,
   StrSplit   = 17,

--- a/src/compression/simpatico_codegen/include/explore/compression_explorer.hpp
+++ b/src/compression/simpatico_codegen/include/explore/compression_explorer.hpp
@@ -99,12 +99,9 @@ size_t column_size_bytes_ex(cudf::column_view const& col, rmm::cuda_stream_view 
 struct operator_trial {
   bool success = false;
   std::string error_message;
-  /// The op applied cleanly but transformed nothing -- it is a bit-exact
-  /// identity on this data. Distinct from `!success`: the operator is valid
-  /// here and an explicit plan naming it still compresses correctly; it simply
-  /// has no value to a search. Only reported by operators that can tell (see
-  /// `try_operator`); false everywhere else, so it never suppresses a candidate
-  /// on a guess.
+  /// Applied cleanly but is a bit-exact identity on this data. Advisory, unlike
+  /// `!success`: only ops that can tell report it, and a plan naming one still
+  /// compresses correctly.
   bool no_benefit = false;
   std::vector<compressible_output> outputs;         ///< typed channels of the resulting rep
   std::size_t output_bytes = 0;                     ///< sum of logical channel byte sizes

--- a/src/compression/simpatico_codegen/include/explore/compression_explorer.hpp
+++ b/src/compression/simpatico_codegen/include/explore/compression_explorer.hpp
@@ -99,6 +99,13 @@ size_t column_size_bytes_ex(cudf::column_view const& col, rmm::cuda_stream_view 
 struct operator_trial {
   bool success = false;
   std::string error_message;
+  /// The op applied cleanly but transformed nothing -- it is a bit-exact
+  /// identity on this data. Distinct from `!success`: the operator is valid
+  /// here and an explicit plan naming it still compresses correctly; it simply
+  /// has no value to a search. Only reported by operators that can tell (see
+  /// `try_operator`); false everywhere else, so it never suppresses a candidate
+  /// on a guess.
+  bool no_benefit = false;
   std::vector<compressible_output> outputs;         ///< typed channels of the resulting rep
   std::size_t output_bytes = 0;                     ///< sum of logical channel byte sizes
   std::shared_ptr<compressed_representation> repr;  ///< keeps the outputs' views valid

--- a/src/compression/simpatico_codegen/plans/tpch_sf1000/lineitem.txt
+++ b/src/compression/simpatico_codegen/plans/tpch_sf1000/lineitem.txt
@@ -21,13 +21,8 @@ input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
 
 ---
 # column: l_quantity  dtype: t26  ratio: 10.383x  depth: 2
-# comp: 696.68 GB/s  decomp: 2938.41 GB/s  (GB300, sf1000 lineitem part.0)
-# Was `input -> bitpack`: 4.885x, comp 1366.78, decomp 2918.00 GB/s on the same
-# data. The mantissas are every multiple of 100 in [100, 5000] -- 50 distinct
-# values that bitpack alone spends 13 bits on -- so dividing the common factor
-# out first halves the bit width at no decode cost. Re-explore also offered a
-# depth-4 variant (two rle levels on chunk_bits) at 10.382x / decomp 2595 GB/s;
-# taken at the knee instead, since the extra depth buys -0.001x for -12% decode.
+# comp: 696.68 GB/s  decomp: 2938.41 GB/s
+# hand-picked knee: -0.001x ratio vs the depth-4 rule pick for +13% decode
 input -> factor -> quotients, divisors
 factor.quotients -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
 ---

--- a/src/compression/simpatico_codegen/plans/tpch_sf1000/lineitem.txt
+++ b/src/compression/simpatico_codegen/plans/tpch_sf1000/lineitem.txt
@@ -20,10 +20,16 @@ input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
 input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
 
 ---
-# column: l_quantity  dtype: t26  ratio: 4.885x  depth: 1
-# comp: 111.87 GB/s  decomp: 251.82 GB/s
-# GB300 (PR #1354, same plan): comp 836.89 GB/s  decomp 1692.77 GB/s
-input -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
+# column: l_quantity  dtype: t26  ratio: 10.383x  depth: 2
+# comp: 696.68 GB/s  decomp: 2938.41 GB/s  (GB300, sf1000 lineitem part.0)
+# Was `input -> bitpack`: 4.885x, comp 1366.78, decomp 2918.00 GB/s on the same
+# data. The mantissas are every multiple of 100 in [100, 5000] -- 50 distinct
+# values that bitpack alone spends 13 bits on -- so dividing the common factor
+# out first halves the bit width at no decode cost. Re-explore also offered a
+# depth-4 variant (two rle levels on chunk_bits) at 10.382x / decomp 2595 GB/s;
+# taken at the knee instead, since the extra depth buys -0.001x for -12% decode.
+input -> factor -> quotients, divisors
+factor.quotients -> bitpack -> chunk_min, chunk_count, chunk_bits, packed
 ---
 # column: l_extendedprice  dtype: t26  ratio: 2.655x  depth: 1
 # comp: 89.73 GB/s  decomp: 218.48 GB/s

--- a/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
+++ b/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
@@ -256,11 +256,18 @@ static std::unique_ptr<compressed_representation> rep_from_leaf_desc(
   auto make_col = [&](std::size_t i) -> std::unique_ptr<cudf::column> {
     auto const& bd     = bufs[i];
     cudf::data_type dt = tag_to_dtype(bd.type_tag);
-    auto col           = cudf::make_numeric_column(dt,
-                                         static_cast<cudf::size_type>(bd.num_rows),
-                                         cudf::mask_state::UNALLOCATED,
-                                         stream,
-                                         leaf_mr);
+    // make_fixed_width_column, not make_numeric_column: cudf classes fixed-point
+    // and chrono types as non-numeric, and a leaf buffer can legitimately carry
+    // either -- ALP's `exceptions` channel on a DECIMAL column is stored with
+    // the column's own fixed-point type. (tag_to_dtype yields scale 0 here; the
+    // real scale rides on the column record and apply_stored_dtype restores it
+    // at the end of decompress. Nothing in between reads the scale -- the buffer
+    // is the mantissa either way.)
+    auto col = cudf::make_fixed_width_column(dt,
+                                             static_cast<cudf::size_type>(bd.num_rows),
+                                             cudf::mask_state::UNALLOCATED,
+                                             stream,
+                                             leaf_mr);
     if (bd.size_bytes > 0) {
       fill(i, col->mutable_view().head<void>(), static_cast<std::size_t>(bd.size_bytes), stream);
     }

--- a/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
+++ b/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
@@ -284,7 +284,7 @@ static std::unique_ptr<compressed_representation> rep_from_leaf_desc(
   };
 
   if (ld.kind == OpId::Delta || ld.kind == OpId::Rle || ld.kind == OpId::For ||
-      ld.kind == OpId::Zigzag || ld.kind == OpId::Bitpack) {
+      ld.kind == OpId::Factor || ld.kind == OpId::Zigzag || ld.kind == OpId::Bitpack) {
     return make_fused_rep(ld.kind);
   }
   if (ld.kind == OpId::Identity) {

--- a/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
+++ b/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
@@ -323,7 +323,7 @@ static std::unique_ptr<compressed_representation> rep_from_leaf_desc(
 // 11: a Bitpack "packed" buffer counts its decode gather guard words in num_rows, so the
 //     stored word count is what the reader allocates and the guard needs no read-side
 //     reconstruction (see compact_bitpack_packed).
-static constexpr std::uint8_t kVersion = 11;
+static constexpr std::uint8_t kVersion = 12;
 
 // Serialize one node's structure (op, bitjoin params, edges, output names).
 // Other ops carry their params in the op name, so only bitjoin needs attrs.

--- a/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
+++ b/src/compression/simpatico_codegen/src/api/compressed_table_io.cpp
@@ -256,13 +256,9 @@ static std::unique_ptr<compressed_representation> rep_from_leaf_desc(
   auto make_col = [&](std::size_t i) -> std::unique_ptr<cudf::column> {
     auto const& bd     = bufs[i];
     cudf::data_type dt = tag_to_dtype(bd.type_tag);
-    // make_fixed_width_column, not make_numeric_column: cudf classes fixed-point
-    // and chrono types as non-numeric, and a leaf buffer can legitimately carry
-    // either -- ALP's `exceptions` channel on a DECIMAL column is stored with
-    // the column's own fixed-point type. (tag_to_dtype yields scale 0 here; the
-    // real scale rides on the column record and apply_stored_dtype restores it
-    // at the end of decompress. Nothing in between reads the scale -- the buffer
-    // is the mantissa either way.)
+    // Not make_numeric_column: cudf classes fixed-point and chrono as
+    // non-numeric, and a leaf buffer can carry either (alp's `exceptions` on a
+    // DECIMAL column). Scale is 0 here; apply_stored_dtype restores the real one.
     auto col = cudf::make_fixed_width_column(dt,
                                              static_cast<cudf::size_type>(bd.num_rows),
                                              cudf::mask_state::UNALLOCATED,

--- a/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
+++ b/src/compression/simpatico_codegen/src/bridge/codegen_runtime.cpp
@@ -1614,6 +1614,33 @@ static int launch_encode_fused_tree_impl(const simpatico::CodegenHead& head,
           break;
         }
 
+        case cc::OpKind::Factor: {
+          // `divisors` holds num_chunks per-chunk GCDs. Its width follows the
+          // rendered buffer rather than a blanket original_type, for the same
+          // reason as For's `references`: Factor may sit under a channel whose
+          // width differs from the column's (e.g. rle's always-int32 "runs").
+          // Buffer layout is flat: divisors[chunk_id].
+          const auto i_divs = find_buffer_idx(spec.buffers, node_id, "divisors");
+          const std::int32_t divs_elem_size =
+            static_cast<std::int32_t>(spec.buffers[i_divs].elem_size);
+          const cudf::data_type divs_elem_type =
+            (divs_elem_size == static_cast<std::int32_t>(cudf::size_of(original_type)))
+              ? original_type
+            : (divs_elem_size == 8) ? cudf::data_type(cudf::type_id::INT64)
+            : (divs_elem_size == 1) ? cudf::data_type(cudf::type_id::UINT8)
+                                    : cudf::data_type(cudf::type_id::INT32);
+          auto divs_col = std::make_unique<cudf::column>(divs_elem_type,
+                                                         static_cast<cudf::size_type>(num_chunks),
+                                                         std::move(bufs[i_divs]),
+                                                         rmm::device_buffer(0, stream),
+                                                         0);
+          auto rep      = std::make_unique<simpatico::codegen_fused_representation>(
+            simpatico::OpId::Factor, original_type, static_cast<cudf::size_type>(num_rows));
+          rep->buffers.emplace_back("divisors", std::move(divs_col));
+          builder->leaves.emplace(origin.plan_node, std::move(rep));
+          break;
+        }
+
         case cc::OpKind::Zigzag: {
           // Transformer mode (fused child on the `zigzag` channel): ZigZag
           // rewrote the lane value inline and stored NOTHING — the child owns
@@ -1682,7 +1709,8 @@ static int launch_encode_fused_tree_impl(const simpatico::CodegenHead& head,
           // width from a "is this channel literally named 'runs'" special
           // case plus original_type.
 
-          const bool is_fixed_stride = (origin.parent_op == "for" || origin.parent_op == "delta");
+          const bool is_fixed_stride = (origin.parent_op == "for" || origin.parent_op == "delta" ||
+                                        origin.parent_op == "factor");
 
           const auto i_data            = find_buffer_idx(spec.buffers, node_id, "data");
           const std::int32_t elem_size = static_cast<std::int32_t>(spec.buffers[i_data].elem_size);

--- a/src/compression/simpatico_codegen/src/bridge/fused_tree_build.cpp
+++ b/src/compression/simpatico_codegen/src/bridge/fused_tree_build.cpp
@@ -118,6 +118,24 @@ std::shared_ptr<jit::FusedTree> build_rec(PlanTree const& tree, NodeId nid, Buil
     return t;
   }
 
+  if (node.op == "factor") {
+    // Dual-mode, mirroring `for`: fuse a codegen quotients child, or
+    // synthesize a Raw passthrough that materialises the quotient stream.
+    PlanEdge const* quotients = find_edge(node, "quotients");
+    auto t                    = jit::FusedTree::make(OpKind::Factor);
+    out.preorder.push_back({t.get(), nid, false, 0});
+    std::shared_ptr<jit::FusedTree> quotients_child;
+    if (quotients != nullptr && is_codegen_compressor(tree.nodes[quotients->child].op)) {
+      quotients_child = build_rec(tree, quotients->child, out);
+      if (!quotients_child) return nullptr;
+    } else {
+      quotients_child = jit::FusedTree::make(OpKind::Raw);
+      out.preorder.push_back({quotients_child.get(), 0, true, nid, "factor", "quotients"});
+    }
+    t->children.emplace("quotients", std::move(quotients_child));
+    return t;
+  }
+
   return nullptr;  // non-fusable op
 }
 

--- a/src/compression/simpatico_codegen/src/decode/jit/renderer.cpp
+++ b/src/compression/simpatico_codegen/src/decode/jit/renderer.cpp
@@ -367,6 +367,10 @@ class Walker {
                          const std::string& dst,
                          const std::string& len,
                          const std::string& elem_type);
+  void emit_factor_producer(const ::codegen::jit::FusedTree& node,
+                            const std::string& dst,
+                            const std::string& len,
+                            const std::string& elem_type);
   void emit_for_producer(const ::codegen::jit::FusedTree& node,
                          const std::string& dst,
                          const std::string& len,
@@ -508,6 +512,7 @@ void Walker::emit_producer(const ::codegen::jit::FusedTree& node,
     case ::codegen::OpKind::Delta: emit_delta_producer(node, dst, len, elem_type); return;
     case ::codegen::OpKind::Rle: emit_rle_producer(node, dst, len, elem_type); return;
     case ::codegen::OpKind::For: emit_for_producer(node, dst, len, elem_type); return;
+    case ::codegen::OpKind::Factor: emit_factor_producer(node, dst, len, elem_type); return;
     case ::codegen::OpKind::Raw: emit_raw_producer(node, dst, len, elem_type); return;
     case ::codegen::OpKind::Zigzag: emit_zigzag_producer(node, dst, len, elem_type); return;
     default:
@@ -1351,6 +1356,93 @@ void Walker::emit_for_producer(const ::codegen::jit::FusedTree& node,
           << "        (" << dst << ")[i] = static_cast<" << elem_type << ">(\n"
           << "            static_cast<" << futype << ">(" << slab << "[i]) + static_cast<" << futype
           << ">(" << v_ref << "));\n"
+          << "    }\n"
+          << "    __syncthreads();\n";
+    sm_.release_to(mark);
+  }
+}
+
+// =====================================================================
+// FACTOR — semi-inline reverse transformer (mirrors emit_for_producer).
+//
+// Inverts the encode FACTOR step: given the compressed quotients (the
+// `quotients` child) and the per-chunk GCD stored in `divisors[chunk_id]`,
+// reconstruct `original[i] = quotient[i] * divisor`.
+//
+// Same two paths as FOR:
+//   * Closed-form child (Bitpack/Raw leaf): splice a `value_source` expr
+//     and multiply in a single strided loop.
+//   * Producer child (Delta/Rle): materialise into a shared slab first,
+//     then multiply in a second strided loop.
+// =====================================================================
+void Walker::emit_factor_producer(const ::codegen::jit::FusedTree& node,
+                                  const std::string& dst,
+                                  const std::string& len,
+                                  const std::string& elem_type)
+{
+  if (node.children.size() != 1) {
+    throw RenderError(
+      "decode render: FACTOR must have exactly one child named 'quotients' "
+      "(got " +
+      std::to_string(node.children.size()) + " children)");
+  }
+  auto qit = node.children.find("quotients");
+  if (qit == node.children.end()) {
+    throw RenderError("decode render: FACTOR missing 'quotients' child (got '" +
+                      node.children.begin()->first + "' instead)");
+  }
+  const std::size_t esize = dtype_elem_size(elem_type);
+  if (esize == 0) {
+    throw RenderError("decode render: FACTOR op-local dtype '" + elem_type + "' not supported");
+  }
+
+  const std::int32_t id   = id_of(node);
+  const std::string idstr = std::to_string(id);
+
+  // Kernel parameter: divisors buffer (one entry per chunk).
+  const std::string p_divs = "divisors_" + idstr;
+  add_param("const " + elem_type + "* __restrict__", p_divs);
+  add_buffer(id, "divisors", esize);
+
+  const std::string v_div = "fac_div_" + idstr;
+
+  body_ << "    // --- node " << id << ": FACTOR (reverse, " << elem_type << ") ---\n"
+        << "    const " << elem_type << " " << v_div << " = " << p_divs << "[chunk_id];\n";
+
+  const bool child_is_leaf =
+    (qit->second->op == ::codegen::OpKind::Bitpack && qit->second->children.empty()) ||
+    (qit->second->op == ::codegen::OpKind::Raw && qit->second->children.empty());
+
+  // quotient * divisor reproduces the original exactly, but the product can
+  // reach the signed extremes; multiply in the unsigned counterpart so the
+  // reconstruction never relies on signed-overflow UB (see emit_for_producer).
+  const std::string futype = unsigned_counterpart(esize);
+
+  if (child_is_leaf) {
+    const auto mark      = sm_.mark();
+    ValueSource child_vs = value_source(*qit->second, elem_type, len);
+    body_ << "    for (int32_t i = tid; i < static_cast<int32_t>(" << len << "); i += " << tbs_
+          << ") {\n"
+          << "        (" << dst << ")[i] = static_cast<" << elem_type << ">(\n"
+          << "            static_cast<" << futype << ">(" << at_pos(child_vs.read_expr, "i")
+          << ") * static_cast<" << futype << ">(" << v_div << "));\n"
+          << "    }\n"
+          << "    __syncthreads();\n";
+    sm_.release_to(mark);
+  } else {
+    const auto mark        = sm_.mark();
+    const std::string slab = "fac_slab_" + idstr;
+    const std::size_t off  = sm_.alloc(esize, ::codegen::kChunkSize);
+
+    body_ << "    " << elem_type << "* " << slab << " = reinterpret_cast<" << elem_type
+          << "*>(workspace + " << off << ");\n";
+    emit_producer(*qit->second, slab, len, elem_type);
+    body_ << "    __syncthreads();\n"
+          << "    for (int32_t i = tid; i < static_cast<int32_t>(" << len << "); i += " << tbs_
+          << ") {\n"
+          << "        (" << dst << ")[i] = static_cast<" << elem_type << ">(\n"
+          << "            static_cast<" << futype << ">(" << slab << "[i]) * static_cast<" << futype
+          << ">(" << v_div << "));\n"
           << "    }\n"
           << "    __syncthreads();\n";
     sm_.release_to(mark);

--- a/src/compression/simpatico_codegen/src/encode/jit/renderer.cpp
+++ b/src/compression/simpatico_codegen/src/encode/jit/renderer.cpp
@@ -324,6 +324,7 @@ class Walker {
   void emit_node(const ::codegen::jit::FusedTree& node, LaneInput in);
   void emit_delta(const ::codegen::jit::FusedTree& node, LaneInput in);
   void emit_for(const ::codegen::jit::FusedTree& node, LaneInput in);
+  void emit_factor(const ::codegen::jit::FusedTree& node, LaneInput in);
   // use_smem: accumulate into a per-block __shared__ slab, then store to global.
   //   Eliminates the cudaMemsetAsync pre-zero requirement for the packed buffer.
   //   Valid only for leaf Bitpacks where bits * kChunkSize / 32 + 2 fits in the
@@ -346,6 +347,8 @@ class Walker {
 
 struct SimpaticoMin { template <class T> __device__ __forceinline__ T operator()(const T& a, const T& b) const { return a < b ? a : b; } };
 struct SimpaticoMax { template <class T> __device__ __forceinline__ T operator()(const T& a, const T& b) const { return a > b ? a : b; } };
+__device__ __forceinline__ unsigned long long simpatico_gcd_u64(unsigned long long a, unsigned long long b) { while (b != 0ULL) { unsigned long long t = a % b; a = b; b = t; } return a; }
+struct SimpaticoGcd { __device__ __forceinline__ unsigned long long operator()(const unsigned long long& a, const unsigned long long& b) const { return simpatico_gcd_u64(a, b); } };
 
 using ::cuda::std::int8_t;
 using ::cuda::std::int16_t;
@@ -382,6 +385,7 @@ void Walker::emit_node(const ::codegen::jit::FusedTree& node, LaneInput in)
     case ::codegen::OpKind::Rle: emit_rle(node, std::move(in)); return;
     case ::codegen::OpKind::Raw: emit_raw(node, std::move(in)); return;
     case ::codegen::OpKind::For: emit_for(node, std::move(in)); return;
+    case ::codegen::OpKind::Factor: emit_factor(node, std::move(in)); return;
     case ::codegen::OpKind::Zigzag: emit_zigzag(node, std::move(in)); return;
     case ::codegen::OpKind::None:
     default:
@@ -572,6 +576,105 @@ void Walker::emit_for(const ::codegen::jit::FusedTree& node, LaneInput in)
   out.length_expr = in.length_expr;
 
   emit_node(*dit->second, std::move(out));
+}
+
+// =====================================================================
+// emit_factor — semi-inline transformer (FOR's structural twin).
+//
+// FACTOR computes the GCD of the magnitudes of a chunk's values (via CUB
+// BlockReduce over a Euclid functor), stores it in `divisors[chunk_id]`,
+// then rewrites the LaneInput so downstream ops see `value / divisor`.
+// Decode multiplies back.  Like FOR it preserves the element count and
+// needs no shared slab — the quotient is a closed-form expression the
+// child splices in.
+//
+// This is the integer/decimal analogue of ALP's factor step: a DECIMAL
+// column whose values share a common divisor (e.g. TPC-H l_quantity,
+// stored as mantissas 100..5000 that are all multiples of 100) collapses
+// to a far narrower range before bitpack sees it.  The GCD generalises
+// ALP's power-of-ten factor and costs one block reduction, not a search.
+//
+// `divisors` is a kernel output buffer (num_chunks x elem_size) exposed
+// as `named_channels()["divisors"]`, exactly like FOR's `references`.
+// =====================================================================
+void Walker::emit_factor(const ::codegen::jit::FusedTree& node, LaneInput in)
+{
+  if (node.children.size() != 1) {
+    throw RenderError(
+      "render: FACTOR must have exactly one child named 'quotients' "
+      "(got " +
+      std::to_string(node.children.size()) + " children)");
+  }
+  auto qit = node.children.find("quotients");
+  if (qit == node.children.end()) {
+    throw RenderError("render: FACTOR missing 'quotients' child (got '" +
+                      node.children.begin()->first + "' instead)");
+  }
+
+  const DtypeInfo* op_dt = lookup_dtype(in.elem_type);
+  if (op_dt == nullptr) {
+    throw RenderError("render: FACTOR op-local dtype '" + in.elem_type + "' not in dtype table");
+  }
+
+  const std::int32_t id   = take_id();
+  const std::string idstr = std::to_string(id);
+
+  // Output buffer: divisors[num_chunks] — one per-chunk GCD.
+  const std::string p_divs = "divisors_" + idstr;
+  add_param(in.elem_type + "*", p_divs);
+  add_buffer(id, "divisors", op_dt->elem_size, static_cast<std::size_t>(num_chunks_));
+
+  const std::string sh_div = "sh_fac_div_" + idstr;
+  const std::string v_div  = "fac_div_" + idstr;
+  const std::string v_lg   = "fac_lg_" + idstr;
+
+  // Per-lane running GCD of |value|, then a block-wide GCD reduce.
+  // Magnitudes are taken in uint64 via unsigned negation so INT*_MIN is
+  // well-defined (unary minus on the signed minimum is UB).  gcd(0, x) == x,
+  // so 0 is the correct identity for both the lane seed and empty lanes.
+  body_ << "    // --- node " << id << ": FACTOR (semi-inline, " << in.elem_type << ") ---\n"
+        << "    const int32_t fac_len_" << idstr << " = static_cast<int32_t>(" << in.length_expr
+        << ");\n"
+        << "    unsigned long long " << v_lg << " = 0ULL;\n"
+        << "    for (int32_t i = tid; i < fac_len_" << idstr << "; i += 128) {\n"
+        << "        " << in.elem_type << " _qv = (" << at_lane(in.read_expr, "i") << ");\n"
+        << "        unsigned long long _qu = static_cast<unsigned long long>("
+        << "static_cast<long long>(_qv));\n"
+        << "        unsigned long long _qm = (_qv < static_cast<" << in.elem_type
+        << ">(0)) ? (0ULL - _qu) : _qu;\n"
+        << "        " << v_lg << " = simpatico_gcd_u64(" << v_lg << ", _qm);\n"
+        << "    }\n"
+        << "    typedef cub::BlockReduce<unsigned long long, 128> FacBR_" << idstr << ";\n"
+        << "    __shared__ typename FacBR_" << idstr << "::TempStorage fac_br_ts_" << idstr << ";\n"
+        << "    __shared__ " << in.elem_type << " " << sh_div << ";\n"
+        << "    {\n"
+        << "        unsigned long long _g = FacBR_" << idstr << "(fac_br_ts_" << idstr
+        << ").Reduce(" << v_lg << ", SimpaticoGcd());\n"
+        << "        if (tid == 0) {\n"
+        // An all-zero chunk reduces to 0, and a chunk whose magnitudes are all
+        // exactly the type minimum reduces to 2^(N-1), which does not fit the
+        // signed divisor slot. Both fall back to the no-op divisor 1.
+        << "            if (_g == 0ULL || _g > static_cast<unsigned long long>("
+        << op_dt->max_literal << ")) _g = 1ULL;\n"
+        << "            " << sh_div << " = static_cast<" << in.elem_type << ">(_g);\n"
+        << "        }\n"
+        << "    }\n"
+        << "    __syncthreads();\n"
+        << "    const " << in.elem_type << " " << v_div << " = " << sh_div << ";\n"
+        << "    if (tid == 0) " << p_divs << "[chunk_id] = " << v_div << ";\n";
+
+  // Rewrite LaneInput for the child: quotient = parent_value / chunk_divisor.
+  // The divisor divides every magnitude in the chunk exactly, so the truncating
+  // signed division is exact for both signs and decode's multiply is lossless.
+  // Length is unchanged — FACTOR preserves the element count.
+  LaneInput out;
+  out.kind      = LaneInput::Expr;
+  out.elem_type = in.elem_type;
+  out.read_expr = "(static_cast<" + in.elem_type + ">((" + at_lane(in.read_expr, "(__LANE__)") +
+                  ") / " + v_div + "))";
+  out.length_expr = in.length_expr;
+
+  emit_node(*qit->second, std::move(out));
 }
 
 // =====================================================================

--- a/src/compression/simpatico_codegen/src/encode/jit/renderer.cpp
+++ b/src/compression/simpatico_codegen/src/encode/jit/renderer.cpp
@@ -588,12 +588,6 @@ void Walker::emit_for(const ::codegen::jit::FusedTree& node, LaneInput in)
 // needs no shared slab — the quotient is a closed-form expression the
 // child splices in.
 //
-// This is the integer/decimal analogue of ALP's factor step: a DECIMAL
-// column whose values share a common divisor (e.g. TPC-H l_quantity,
-// stored as mantissas 100..5000 that are all multiples of 100) collapses
-// to a far narrower range before bitpack sees it.  The GCD generalises
-// ALP's power-of-ten factor and costs one block reduction, not a search.
-//
 // `divisors` is a kernel output buffer (num_chunks x elem_size) exposed
 // as `named_channels()["divisors"]`, exactly like FOR's `references`.
 // =====================================================================

--- a/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
+++ b/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
@@ -73,7 +73,7 @@ inline double op_decode_cost(std::string_view op)
   if (op == "deflate" || op == "lz4" || op == "snappy" || op == "cascaded") return 5.0;
   if (op == "dictionary") return 3.0;
   if (op == "ans" || op == "bitcomp" || op == "alp" || op == "alp_rd") return 2.0;
-  return 1.0;  // bitpack, rle, delta, zigzag, for, bitextract — fast
+  return 1.0;  // bitpack, rle, delta, zigzag, for, factor, bitextract — fast
 }
 
 inline double weighted_score(double ratio, double comp, double decomp, double const w[3])
@@ -328,8 +328,8 @@ operator_trial try_operator(std::string const& name,
     return r;
   }
   // Integer-only preprocessing operators
-  if ((name == "delta" || name == "for" || name == "zigzag" || name == "bitpack" ||
-       name == "rle") &&
+  if ((name == "delta" || name == "for" || name == "zigzag" || name == "bitpack" || name == "rle" ||
+       name == "factor") &&
       !is_int && !is_float) {
     r.error_message = name + ": requires numeric input";
     return r;

--- a/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
+++ b/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
@@ -292,15 +292,8 @@ std::string format_output_names(std::vector<compressible_output> const& outs)
 
 namespace {
 
-// True when every element of `col` is the integer 1, read through the column's
-// underlying storage -- a fixed-point column's data IS its mantissa, so the
-// same comparison works for DECIMAL divisors without materialising a scale.
-// Dispatches on storage width because a `divisors` channel takes its width from
-// the rendered buffer (it can sit under a channel narrower than the column).
-//
-// Checked host-side: this translation unit is compiled by the host compiler, and
-// the channel is one element per 1024-row chunk (~780 KB for a 100M-row column),
-// so the copy is far cheaper than the encode that just produced it.
+// Compares raw storage, so a DECIMAL column's mantissa works unchanged. Host
+// side: this TU is host-compiled, and the channel is one element per chunk.
 bool all_ones(cudf::column_view const& col, rmm::cuda_stream_view stream)
 {
   auto const n = col.size();
@@ -336,15 +329,9 @@ bool all_ones(cudf::column_view const& col, rmm::cuda_stream_view stream)
   }
 }
 
-// Ask an operator's own output whether it actually did anything. Only ops that
-// can answer honestly are listed; everything else reports false and is left to
-// the byte-size rules.
-//
-// `factor` can answer exactly: its `divisors` channel is the per-chunk GCD, so
-// an all-ones channel means every chunk was divided by 1 and the transform is a
-// bit-exact identity. Detecting it here rather than by failing the operator
-// keeps `factor` safe to name in a hand-written plan -- a column whose GCD
-// happens to be 1 on one partition must still compress, not abort.
+// `factor`'s divisors are per-chunk GCDs, so all-ones means it divided by 1
+// everywhere. Reported rather than failed, so a plan naming `factor` still
+// compresses on a partition whose GCD happens to be 1.
 bool trial_is_identity(std::string const& name,
                        std::vector<compressible_output> const& outputs,
                        rmm::cuda_stream_view stream)
@@ -386,11 +373,8 @@ operator_trial try_operator(std::string const& name,
     r.error_message = name + ": requires float32 input";
     return r;
   }
-  // alp takes fixed-point too: a DECIMAL column's mantissa is already an
-  // integer, so ALP's scale search there is exact integer divisibility -- and
-  // unlike `factor`, which needs a divisor common to EVERY value in a chunk,
-  // ALP can take a power of ten that most values share and bank the rest as
-  // exceptions. alp_rd stays float-only; it splits an IEEE significand.
+  // A DECIMAL mantissa is already an integer, so alp's scale search there is
+  // exact divisibility. alp_rd stays float-only; it splits an IEEE significand.
   bool const is_decimal = cudf::is_fixed_point(col.type()) &&
                           (tid == cudf::type_id::DECIMAL32 || tid == cudf::type_id::DECIMAL64);
   if (name == "alp" && !is_float && !is_decimal) {
@@ -644,13 +628,9 @@ exploration_result explore_column_compression(cudf::column_view input,
                       << "x)\n";
           }
 
-          // Preprocessing ops are exempt from the must-shrink rule below --
-          // they earn their place at the NEXT level, not this one (`factor`
-          // measures 0.999x on its own and only pays off once bitpack sees the
-          // narrowed values). That waiver is only justified when the op
-          // transformed something: one that reports itself an identity would
-          // otherwise occupy a beam slot all the way to the depth where it is
-          // finally revealed to be worthless.
+          // The must-shrink waiver below only makes sense for an op that
+          // transformed something; an identity would ride the beam to the depth
+          // where it is finally revealed worthless.
           if (trial.no_benefit) continue;
           bool is_pre = is_preprocessing_compressor(op_name);
           if (trial.output_bytes >= pend.size_bytes && !is_pre) continue;

--- a/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
+++ b/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
@@ -319,7 +319,18 @@ operator_trial try_operator(std::string const& name,
     r.error_message = name + ": requires float32 input";
     return r;
   }
-  if ((name == "alp" || name == "alp_rd") && !is_float) {
+  // alp takes fixed-point too: a DECIMAL column's mantissa is already an
+  // integer, so ALP's scale search there is exact integer divisibility -- and
+  // unlike `factor`, which needs a divisor common to EVERY value in a chunk,
+  // ALP can take a power of ten that most values share and bank the rest as
+  // exceptions. alp_rd stays float-only; it splits an IEEE significand.
+  bool const is_decimal = cudf::is_fixed_point(col.type()) &&
+                          (tid == cudf::type_id::DECIMAL32 || tid == cudf::type_id::DECIMAL64);
+  if (name == "alp" && !is_float && !is_decimal) {
+    r.error_message = name + ": requires floating-point or DECIMAL32/64 input";
+    return r;
+  }
+  if (name == "alp_rd" && !is_float) {
     r.error_message = name + ": requires floating-point input";
     return r;
   }

--- a/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
+++ b/src/compression/simpatico_codegen/src/explore/compression_explorer.cpp
@@ -290,6 +290,73 @@ std::string format_output_names(std::vector<compressible_output> const& outs)
   return oss.str();
 }
 
+namespace {
+
+// True when every element of `col` is the integer 1, read through the column's
+// underlying storage -- a fixed-point column's data IS its mantissa, so the
+// same comparison works for DECIMAL divisors without materialising a scale.
+// Dispatches on storage width because a `divisors` channel takes its width from
+// the rendered buffer (it can sit under a channel narrower than the column).
+//
+// Checked host-side: this translation unit is compiled by the host compiler, and
+// the channel is one element per 1024-row chunk (~780 KB for a 100M-row column),
+// so the copy is far cheaper than the encode that just produced it.
+bool all_ones(cudf::column_view const& col, rmm::cuda_stream_view stream)
+{
+  auto const n = col.size();
+  if (n == 0) return true;
+  auto const width = cudf::size_of(col.type());
+  if (width == 0 || width > 8) return false;
+
+  std::vector<std::uint8_t> host(static_cast<std::size_t>(n) * width);
+  if (cudaMemcpyAsync(host.data(),
+                      col.head<std::uint8_t>() + static_cast<std::size_t>(col.offset()) * width,
+                      host.size(),
+                      cudaMemcpyDeviceToHost,
+                      stream.value()) != cudaSuccess) {
+    cudaGetLastError();
+    return false;
+  }
+  if (cudaStreamSynchronize(stream.value()) != cudaSuccess) {
+    cudaGetLastError();
+    return false;
+  }
+
+  auto scan = [n](auto const* p) {
+    for (cudf::size_type i = 0; i < n; ++i)
+      if (p[i] != 1) return false;
+    return true;
+  };
+  switch (width) {
+    case 1: return scan(reinterpret_cast<std::int8_t const*>(host.data()));
+    case 2: return scan(reinterpret_cast<std::int16_t const*>(host.data()));
+    case 4: return scan(reinterpret_cast<std::int32_t const*>(host.data()));
+    case 8: return scan(reinterpret_cast<std::int64_t const*>(host.data()));
+    default: return false;
+  }
+}
+
+// Ask an operator's own output whether it actually did anything. Only ops that
+// can answer honestly are listed; everything else reports false and is left to
+// the byte-size rules.
+//
+// `factor` can answer exactly: its `divisors` channel is the per-chunk GCD, so
+// an all-ones channel means every chunk was divided by 1 and the transform is a
+// bit-exact identity. Detecting it here rather than by failing the operator
+// keeps `factor` safe to name in a hand-written plan -- a column whose GCD
+// happens to be 1 on one partition must still compress, not abort.
+bool trial_is_identity(std::string const& name,
+                       std::vector<compressible_output> const& outputs,
+                       rmm::cuda_stream_view stream)
+{
+  if (name != "factor") return false;
+  for (auto const& o : outputs)
+    if (o.name == "divisors") return all_ones(o.view, stream);
+  return false;
+}
+
+}  // namespace
+
 operator_trial try_operator(std::string const& name,
                             cudf::column_view col,
                             rmm::cuda_stream_view stream,
@@ -369,7 +436,8 @@ operator_trial try_operator(std::string const& name,
     for (auto const& o : r.outputs) {
       r.output_bytes += column_size_bytes_ex(o.view, stream);
     }
-    r.success = true;
+    r.no_benefit = trial_is_identity(name, r.outputs, stream);
+    r.success    = true;
   } catch (std::exception const& e) {
     cudaGetLastError();  // clear any CUDA error state left by the exception
     r.error_message = e.what();
@@ -576,6 +644,14 @@ exploration_result explore_column_compression(cudf::column_view input,
                       << "x)\n";
           }
 
+          // Preprocessing ops are exempt from the must-shrink rule below --
+          // they earn their place at the NEXT level, not this one (`factor`
+          // measures 0.999x on its own and only pays off once bitpack sees the
+          // narrowed values). That waiver is only justified when the op
+          // transformed something: one that reports itself an identity would
+          // otherwise occupy a beam slot all the way to the depth where it is
+          // finally revealed to be worthless.
+          if (trial.no_benefit) continue;
           bool is_pre = is_preprocessing_compressor(op_name);
           if (trial.output_bytes >= pend.size_bytes && !is_pre) continue;
 

--- a/src/compression/simpatico_codegen/src/operators/alp_common.cuh
+++ b/src/compression/simpatico_codegen/src/operators/alp_common.cuh
@@ -35,13 +35,14 @@ struct alp_exception_columns {
 // corresponding `values_source[i]` payloads into `values`. All work is enqueued
 // on `stream`; the thrust::reduce return makes `count` valid on the host on
 // return, but the caller must sync before reading the columns from another
-// stream. `ValueT` is both the source element type and the `values` column type
-// (which must equal `value_type_id`).
+// stream. `ValueT` is the source element type and the storage type of the
+// `values` column; `value_dtype` is that column's full cudf type, taken as a
+// data_type rather than a type_id so a fixed-point column keeps its scale.
 template <typename ValueT>
 alp_exception_columns compact_exceptions(const uint8_t* d_flags,
                                          cudf::size_type n,
                                          const ValueT* values_source,
-                                         cudf::type_id value_type_id,
+                                         cudf::data_type value_dtype,
                                          rmm::cuda_stream_view stream,
                                          rmm::device_async_resource_ref mr)
 {
@@ -55,7 +56,7 @@ alp_exception_columns compact_exceptions(const uint8_t* d_flags,
   alp_exception_columns out;
   out.count  = static_cast<cudf::size_type>(exc_count);
   out.values = cudf::make_fixed_width_column(
-    cudf::data_type(value_type_id), out.count, cudf::mask_state::UNALLOCATED, stream, mr);
+    value_dtype, out.count, cudf::mask_state::UNALLOCATED, stream, mr);
   out.positions = cudf::make_fixed_width_column(
     cudf::data_type(cudf::type_id::INT32), out.count, cudf::mask_state::UNALLOCATED, stream, mr);
 

--- a/src/compression/simpatico_codegen/src/operators/alp_compressor.cu
+++ b/src/compression/simpatico_codegen/src/operators/alp_compressor.cu
@@ -46,6 +46,16 @@ namespace {
 // Vector size is fixed at 1024 (matches ALP & FastLanes; aligned with G-ALP).
 constexpr int kAlpVectorSize = 1024;
 
+// Scale-selection sample: kAlpSampleRuns contiguous runs of kAlpSampleRunLen,
+// spread evenly across the vector. The total must be a whole number of warps
+// (the selection phase shuffle-reduces with a full mask) and no larger than the
+// vector.
+constexpr int kAlpSampleRuns   = 8;
+constexpr int kAlpSampleRunLen = 8;
+constexpr int kAlpSampleSize   = kAlpSampleRuns * kAlpSampleRunLen;  // 64 = 2 warps
+static_assert(kAlpSampleSize % 32 == 0, "sample must be a whole number of warps");
+static_assert(kAlpSampleSize <= kAlpVectorSize, "sample must fit in a vector");
+
 // -----------------------------------------------------------------------------
 // Per-type constant tables. Two separate __constant__ symbol sets because CUDA
 // does not allow __constant__ arrays inside templates with proper linkage.
@@ -263,6 +273,40 @@ __device__ inline int64_t atomic_max(int64_t* a, int64_t v)
 }
 
 // -----------------------------------------------------------------------------
+// Full-warp shuffle reductions. __shfl_down_sync handles 64-bit operands
+// natively, so one template covers int32_t and int64_t. Callers must have all
+// 32 lanes of the warp active (the sampling loop below sizes its participant
+// count as a whole number of warps precisely so this holds).
+// -----------------------------------------------------------------------------
+
+template <typename V>
+__device__ inline V warp_reduce_min(V x)
+{
+  for (int off = 16; off > 0; off >>= 1) {
+    V const y = __shfl_down_sync(0xFFFFFFFFu, x, off);
+    x         = (y < x) ? y : x;
+  }
+  return x;
+}
+
+template <typename V>
+__device__ inline V warp_reduce_max(V x)
+{
+  for (int off = 16; off > 0; off >>= 1) {
+    V const y = __shfl_down_sync(0xFFFFFFFFu, x, off);
+    x         = (y > x) ? y : x;
+  }
+  return x;
+}
+
+__device__ inline uint32_t warp_reduce_add(uint32_t x)
+{
+  for (int off = 16; off > 0; off >>= 1)
+    x += __shfl_down_sync(0xFFFFFFFFu, x, off);
+  return x;
+}
+
+// -----------------------------------------------------------------------------
 // Device helpers
 // -----------------------------------------------------------------------------
 
@@ -309,12 +353,32 @@ __device__ inline typename alp_traits<T>::int_t alp_encode_value(T v, int d, boo
 
 // -----------------------------------------------------------------------------
 // Encode kernel: 1 block == 1 vector of 1024 values. blockDim.x == 1024.
-// Each thread handles one value. For each candidate scale d the threads
-// atomically update per-candidate (exc_count, min_enc, max_enc) in shared mem;
-// thread 0 then picks the d with the lowest cost
-// (`vec_n * bitwidth + exc_count * exception_cost_bits`) and stores it into the
-// metadata column. Finally every thread re-encodes its value with the winning
-// d and writes (integer, exception_flag).
+//
+// Two phases:
+//
+//   Selection -- the first kAlpSampleSize threads each hold one SAMPLED value
+//     and evaluate every candidate scale d on it, accumulating per-candidate
+//     (exc_count, min_enc, max_enc). Thread 0 then picks the d with the lowest
+//     cost (`vec_n * bitwidth + exc_count * exception_cost_bits`) and stores it
+//     into the metadata column.
+//
+//   Emit -- every thread re-encodes its own value with the winning d and writes
+//     (integer, exception_flag). This pass is exact and covers all 1024 values,
+//     so sampling only ever costs ratio (a slightly worse d), never correctness.
+//
+// Sampling is what makes the encoder affordable: scoring all 1024 values
+// against all candidates costs ~19k round-trip encodes per vector, each several
+// float multiplies, and on parts with cut FP64 throughput that dominates
+// everything. The published ALP algorithm samples too, for the same reason.
+//
+// The sample is kAlpSampleRuns contiguous runs spread evenly across the vector,
+// not a fixed stride: a stride can land on a period of the data (round-robin
+// sensor readings, interleaved currencies) and then observe only one phase of
+// it, picking a scale that suits a sixteenth of the rows.
+//
+// Within the selection phase the per-candidate accumulators are reduced across
+// each warp by shuffle first, so a candidate costs one shared atomic per warp
+// rather than one per participating thread.
 // -----------------------------------------------------------------------------
 template <typename T>
 __global__ void alp_encode_kernel(const T* __restrict__ in,
@@ -329,11 +393,12 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
 
   int vec      = blockIdx.x;
   int tid      = threadIdx.x;
-  int global_i = vec * kAlpVectorSize + tid;
+  int vec_base = vec * kAlpVectorSize;
+  int global_i = vec_base + tid;
   bool valid   = (global_i < n_rows);
   T v          = valid ? in[global_i] : T{0};
 
-  int vec_n = min(n_rows - vec * kAlpVectorSize, kAlpVectorSize);
+  int vec_n = min(n_rows - vec_base, kAlpVectorSize);
 
   __shared__ uint32_t s_exc_count[cand_count];
   __shared__ int_t s_min_enc[cand_count];
@@ -350,18 +415,49 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
   }
   __syncthreads();
 
-  // Sweep candidates. Atomic contention is per-candidate across the block; for
-  // typical inputs most threads hit the same min/max paths so this is
-  // dominated by atomic latency, not contention.
-  for (int c = 0; c < cand_count; ++c) {
-    if (valid) {
-      bool is_exc;
-      int_t enc = alp_encode_value<T>(v, c, is_exc);
-      if (is_exc) {
-        atomicAdd(&s_exc_count[c], 1u);
-      } else {
-        atomic_min(&s_min_enc[c], enc);
-        atomic_max(&s_max_enc[c], enc);
+  // Pick this thread's sample: kAlpSampleRuns contiguous runs spread evenly
+  // over the vector. Threads at or past kAlpSampleSize sit the phase out.
+  // Short vectors (the trailing partial one) collapse runs onto each other,
+  // which just resamples the same values -- harmless for a ranking.
+  bool const samples = (tid < kAlpSampleSize);
+  T sv               = T{0};
+  bool sv_valid      = false;
+  if (samples) {
+    int const run = tid / kAlpSampleRunLen;
+    int const off = tid % kAlpSampleRunLen;
+    int const idx = (run * vec_n) / kAlpSampleRuns + off;
+    sv_valid      = (idx < vec_n);
+    if (sv_valid) sv = in[vec_base + idx];
+  }
+
+  // Score every candidate on the sample. Each warp reduces its own lanes by
+  // shuffle and contributes a single atomic per candidate; kAlpSampleSize is a
+  // whole number of warps so every lane in a participating warp is active and
+  // the full-mask shuffles below are well formed.
+  if (samples) {
+    int const lane = tid & 31;
+    for (int c = 0; c < cand_count; ++c) {
+      bool is_exc = true;
+      int_t enc   = int_t{0};
+      if (sv_valid) enc = alp_encode_value<T>(sv, c, is_exc);
+
+      // Non-participating lanes fold in as identities: they add 0 exceptions
+      // and contribute the neutral extremes to min/max.
+      uint32_t const exc_bit = (sv_valid && is_exc) ? 1u : 0u;
+      bool const counts      = (sv_valid && !is_exc);
+      int_t const lo_in      = counts ? enc : traits::int_max;
+      int_t const hi_in      = counts ? enc : traits::int_min;
+
+      uint32_t const exc_sum = warp_reduce_add(exc_bit);
+      int_t const lo         = warp_reduce_min<int_t>(lo_in);
+      int_t const hi         = warp_reduce_max<int_t>(hi_in);
+
+      if (lane == 0) {
+        if (exc_sum != 0u) atomicAdd(&s_exc_count[c], exc_sum);
+        if (lo <= hi) {
+          atomic_min(&s_min_enc[c], lo);
+          atomic_max(&s_max_enc[c], hi);
+        }
       }
     }
   }
@@ -369,11 +465,16 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
 
   // Single-thread cost-based selection. cand_count is small; full pass is fine.
   if (tid == 0) {
-    uint64_t best_cost = UINT64_MAX;
-    int best           = 0;
+    // Scored over the sample, so `sample_n` (not vec_n) is the population the
+    // exception counts are drawn from. Cost is proportional either way; what
+    // matters is that the bit-width term and the exception term are weighed
+    // against the same denominator.
+    uint32_t const sample_n = static_cast<uint32_t>(min(vec_n, kAlpSampleSize));
+    uint64_t best_cost      = UINT64_MAX;
+    int best                = 0;
     for (int c = 0; c < cand_count; ++c) {
       uint32_t exc     = s_exc_count[c];
-      uint32_t non_exc = static_cast<uint32_t>(vec_n) - exc;
+      uint32_t non_exc = sample_n - exc;
       uint32_t bits    = 0;
       if (non_exc > 0) {
         int_t lo = s_min_enc[c];
@@ -386,7 +487,7 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
           bits           = static_cast<uint32_t>(bits_for_range_u64(range));
         }
       }
-      uint64_t cost = static_cast<uint64_t>(vec_n) * bits +
+      uint64_t cost = static_cast<uint64_t>(sample_n) * bits +
                       static_cast<uint64_t>(exc) * traits::exception_cost_bits;
       if (cost < best_cost) {
         best_cost = cost;
@@ -401,9 +502,11 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
     // down to zero whenever the real values cluster away from it, so a single
     // exception could cost ~30 bits per row on an otherwise narrow chunk --
     // and it made the emitted buffer disagree with the bit-width this very
-    // cost model just scored. s_min_enc keeps its int_max sentinel when every
-    // value in the vector is an exception; 0 is as good as anything there.
-    s_fill = (s_exc_count[best] < static_cast<uint32_t>(vec_n)) ? s_min_enc[best] : int_t{0};
+    // cost model just scored. Being a sample minimum it may sit above the true
+    // vector minimum, but never below it, so it always lands inside the range
+    // bitpack will cover. s_min_enc keeps its int_max sentinel when every
+    // sampled value is an exception; 0 is as good as anything there.
+    s_fill = (s_exc_count[best] < sample_n) ? s_min_enc[best] : int_t{0};
   }
   __syncthreads();
 

--- a/src/compression/simpatico_codegen/src/operators/alp_compressor.cu
+++ b/src/compression/simpatico_codegen/src/operators/alp_compressor.cu
@@ -49,6 +49,12 @@ constexpr int kAlpVectorSize = 1024;
 
 // Scale-selection sample: contiguous runs spread evenly across the vector. The
 // total must be a whole number of warps and no larger than the vector.
+// Decode maps one block to one vector, so the scale is read once per block and
+// each thread carries kAlpVectorSize / kAlpDecodeBlock elements.
+constexpr int kAlpDecodeBlock     = 256;
+constexpr int kAlpDecodePerThread = kAlpVectorSize / kAlpDecodeBlock;
+static_assert(kAlpVectorSize % kAlpDecodeBlock == 0, "decode block must divide the vector");
+
 constexpr int kAlpSampleRuns   = 8;
 constexpr int kAlpSampleRunLen = 8;
 constexpr int kAlpSampleSize   = kAlpSampleRuns * kAlpSampleRunLen;  // 64 = 2 warps
@@ -555,11 +561,13 @@ __global__ void alp_decode_kernel(const typename alp_traits<T>::int_t* __restric
                                   int32_t n_rows,
                                   T* __restrict__ out)
 {
-  int i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i >= n_rows) return;
-  int const vec = i / kAlpVectorSize;
-  int const d   = static_cast<int>(metadata[vec]);
-  out[i]        = alp_decode_value<T>(integers[i], d);
+  int const base = blockIdx.x * kAlpVectorSize;
+  int const d    = static_cast<int>(metadata[blockIdx.x]);
+#pragma unroll
+  for (int k = 0; k < kAlpDecodePerThread; ++k) {
+    int const i = base + k * kAlpDecodeBlock + static_cast<int>(threadIdx.x);
+    if (i < n_rows) out[i] = alp_decode_value<T>(integers[i], d);
+  }
 }
 
 // Exception scatter: fully data-parallel (G-ALP's key GPU optimisation).
@@ -657,8 +665,8 @@ std::unique_ptr<cudf::column> alp_decompress_impl(alp_compressed_representation 
   auto out = cudf::make_fixed_width_column(
     repr.original_type, repr.num_rows, cudf::mask_state::UNALLOCATED, stream, mr);
 
-  const int block = 256;
-  int grid        = (repr.num_rows + block - 1) / block;
+  const int block = kAlpDecodeBlock;
+  int const grid  = repr.num_vectors;
   alp_decode_kernel<T><<<grid, block, 0, stream.value()>>>(repr.integers()->view().data<int_t>(),
                                                            repr.metadata()->view().data<uint16_t>(),
                                                            repr.num_rows,

--- a/src/compression/simpatico_codegen/src/operators/alp_compressor.cu
+++ b/src/compression/simpatico_codegen/src/operators/alp_compressor.cu
@@ -47,10 +47,8 @@ namespace {
 // Vector size is fixed at 1024 (matches ALP & FastLanes; aligned with G-ALP).
 constexpr int kAlpVectorSize = 1024;
 
-// Scale-selection sample: kAlpSampleRuns contiguous runs of kAlpSampleRunLen,
-// spread evenly across the vector. The total must be a whole number of warps
-// (the selection phase shuffle-reduces with a full mask) and no larger than the
-// vector.
+// Scale-selection sample: contiguous runs spread evenly across the vector. The
+// total must be a whole number of warps and no larger than the vector.
 constexpr int kAlpSampleRuns   = 8;
 constexpr int kAlpSampleRunLen = 8;
 constexpr int kAlpSampleSize   = kAlpSampleRuns * kAlpSampleRunLen;  // 64 = 2 warps
@@ -63,16 +61,9 @@ static_assert(kAlpSampleSize <= kAlpVectorSize, "sample must fit in a vector");
 // alp_traits<T> selects between them via the static accessor methods below.
 // -----------------------------------------------------------------------------
 
-// The 10^k tables below are the ONLY scaling constants either direction uses,
-// and every entry is exactly representable in its float type (10^k is exact up
-// to k=10 in f32 and k=22 in f64, both beyond the ranges searched here). Encode
-// and decode therefore scale by multiplying and DIVIDING by exact powers of
-// ten, never by a rounded reciprocal 10^-k: `enc * 0.01` and `enc / 100.0`
-// differ by an ulp on ordinary decimal data, and since the encoder's
-// round-trip check rejects any value that does not reproduce bit-exactly, that
-// ulp turns into a stored exception. On TPC-H l_extendedprice as f64 the
-// reciprocal form flagged 13.83% of rows as exceptions; the division form
-// flags 0.00%.
+// Every 10^k below is exactly representable in its float type. Never scale by a
+// rounded reciprocal instead: `enc * 0.01` and `enc / 100.0` differ by an ulp,
+// and the encoder's bit-exact round-trip check turns that ulp into an exception.
 namespace host_consts_f32 {
 // FLOAT32: e ∈ [0..10], f ∈ [0..min(e, 9)].
 constexpr float kExp[11] = {1.0f,
@@ -116,10 +107,8 @@ constexpr double kExp[19] = {1e0,
 constexpr int kCandCount = 19;
 }  // namespace host_consts_f64
 
-// Exact power-of-ten tables for the fixed-point path. A DECIMAL column's
-// storage IS an integer mantissa, so its "scale search" is pure integer
-// arithmetic: divide by 10^d and check the division was exact. No float
-// constants, no rounding, no reciprocal.
+// Fixed-point path: a DECIMAL column's storage is already an integer mantissa,
+// so its scale search is integer division with an exactness check.
 constexpr int kP10I32Count = 10;  // 10^9 is the largest that fits int32
 constexpr int kP10I64Count = 19;  // 10^18 is the largest that fits int64
 __constant__ int32_t d_alp_p10_i32[kP10I32Count];
@@ -133,16 +122,12 @@ __constant__ double d_alp_exp_f64[19];
 __constant__ double d_alp_rhi_f64[19];
 __constant__ double d_alp_rlo_f64[19];
 
-// Unevaluated-sum ("double-double") split of 10^-k: rhi = fl(10^-k) and
-// rlo = fl(10^-k - rhi), so rhi + rlo carries roughly twice the working
-// precision. Scaling by a single rounded 10^-k is what inflated the exception
-// rate (see the note above the tables); dividing by the exact 10^k fixes that
-// but an FP64 divide is punishingly slow on parts with cut FP64 throughput.
-// fma(v, rhi, v * rlo) recovers the divide's accuracy at two multiply-class
-// ops. Note this only has to be ACCURATE, never provably exact: encode's
-// round-trip check evaluates the identical expression, so any value the
-// approximation cannot reproduce simply becomes a stored exception. Accuracy
-// buys ratio, not correctness.
+// Unevaluated-sum split of 10^-k: rhi + rlo carries roughly twice the working
+// precision, so fma(v, rhi, v * rlo) matches a divide by 10^k at two
+// multiply-class ops (FP64 divide is punishing on parts with cut FP64). This
+// only has to be accurate, not exact -- encode's round-trip check evaluates the
+// identical expression, so what it cannot reproduce becomes an exception.
+// Accuracy buys ratio, not correctness.
 template <typename Wide, typename Narrow>
 void fill_reciprocal_split(Narrow* rhi, Narrow* rlo, int count)
 {
@@ -277,11 +262,8 @@ struct alp_traits<double> {
   __device__ static value_t rlo_(int i) { return d_alp_rlo_f64[i]; }
 };
 
-// Fixed-point (DECIMAL32 / DECIMAL64) specialisations. `value_t == int_t`: the
-// column's storage is already the integer ALP would produce, so encoding is a
-// division by 10^d and the round-trip check is an exact-divisibility test.
-// `value_type_id` is only the storage id -- the compress path passes the
-// column's real data_type (carrying its scale) where the type matters.
+// Fixed-point specialisations; `value_t == int_t`. `value_type_id` is only the
+// storage id -- compress passes the column's real data_type, carrying its scale.
 template <>
 struct alp_traits<int32_t> {
   using value_t                                 = int32_t;
@@ -329,10 +311,7 @@ __device__ inline int64_t atomic_max(int64_t* a, int64_t v)
 }
 
 // -----------------------------------------------------------------------------
-// Full-warp shuffle reductions. __shfl_down_sync handles 64-bit operands
-// natively, so one template covers int32_t and int64_t. Callers must have all
-// 32 lanes of the warp active (the sampling loop below sizes its participant
-// count as a whole number of warps precisely so this holds).
+// Full-warp shuffle reductions; callers must have all 32 lanes active.
 // -----------------------------------------------------------------------------
 
 template <typename V>
@@ -385,11 +364,8 @@ __device__ inline typename alp_traits<T>::int_t alp_encode_value(T v, int d, boo
   using int_t  = typename traits::int_t;
 
   if constexpr (cuda::std::is_integral_v<T>) {
-    // Fixed-point path: the mantissa is already an integer, so "encoding at
-    // scale d" is dividing by 10^d and the round-trip is exact iff 10^d
-    // divides it. |q * p| <= |v| by construction, so the check cannot
-    // overflow. Truncation toward zero is the same on both signs, so a
-    // negative mantissa needs no special case.
+    // |q * p| <= |v| by construction, so the check cannot overflow, and
+    // truncation toward zero behaves the same on both signs.
     int_t const p = traits::p10_(d);
     int_t const q = v / p;
     is_exception  = (q * p != v);
@@ -399,13 +375,9 @@ __device__ inline typename alp_traits<T>::int_t alp_encode_value(T v, int d, boo
       is_exception = true;
       return 0;
     }
-    // ALP as published parameterises the scale by a pair (e, f) and encodes
-    // round(v * 10^e * 10^-f), decoding as i * 10^f * 10^-e -- but only the
-    // DIFFERENCE d = e - f ever affects the result, and the published combo
-    // table constrains f <= e so d is exactly the non-negative range swept here.
-    // Collapsing to d drops the f64 candidate set from 190 pairs to 19 scales
-    // with no loss of coverage, and scaling by the single exact 10^d rounds once
-    // instead of twice.
+    // Published ALP encodes round(v * 10^e * 10^-f), but only d = e - f affects
+    // the result and its combo table constrains f <= e, so sweeping d covers the
+    // same ground in 19 scales rather than 190 pairs.
     T tmp = v * traits::exp_(d);
     // Magic-number round-to-nearest-even.
     T rounded = (tmp + traits::magic) - traits::magic;
@@ -421,8 +393,8 @@ __device__ inline typename alp_traits<T>::int_t alp_encode_value(T v, int d, boo
   }
 }
 
-// Inverse of alp_encode_value. Kept as one function so encode's round-trip
-// check and the decode kernel can never drift apart.
+// Inverse of alp_encode_value. One function so encode's round-trip check and
+// the decode kernel cannot drift apart.
 template <typename T>
 __device__ inline T alp_decode_value(typename alp_traits<T>::int_t enc, int d)
 {
@@ -437,32 +409,12 @@ __device__ inline T alp_decode_value(typename alp_traits<T>::int_t enc, int d)
 
 // -----------------------------------------------------------------------------
 // Encode kernel: 1 block == 1 vector of 1024 values. blockDim.x == 1024.
-//
-// Two phases:
-//
-//   Selection -- the first kAlpSampleSize threads each hold one SAMPLED value
-//     and evaluate every candidate scale d on it, accumulating per-candidate
-//     (exc_count, min_enc, max_enc). Thread 0 then picks the d with the lowest
-//     cost (`vec_n * bitwidth + exc_count * exception_cost_bits`) and stores it
-//     into the metadata column.
-//
-//   Emit -- every thread re-encodes its own value with the winning d and writes
-//     (integer, exception_flag). This pass is exact and covers all 1024 values,
-//     so sampling only ever costs ratio (a slightly worse d), never correctness.
-//
-// Sampling is what makes the encoder affordable: scoring all 1024 values
-// against all candidates costs ~19k round-trip encodes per vector, each several
-// float multiplies, and on parts with cut FP64 throughput that dominates
-// everything. The published ALP algorithm samples too, for the same reason.
-//
-// The sample is kAlpSampleRuns contiguous runs spread evenly across the vector,
-// not a fixed stride: a stride can land on a period of the data (round-robin
-// sensor readings, interleaved currencies) and then observe only one phase of
-// it, picking a scale that suits a sixteenth of the rows.
-//
-// Within the selection phase the per-candidate accumulators are reduced across
-// each warp by shuffle first, so a candidate costs one shared atomic per warp
-// rather than one per participating thread.
+// Selection: the first kAlpSampleSize threads score every candidate scale d on
+// one sampled value each, warp-reducing per-candidate (exc_count, min_enc,
+// max_enc) before a single shared atomic; thread 0 picks the lowest-cost d
+// (`sample_n * bitwidth + exc_count * exception_cost_bits`) into the metadata
+// column. Emit: every thread re-encodes its own value with the winning d, so
+// sampling costs ratio (a worse d), never correctness.
 // -----------------------------------------------------------------------------
 template <typename T>
 __global__ void alp_encode_kernel(const T* __restrict__ in,
@@ -490,8 +442,7 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
   __shared__ uint16_t s_best_d;  // the winning scale exponent, stored verbatim
   __shared__ int_t s_fill;       // value written at exception slots
 
-  // Init the per-candidate accumulators. cand_count <= 1024 so the first
-  // `cand_count` threads cover the init in one pass.
+  // cand_count <= 1024, so the first cand_count threads init in one pass.
   if (tid < cand_count) {
     s_exc_count[tid] = 0u;
     s_min_enc[tid]   = traits::int_max;
@@ -499,10 +450,9 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
   }
   __syncthreads();
 
-  // Pick this thread's sample: kAlpSampleRuns contiguous runs spread evenly
-  // over the vector. Threads at or past kAlpSampleSize sit the phase out.
-  // Short vectors (the trailing partial one) collapse runs onto each other,
-  // which just resamples the same values -- harmless for a ranking.
+  // Contiguous runs, not a fixed stride: a stride can land on a period of the
+  // data and observe only one phase of it. A short trailing vector collapses
+  // runs onto each other, which merely resamples -- harmless for a ranking.
   bool const samples = (tid < kAlpSampleSize);
   T sv               = T{0};
   bool sv_valid      = false;
@@ -514,10 +464,8 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
     if (sv_valid) sv = in[vec_base + idx];
   }
 
-  // Score every candidate on the sample. Each warp reduces its own lanes by
-  // shuffle and contributes a single atomic per candidate; kAlpSampleSize is a
-  // whole number of warps so every lane in a participating warp is active and
-  // the full-mask shuffles below are well formed.
+  // kAlpSampleSize is a whole number of warps, so every lane in a participating
+  // warp is active and the full-mask shuffles below are well formed.
   if (samples) {
     int const lane = tid & 31;
     for (int c = 0; c < cand_count; ++c) {
@@ -525,8 +473,7 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
       int_t enc   = int_t{0};
       if (sv_valid) enc = alp_encode_value<T>(sv, c, is_exc);
 
-      // Non-participating lanes fold in as identities: they add 0 exceptions
-      // and contribute the neutral extremes to min/max.
+      // Non-participating lanes fold in as reduction identities.
       uint32_t const exc_bit = (sv_valid && is_exc) ? 1u : 0u;
       bool const counts      = (sv_valid && !is_exc);
       int_t const lo_in      = counts ? enc : traits::int_max;
@@ -549,10 +496,8 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
 
   // Single-thread cost-based selection. cand_count is small; full pass is fine.
   if (tid == 0) {
-    // Scored over the sample, so `sample_n` (not vec_n) is the population the
-    // exception counts are drawn from. Cost is proportional either way; what
-    // matters is that the bit-width term and the exception term are weighed
-    // against the same denominator.
+    // sample_n, not vec_n: both cost terms must share the denominator the
+    // exception counts were drawn from.
     uint32_t const sample_n = static_cast<uint32_t>(min(vec_n, kAlpSampleSize));
     uint64_t best_cost      = UINT64_MAX;
     int best                = 0;
@@ -580,24 +525,18 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
     }
     s_best_d          = static_cast<uint16_t>(best);
     out_metadata[vec] = s_best_d;
-    // Fill value for exception slots: the winning candidate's minimum encoded
-    // value, which is exactly the frame of reference a downstream bitpack will
-    // subtract. Writing 0 instead (the old behaviour) drags the chunk's range
-    // down to zero whenever the real values cluster away from it, so a single
-    // exception could cost ~30 bits per row on an otherwise narrow chunk --
-    // and it made the emitted buffer disagree with the bit-width this very
-    // cost model just scored. Being a sample minimum it may sit above the true
-    // vector minimum, but never below it, so it always lands inside the range
-    // bitpack will cover. s_min_enc keeps its int_max sentinel when every
-    // sampled value is an exception; 0 is as good as anything there.
+    // Exception slots take the winning candidate's minimum encoded value -- the
+    // frame of reference a downstream bitpack subtracts. Writing 0 instead would
+    // stretch the chunk's range whenever the real values cluster away from it.
+    // A sample minimum can sit above the true one but never below, so it always
+    // lands inside bitpack's range. int_max sentinel survives when every sampled
+    // value is an exception; 0 is as good as anything there.
     s_fill = (s_exc_count[best] < sample_n) ? s_min_enc[best] : int_t{0};
   }
   __syncthreads();
 
-  // Re-encode with the chosen scale. Exception positions get the fill value
-  // (the vector's minimum encoded value) so downstream bit-packing on the
-  // chunk stays tight; the real payload lives in the `exceptions` channel and
-  // is scattered back over these slots on decode.
+  // Exception slots carry the fill value; their real payload lives in the
+  // `exceptions` channel and is scattered back over them on decode.
   if (valid) {
     bool is_exc;
     int_t enc                    = alp_encode_value<T>(v, static_cast<int>(s_best_d), is_exc);
@@ -789,8 +728,7 @@ std::unique_ptr<compressed_representation> alp_compressor::compress(
   switch (dt.id()) {
     case cudf::type_id::FLOAT32: return alp_compress_impl<float>(column_to_compress, stream, mr);
     case cudf::type_id::FLOAT64: return alp_compress_impl<double>(column_to_compress, stream, mr);
-    // DECIMAL128's mantissa is __int128; there is no power-of-ten table or
-    // atomic support for it here, so it stays out.
+    // DECIMAL128 stays out: its mantissa is __int128, with no table or atomics.
     case cudf::type_id::DECIMAL32:
       return alp_compress_impl<int32_t>(column_to_compress, stream, mr);
     case cudf::type_id::DECIMAL64:

--- a/src/compression/simpatico_codegen/src/operators/alp_compressor.cu
+++ b/src/compression/simpatico_codegen/src/operators/alp_compressor.cu
@@ -7,9 +7,9 @@
 //   integers             INT32  (f32 input) / INT64 (f64 input) — main payload
 //   exceptions           FLOAT32 / FLOAT64 — raw values that failed lossless encode
 //   exception_positions  INT32  — global row indices of exceptions
-//   metadata             UINT16 — one per 1024-vector: (exp_idx << 8) | fac_idx
+//   metadata             UINT16 — one per 1024-vector: the scale exponent d
 //
-// Decode: v[i] = integers[i] * 10^f / 10^e; then scatter exceptions.
+// Decode: v[i] = integers[i] * 10^-d; then scatter exceptions.
 //
 // Implementation note: the kernels and host orchestrator are templated on
 // the float type T; per-type constants live in __constant__ symbols selected
@@ -52,150 +52,94 @@ constexpr int kAlpVectorSize = 1024;
 // alp_traits<T> selects between them via the static accessor methods below.
 // -----------------------------------------------------------------------------
 
+// The 10^k tables below are the ONLY scaling constants either direction uses,
+// and every entry is exactly representable in its float type (10^k is exact up
+// to k=10 in f32 and k=22 in f64, both beyond the ranges searched here). Encode
+// and decode therefore scale by multiplying and DIVIDING by exact powers of
+// ten, never by a rounded reciprocal 10^-k: `enc * 0.01` and `enc / 100.0`
+// differ by an ulp on ordinary decimal data, and since the encoder's
+// round-trip check rejects any value that does not reproduce bit-exactly, that
+// ulp turns into a stored exception. On TPC-H l_extendedprice as f64 the
+// reciprocal form flagged 13.83% of rows as exceptions; the division form
+// flags 0.00%.
 namespace host_consts_f32 {
-// FLOAT32: e ∈ [0..10], f ∈ [0..min(e, 9)]. FACT has 10 entries because
-// 10^10 doesn't fit in int32.
-constexpr float kExp[11]    = {1.0f,
-                               10.0f,
-                               100.0f,
-                               1000.0f,
-                               10000.0f,
-                               100000.0f,
-                               1000000.0f,
-                               10000000.0f,
-                               100000000.0f,
-                               1000000000.0f,
-                               10000000000.0f};
-constexpr float kFrac[11]   = {1.0f,
-                               0.1f,
-                               0.01f,
-                               0.001f,
-                               0.0001f,
-                               0.00001f,
-                               0.000001f,
-                               0.0000001f,
-                               0.00000001f,
-                               0.000000001f,
-                               0.0000000001f};
-constexpr int32_t kFact[10] = {
-  1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000};
-constexpr int kMaxExp  = 10;
-constexpr int kMaxFrac = 9;
-// 1+2+...+10 + 10 = 65 combos.
-constexpr int kComboCount = 65;
+// FLOAT32: e ∈ [0..10], f ∈ [0..min(e, 9)].
+constexpr float kExp[11] = {1.0f,
+                            10.0f,
+                            100.0f,
+                            1000.0f,
+                            10000.0f,
+                            100000.0f,
+                            1000000.0f,
+                            10000000.0f,
+                            100000000.0f,
+                            1000000000.0f,
+                            10000000000.0f};
+// Candidate scales are 10^d for d in [0..10]; see alp_encode_value for why the
+// paper's (e, f) pair collapses to their difference.
+constexpr int kCandCount = 11;
 }  // namespace host_consts_f32
 
 namespace host_consts_f64 {
-// FLOAT64: e ∈ [0..18], f ∈ [0..min(e, 18)]. FACT goes up to 10^18 (fits in
-// int64; max int64 ≈ 9.22e18).
-constexpr double kExp[19]   = {1e0,
-                               1e1,
-                               1e2,
-                               1e3,
-                               1e4,
-                               1e5,
-                               1e6,
-                               1e7,
-                               1e8,
-                               1e9,
-                               1e10,
-                               1e11,
-                               1e12,
-                               1e13,
-                               1e14,
-                               1e15,
-                               1e16,
-                               1e17,
-                               1e18};
-constexpr double kFrac[19]  = {1e-0,
-                               1e-1,
-                               1e-2,
-                               1e-3,
-                               1e-4,
-                               1e-5,
-                               1e-6,
-                               1e-7,
-                               1e-8,
-                               1e-9,
-                               1e-10,
-                               1e-11,
-                               1e-12,
-                               1e-13,
-                               1e-14,
-                               1e-15,
-                               1e-16,
-                               1e-17,
-                               1e-18};
-constexpr int64_t kFact[19] = {1LL,
-                               10LL,
-                               100LL,
-                               1000LL,
-                               10000LL,
-                               100000LL,
-                               1000000LL,
-                               10000000LL,
-                               100000000LL,
-                               1000000000LL,
-                               10000000000LL,
-                               100000000000LL,
-                               1000000000000LL,
-                               10000000000000LL,
-                               100000000000000LL,
-                               1000000000000000LL,
-                               10000000000000000LL,
-                               100000000000000000LL,
-                               1000000000000000000LL};
-constexpr int kMaxExp       = 18;
-constexpr int kMaxFrac      = 18;
-// 1+2+...+19 = 190 combos.
-constexpr int kComboCount = 190;
+// FLOAT64: e ∈ [0..18], f ∈ [0..min(e, 18)].
+constexpr double kExp[19] = {1e0,
+                             1e1,
+                             1e2,
+                             1e3,
+                             1e4,
+                             1e5,
+                             1e6,
+                             1e7,
+                             1e8,
+                             1e9,
+                             1e10,
+                             1e11,
+                             1e12,
+                             1e13,
+                             1e14,
+                             1e15,
+                             1e16,
+                             1e17,
+                             1e18};
+// Candidate scales are 10^d for d in [0..18].
+constexpr int kCandCount = 19;
 }  // namespace host_consts_f64
 
 __constant__ float d_alp_exp_f32[11];
-__constant__ float d_alp_frac_f32[11];
-__constant__ int32_t d_alp_fact_f32[10];
-__constant__ uint8_t d_alp_combos_f32[host_consts_f32::kComboCount];
+__constant__ float d_alp_rhi_f32[11];
+__constant__ float d_alp_rlo_f32[11];
 
 __constant__ double d_alp_exp_f64[19];
-__constant__ double d_alp_frac_f64[19];
-__constant__ int64_t d_alp_fact_f64[19];
-__constant__ uint8_t d_alp_combos_f64[host_consts_f64::kComboCount];
+__constant__ double d_alp_rhi_f64[19];
+__constant__ double d_alp_rlo_f64[19];
+
+// Unevaluated-sum ("double-double") split of 10^-k: rhi = fl(10^-k) and
+// rlo = fl(10^-k - rhi), so rhi + rlo carries roughly twice the working
+// precision. Scaling by a single rounded 10^-k is what inflated the exception
+// rate (see the note above the tables); dividing by the exact 10^k fixes that
+// but an FP64 divide is punishingly slow on parts with cut FP64 throughput.
+// fma(v, rhi, v * rlo) recovers the divide's accuracy at two multiply-class
+// ops. Note this only has to be ACCURATE, never provably exact: encode's
+// round-trip check evaluates the identical expression, so any value the
+// approximation cannot reproduce simply becomes a stored exception. Accuracy
+// buys ratio, not correctness.
+template <typename Wide, typename Narrow>
+void fill_reciprocal_split(Narrow* rhi, Narrow* rlo, int count)
+{
+  Wide p = Wide{1};
+  for (int k = 0; k < count; ++k) {
+    Wide const r = Wide{1} / p;
+    rhi[k]       = static_cast<Narrow>(r);
+    rlo[k]       = static_cast<Narrow>(r - static_cast<Wide>(rhi[k]));
+    p *= Wide{10};
+  }
+}
 
 // One-shot initialisation of both __constant__ table sets. Idempotent.
 // Uploads run async on the caller's stream and are bounded by a single
 // stream sync, avoiding the legacy default stream entirely.
 void alp_upload_constants(rmm::cuda_stream_view stream)
 {
-  // Build packed combo tables on the host then upload.
-  uint8_t combos_f32[host_consts_f32::kComboCount];
-  {
-    int idx = 0;
-    for (uint8_t e = 0; e <= host_consts_f32::kMaxExp; ++e) {
-      uint8_t f_max = (e <= host_consts_f32::kMaxFrac) ? e : host_consts_f32::kMaxFrac;
-      for (uint8_t f = 0; f <= f_max; ++f) {
-        combos_f32[idx++] = static_cast<uint8_t>((e << 4) | f);
-      }
-    }
-    if (idx != host_consts_f32::kComboCount) {
-      throw std::runtime_error("alp: f32 combo table size mismatch");
-    }
-  }
-  uint8_t combos_f64[host_consts_f64::kComboCount];
-  {
-    int idx = 0;
-    for (uint8_t e = 0; e <= host_consts_f64::kMaxExp; ++e) {
-      uint8_t f_max = (e <= host_consts_f64::kMaxFrac) ? e : host_consts_f64::kMaxFrac;
-      for (uint8_t f = 0; f <= f_max; ++f) {
-        // Pack (e << 5) | f. Both e and f are ≤ 18 < 32 so 5 bits each fit
-        // in a uint8_t. f32 uses (e << 4) | f because both ≤ 10 there.
-        combos_f64[idx++] = static_cast<uint8_t>((e << 5) | f);
-      }
-    }
-    if (idx != host_consts_f64::kComboCount) {
-      throw std::runtime_error("alp: f64 combo table size mismatch");
-    }
-  }
-
   auto const s = stream.value();
   cudaMemcpyToSymbolAsync(d_alp_exp_f32,
                           host_consts_f32::kExp,
@@ -203,20 +147,10 @@ void alp_upload_constants(rmm::cuda_stream_view stream)
                           0,
                           cudaMemcpyHostToDevice,
                           s);
-  cudaMemcpyToSymbolAsync(d_alp_frac_f32,
-                          host_consts_f32::kFrac,
-                          sizeof(host_consts_f32::kFrac),
-                          0,
-                          cudaMemcpyHostToDevice,
-                          s);
-  cudaMemcpyToSymbolAsync(d_alp_fact_f32,
-                          host_consts_f32::kFact,
-                          sizeof(host_consts_f32::kFact),
-                          0,
-                          cudaMemcpyHostToDevice,
-                          s);
-  cudaMemcpyToSymbolAsync(
-    d_alp_combos_f32, combos_f32, sizeof(combos_f32), 0, cudaMemcpyHostToDevice, s);
+  float rhi_f32[11], rlo_f32[11];
+  fill_reciprocal_split<double, float>(rhi_f32, rlo_f32, 11);
+  cudaMemcpyToSymbolAsync(d_alp_rhi_f32, rhi_f32, sizeof(rhi_f32), 0, cudaMemcpyHostToDevice, s);
+  cudaMemcpyToSymbolAsync(d_alp_rlo_f32, rlo_f32, sizeof(rlo_f32), 0, cudaMemcpyHostToDevice, s);
 
   cudaMemcpyToSymbolAsync(d_alp_exp_f64,
                           host_consts_f64::kExp,
@@ -224,20 +158,10 @@ void alp_upload_constants(rmm::cuda_stream_view stream)
                           0,
                           cudaMemcpyHostToDevice,
                           s);
-  cudaMemcpyToSymbolAsync(d_alp_frac_f64,
-                          host_consts_f64::kFrac,
-                          sizeof(host_consts_f64::kFrac),
-                          0,
-                          cudaMemcpyHostToDevice,
-                          s);
-  cudaMemcpyToSymbolAsync(d_alp_fact_f64,
-                          host_consts_f64::kFact,
-                          sizeof(host_consts_f64::kFact),
-                          0,
-                          cudaMemcpyHostToDevice,
-                          s);
-  cudaMemcpyToSymbolAsync(
-    d_alp_combos_f64, combos_f64, sizeof(combos_f64), 0, cudaMemcpyHostToDevice, s);
+  double rhi_f64[19], rlo_f64[19];
+  fill_reciprocal_split<long double, double>(rhi_f64, rlo_f64, 19);
+  cudaMemcpyToSymbolAsync(d_alp_rhi_f64, rhi_f64, sizeof(rhi_f64), 0, cudaMemcpyHostToDevice, s);
+  cudaMemcpyToSymbolAsync(d_alp_rlo_f64, rlo_f64, sizeof(rlo_f64), 0, cudaMemcpyHostToDevice, s);
 
   // Constants must be visible before any kernel that reads them runs; the
   // upload is host-side one-time work so a bounded sync here is acceptable.
@@ -279,7 +203,7 @@ struct alp_traits<float> {
   using uint_t                                 = uint32_t;
   static constexpr cudf::type_id value_type_id = cudf::type_id::FLOAT32;
   static constexpr cudf::type_id int_type_id   = cudf::type_id::INT32;
-  static constexpr int combo_count             = host_consts_f32::kComboCount;
+  static constexpr int cand_count              = host_consts_f32::kCandCount;
   static constexpr value_t magic               = 12582912.0f;    // 2^23 + 2^22
   static constexpr value_t safe_max            = 2147483520.0f;  // ≈ INT32_MAX, f32-representable
   static constexpr value_t safe_min            = -2147483520.0f;
@@ -290,14 +214,8 @@ struct alp_traits<float> {
   // Exception cost: payload (32) + position (16) bits per exception.
   static constexpr uint32_t exception_cost_bits = 32 + 16;
   __device__ static value_t exp_(int i) { return d_alp_exp_f32[i]; }
-  __device__ static value_t frac_(int i) { return d_alp_frac_f32[i]; }
-  __device__ static int_t fact_(int i) { return d_alp_fact_f32[i]; }
-  __device__ static void unpack_combo(int c, uint8_t& e, uint8_t& f)
-  {
-    uint8_t packed = d_alp_combos_f32[c];
-    e              = packed >> 4;
-    f              = packed & 0xF;
-  }
+  __device__ static value_t rhi_(int i) { return d_alp_rhi_f32[i]; }
+  __device__ static value_t rlo_(int i) { return d_alp_rlo_f32[i]; }
 };
 
 template <>
@@ -307,7 +225,7 @@ struct alp_traits<double> {
   using uint_t                                 = uint64_t;
   static constexpr cudf::type_id value_type_id = cudf::type_id::FLOAT64;
   static constexpr cudf::type_id int_type_id   = cudf::type_id::INT64;
-  static constexpr int combo_count             = host_consts_f64::kComboCount;
+  static constexpr int cand_count              = host_consts_f64::kCandCount;
   // 2^52 + 2^51. Adding/subtracting forces IEEE round-to-nearest-even into
   // the mantissa truncation, producing CPU-identical encoded integers.
   static constexpr value_t magic = 6755399441055744.0;
@@ -322,14 +240,8 @@ struct alp_traits<double> {
   // Exception cost: 64-bit payload + 16-bit position.
   static constexpr uint32_t exception_cost_bits = 64 + 16;
   __device__ static value_t exp_(int i) { return d_alp_exp_f64[i]; }
-  __device__ static value_t frac_(int i) { return d_alp_frac_f64[i]; }
-  __device__ static int_t fact_(int i) { return d_alp_fact_f64[i]; }
-  __device__ static void unpack_combo(int c, uint8_t& e, uint8_t& f)
-  {
-    uint8_t packed = d_alp_combos_f64[c];
-    e              = packed >> 5;
-    f              = packed & 0x1F;
-  }
+  __device__ static value_t rhi_(int i) { return d_alp_rhi_f64[i]; }
+  __device__ static value_t rlo_(int i) { return d_alp_rlo_f64[i]; }
 };
 
 // -----------------------------------------------------------------------------
@@ -364,10 +276,7 @@ __device__ inline int bits_for_range_u64(uint64_t range)
 // `is_exception` when the round-trip check fails (or the input is non-finite,
 // ±Inf, NaN, -0.0, or overflows the safe-integer range when scaled).
 template <typename T>
-__device__ inline typename alp_traits<T>::int_t alp_encode_value(T v,
-                                                                 uint8_t e,
-                                                                 uint8_t f,
-                                                                 bool& is_exception)
+__device__ inline typename alp_traits<T>::int_t alp_encode_value(T v, int d, bool& is_exception)
 {
   using traits = alp_traits<T>;
   using int_t  = typename traits::int_t;
@@ -375,7 +284,14 @@ __device__ inline typename alp_traits<T>::int_t alp_encode_value(T v,
     is_exception = true;
     return 0;
   }
-  T tmp = v * traits::exp_(e) * traits::frac_(f);
+  // ALP as published parameterises the scale by a pair (e, f) and encodes
+  // round(v * 10^e * 10^-f), decoding as i * 10^f * 10^-e -- but only the
+  // DIFFERENCE d = e - f ever affects the result, and the published combo
+  // table constrains f <= e so d is exactly the non-negative range swept here.
+  // Collapsing to d drops the f64 candidate set from 190 pairs to 19 scales
+  // with no loss of coverage, and scaling by the single exact 10^d rounds once
+  // instead of twice.
+  T tmp = v * traits::exp_(d);
   // Magic-number round-to-nearest-even.
   T rounded = (tmp + traits::magic) - traits::magic;
   if (!isfinite(rounded) || rounded > traits::safe_max || rounded < traits::safe_min) {
@@ -383,22 +299,22 @@ __device__ inline typename alp_traits<T>::int_t alp_encode_value(T v,
     return 0;
   }
   int_t enc = static_cast<int_t>(rounded);
-  // Round-trip check: decode and compare bit-exactly. The cast-back-to-T after
-  // the integer multiply matches CPU ALP (it forces single/double rounding to
-  // happen in the same order on both sides).
-  T decoded    = static_cast<T>(enc * traits::fact_(f)) * traits::frac_(e);
+  // Round-trip check: decode with the EXACT same expression as
+  // alp_decode_kernel and compare bit-exactly.
+  T const encd = static_cast<T>(enc);
+  T decoded    = fma(encd, traits::rhi_(d), encd * traits::rlo_(d));
   is_exception = (decoded != v);
   return enc;
 }
 
 // -----------------------------------------------------------------------------
 // Encode kernel: 1 block == 1 vector of 1024 values. blockDim.x == 1024.
-// Each thread handles one value. For each candidate (e, f) the threads
-// atomically update per-combo (exc_count, min_enc, max_enc) in shared mem;
-// thread 0 then picks the combo with the lowest cost
-// (`vec_n * bitwidth + exc_count * exception_cost_bits`) and stores the
-// chosen (e, f) into the metadata column. Finally every thread re-encodes
-// its value with the winning (e, f) and writes (integer, exception_flag).
+// Each thread handles one value. For each candidate scale d the threads
+// atomically update per-candidate (exc_count, min_enc, max_enc) in shared mem;
+// thread 0 then picks the d with the lowest cost
+// (`vec_n * bitwidth + exc_count * exception_cost_bits`) and stores it into the
+// metadata column. Finally every thread re-encodes its value with the winning
+// d and writes (integer, exception_flag).
 // -----------------------------------------------------------------------------
 template <typename T>
 __global__ void alp_encode_kernel(const T* __restrict__ in,
@@ -407,9 +323,9 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
                                   uint16_t* __restrict__ out_metadata,
                                   uint8_t* __restrict__ out_exception_flag)
 {
-  using traits              = alp_traits<T>;
-  using int_t               = typename traits::int_t;
-  constexpr int combo_count = traits::combo_count;
+  using traits             = alp_traits<T>;
+  using int_t              = typename traits::int_t;
+  constexpr int cand_count = traits::cand_count;
 
   int vec      = blockIdx.x;
   int tid      = threadIdx.x;
@@ -419,30 +335,28 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
 
   int vec_n = min(n_rows - vec * kAlpVectorSize, kAlpVectorSize);
 
-  __shared__ uint32_t s_exc_count[combo_count];
-  __shared__ int_t s_min_enc[combo_count];
-  __shared__ int_t s_max_enc[combo_count];
-  __shared__ uint16_t s_best_md;  // (e << 8) | f
+  __shared__ uint32_t s_exc_count[cand_count];
+  __shared__ int_t s_min_enc[cand_count];
+  __shared__ int_t s_max_enc[cand_count];
+  __shared__ uint16_t s_best_d;  // the winning scale exponent, stored verbatim
+  __shared__ int_t s_fill;       // value written at exception slots
 
-  // Init the per-combo accumulators. combo_count ≤ 1024 so the first
-  // `combo_count` threads cover the init in one pass.
-  if (tid < combo_count) {
+  // Init the per-candidate accumulators. cand_count <= 1024 so the first
+  // `cand_count` threads cover the init in one pass.
+  if (tid < cand_count) {
     s_exc_count[tid] = 0u;
     s_min_enc[tid]   = traits::int_max;
     s_max_enc[tid]   = traits::int_min;
   }
   __syncthreads();
 
-  // Sweep candidates. Atomic contention is per-combo across the block; for
+  // Sweep candidates. Atomic contention is per-candidate across the block; for
   // typical inputs most threads hit the same min/max paths so this is
   // dominated by atomic latency, not contention.
-  for (int c = 0; c < combo_count; ++c) {
-    uint8_t e, f;
-    traits::unpack_combo(c, e, f);
-
+  for (int c = 0; c < cand_count; ++c) {
     if (valid) {
       bool is_exc;
-      int_t enc = alp_encode_value<T>(v, e, f, is_exc);
+      int_t enc = alp_encode_value<T>(v, c, is_exc);
       if (is_exc) {
         atomicAdd(&s_exc_count[c], 1u);
       } else {
@@ -453,11 +367,11 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
   }
   __syncthreads();
 
-  // Single-thread cost-based selection. combo_count is small; full pass is fine.
+  // Single-thread cost-based selection. cand_count is small; full pass is fine.
   if (tid == 0) {
     uint64_t best_cost = UINT64_MAX;
     int best           = 0;
-    for (int c = 0; c < combo_count; ++c) {
+    for (int c = 0; c < cand_count; ++c) {
       uint32_t exc     = s_exc_count[c];
       uint32_t non_exc = static_cast<uint32_t>(vec_n) - exc;
       uint32_t bits    = 0;
@@ -479,21 +393,28 @@ __global__ void alp_encode_kernel(const T* __restrict__ in,
         best      = c;
       }
     }
-    uint8_t best_e, best_f;
-    traits::unpack_combo(best, best_e, best_f);
-    s_best_md         = (static_cast<uint16_t>(best_e) << 8) | best_f;
-    out_metadata[vec] = s_best_md;
+    s_best_d          = static_cast<uint16_t>(best);
+    out_metadata[vec] = s_best_d;
+    // Fill value for exception slots: the winning candidate's minimum encoded
+    // value, which is exactly the frame of reference a downstream bitpack will
+    // subtract. Writing 0 instead (the old behaviour) drags the chunk's range
+    // down to zero whenever the real values cluster away from it, so a single
+    // exception could cost ~30 bits per row on an otherwise narrow chunk --
+    // and it made the emitted buffer disagree with the bit-width this very
+    // cost model just scored. s_min_enc keeps its int_max sentinel when every
+    // value in the vector is an exception; 0 is as good as anything there.
+    s_fill = (s_exc_count[best] < static_cast<uint32_t>(vec_n)) ? s_min_enc[best] : int_t{0};
   }
   __syncthreads();
 
-  // Re-encode with the chosen (e, f). For exception positions we write 0 to
-  // `integers` so downstream bit-packing on the chunk stays tight.
+  // Re-encode with the chosen scale. Exception positions get the fill value
+  // (the vector's minimum encoded value) so downstream bit-packing on the
+  // chunk stays tight; the real payload lives in the `exceptions` channel and
+  // is scattered back over these slots on decode.
   if (valid) {
-    uint8_t best_e = static_cast<uint8_t>(s_best_md >> 8);
-    uint8_t best_f = static_cast<uint8_t>(s_best_md & 0xFF);
     bool is_exc;
-    int_t enc                    = alp_encode_value<T>(v, best_e, best_f, is_exc);
-    out_integers[global_i]       = is_exc ? int_t{0} : enc;
+    int_t enc                    = alp_encode_value<T>(v, static_cast<int>(s_best_d), is_exc);
+    out_integers[global_i]       = is_exc ? s_fill : enc;
     out_exception_flag[global_i] = is_exc ? 1u : 0u;
   }
 }
@@ -512,13 +433,13 @@ __global__ void alp_decode_kernel(const typename alp_traits<T>::int_t* __restric
   int i        = blockIdx.x * blockDim.x + threadIdx.x;
   if (i >= n_rows) return;
   int vec     = i / kAlpVectorSize;
-  uint16_t md = metadata[vec];
-  uint8_t e   = static_cast<uint8_t>(md >> 8);
-  uint8_t f   = static_cast<uint8_t>(md & 0xFF);
+  int const d = static_cast<int>(metadata[vec]);
   auto enc    = integers[i];
-  // v = enc * 10^f / 10^e. The cast-to-T forces the integer multiply to land
-  // in the target precision before the final scaling, matching CPU ALP.
-  out[i] = static_cast<T>(enc * traits::fact_(f)) * traits::frac_(e);
+  // v = enc * 10^-d, evaluated through the double-double reciprocal so a single
+  // rounded 10^-d never costs us an exception. Must stay bit-identical to the
+  // round-trip check in alp_encode_value.
+  T const encd = static_cast<T>(enc);
+  out[i]       = fma(encd, traits::rhi_(d), encd * traits::rlo_(d));
 }
 
 // Exception scatter: fully data-parallel (G-ALP's key GPU optimisation).

--- a/src/compression/simpatico_codegen/src/operators/alp_compressor.cu
+++ b/src/compression/simpatico_codegen/src/operators/alp_compressor.cu
@@ -29,6 +29,7 @@
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
+#include <cuda/std/type_traits>
 #include <cuda_runtime.h>
 
 #include <cmath>
@@ -115,6 +116,15 @@ constexpr double kExp[19] = {1e0,
 constexpr int kCandCount = 19;
 }  // namespace host_consts_f64
 
+// Exact power-of-ten tables for the fixed-point path. A DECIMAL column's
+// storage IS an integer mantissa, so its "scale search" is pure integer
+// arithmetic: divide by 10^d and check the division was exact. No float
+// constants, no rounding, no reciprocal.
+constexpr int kP10I32Count = 10;  // 10^9 is the largest that fits int32
+constexpr int kP10I64Count = 19;  // 10^18 is the largest that fits int64
+__constant__ int32_t d_alp_p10_i32[kP10I32Count];
+__constant__ int64_t d_alp_p10_i64[kP10I64Count];
+
 __constant__ float d_alp_exp_f32[11];
 __constant__ float d_alp_rhi_f32[11];
 __constant__ float d_alp_rlo_f32[11];
@@ -150,7 +160,20 @@ void fill_reciprocal_split(Narrow* rhi, Narrow* rlo, int count)
 // stream sync, avoiding the legacy default stream entirely.
 void alp_upload_constants(rmm::cuda_stream_view stream)
 {
+  int32_t p10_i32[kP10I32Count];
+  int64_t p10_i64[kP10I64Count];
+  {
+    int32_t p32 = 1;
+    for (int k = 0; k < kP10I32Count; ++k, p32 *= 10)
+      p10_i32[k] = p32;
+    int64_t p64 = 1;
+    for (int k = 0; k < kP10I64Count; ++k, p64 *= 10)
+      p10_i64[k] = p64;
+  }
+
   auto const s = stream.value();
+  cudaMemcpyToSymbolAsync(d_alp_p10_i32, p10_i32, sizeof(p10_i32), 0, cudaMemcpyHostToDevice, s);
+  cudaMemcpyToSymbolAsync(d_alp_p10_i64, p10_i64, sizeof(p10_i64), 0, cudaMemcpyHostToDevice, s);
   cudaMemcpyToSymbolAsync(d_alp_exp_f32,
                           host_consts_f32::kExp,
                           sizeof(host_consts_f32::kExp),
@@ -254,6 +277,39 @@ struct alp_traits<double> {
   __device__ static value_t rlo_(int i) { return d_alp_rlo_f64[i]; }
 };
 
+// Fixed-point (DECIMAL32 / DECIMAL64) specialisations. `value_t == int_t`: the
+// column's storage is already the integer ALP would produce, so encoding is a
+// division by 10^d and the round-trip check is an exact-divisibility test.
+// `value_type_id` is only the storage id -- the compress path passes the
+// column's real data_type (carrying its scale) where the type matters.
+template <>
+struct alp_traits<int32_t> {
+  using value_t                                 = int32_t;
+  using int_t                                   = int32_t;
+  using uint_t                                  = uint32_t;
+  static constexpr cudf::type_id value_type_id  = cudf::type_id::DECIMAL32;
+  static constexpr cudf::type_id int_type_id    = cudf::type_id::INT32;
+  static constexpr int cand_count               = kP10I32Count;
+  static constexpr int_t int_max                = 0x7FFFFFFF;
+  static constexpr int_t int_min                = static_cast<int_t>(0x80000000);
+  static constexpr uint32_t exception_cost_bits = 32 + 16;
+  __device__ static int_t p10_(int i) { return d_alp_p10_i32[i]; }
+};
+
+template <>
+struct alp_traits<int64_t> {
+  using value_t                                 = int64_t;
+  using int_t                                   = int64_t;
+  using uint_t                                  = uint64_t;
+  static constexpr cudf::type_id value_type_id  = cudf::type_id::DECIMAL64;
+  static constexpr cudf::type_id int_type_id    = cudf::type_id::INT64;
+  static constexpr int cand_count               = kP10I64Count;
+  static constexpr int_t int_max                = 0x7FFFFFFFFFFFFFFFLL;
+  static constexpr int_t int_min                = static_cast<int_t>(0x8000000000000000ULL);
+  static constexpr uint32_t exception_cost_bits = 64 + 16;
+  __device__ static int_t p10_(int i) { return d_alp_p10_i64[i]; }
+};
+
 // -----------------------------------------------------------------------------
 // Atomic min/max overloads. CUDA's atomicMin/atomicMax for 64-bit ints want
 // `long long*`, which is not the same type as int64_t on every platform.
@@ -320,35 +376,63 @@ __device__ inline int bits_for_range_u64(uint64_t range)
 // `is_exception` when the round-trip check fails (or the input is non-finite,
 // ±Inf, NaN, -0.0, or overflows the safe-integer range when scaled).
 template <typename T>
+__device__ inline T alp_decode_value(typename alp_traits<T>::int_t enc, int d);
+
+template <typename T>
 __device__ inline typename alp_traits<T>::int_t alp_encode_value(T v, int d, bool& is_exception)
 {
   using traits = alp_traits<T>;
   using int_t  = typename traits::int_t;
-  if (!isfinite(v) || (v == T{0} && signbit(v))) {
-    is_exception = true;
-    return 0;
+
+  if constexpr (cuda::std::is_integral_v<T>) {
+    // Fixed-point path: the mantissa is already an integer, so "encoding at
+    // scale d" is dividing by 10^d and the round-trip is exact iff 10^d
+    // divides it. |q * p| <= |v| by construction, so the check cannot
+    // overflow. Truncation toward zero is the same on both signs, so a
+    // negative mantissa needs no special case.
+    int_t const p = traits::p10_(d);
+    int_t const q = v / p;
+    is_exception  = (q * p != v);
+    return q;
+  } else {
+    if (!isfinite(v) || (v == T{0} && signbit(v))) {
+      is_exception = true;
+      return 0;
+    }
+    // ALP as published parameterises the scale by a pair (e, f) and encodes
+    // round(v * 10^e * 10^-f), decoding as i * 10^f * 10^-e -- but only the
+    // DIFFERENCE d = e - f ever affects the result, and the published combo
+    // table constrains f <= e so d is exactly the non-negative range swept here.
+    // Collapsing to d drops the f64 candidate set from 190 pairs to 19 scales
+    // with no loss of coverage, and scaling by the single exact 10^d rounds once
+    // instead of twice.
+    T tmp = v * traits::exp_(d);
+    // Magic-number round-to-nearest-even.
+    T rounded = (tmp + traits::magic) - traits::magic;
+    if (!isfinite(rounded) || rounded > traits::safe_max || rounded < traits::safe_min) {
+      is_exception = true;
+      return 0;
+    }
+    int_t enc = static_cast<int_t>(rounded);
+    // Round-trip check: decode with the EXACT same expression as
+    // alp_decode_kernel and compare bit-exactly.
+    is_exception = (alp_decode_value<T>(enc, d) != v);
+    return enc;
   }
-  // ALP as published parameterises the scale by a pair (e, f) and encodes
-  // round(v * 10^e * 10^-f), decoding as i * 10^f * 10^-e -- but only the
-  // DIFFERENCE d = e - f ever affects the result, and the published combo
-  // table constrains f <= e so d is exactly the non-negative range swept here.
-  // Collapsing to d drops the f64 candidate set from 190 pairs to 19 scales
-  // with no loss of coverage, and scaling by the single exact 10^d rounds once
-  // instead of twice.
-  T tmp = v * traits::exp_(d);
-  // Magic-number round-to-nearest-even.
-  T rounded = (tmp + traits::magic) - traits::magic;
-  if (!isfinite(rounded) || rounded > traits::safe_max || rounded < traits::safe_min) {
-    is_exception = true;
-    return 0;
+}
+
+// Inverse of alp_encode_value. Kept as one function so encode's round-trip
+// check and the decode kernel can never drift apart.
+template <typename T>
+__device__ inline T alp_decode_value(typename alp_traits<T>::int_t enc, int d)
+{
+  using traits = alp_traits<T>;
+  if constexpr (cuda::std::is_integral_v<T>) {
+    return enc * traits::p10_(d);
+  } else {
+    T const encd = static_cast<T>(enc);
+    return fma(encd, traits::rhi_(d), encd * traits::rlo_(d));
   }
-  int_t enc = static_cast<int_t>(rounded);
-  // Round-trip check: decode with the EXACT same expression as
-  // alp_decode_kernel and compare bit-exactly.
-  T const encd = static_cast<T>(enc);
-  T decoded    = fma(encd, traits::rhi_(d), encd * traits::rlo_(d));
-  is_exception = (decoded != v);
-  return enc;
 }
 
 // -----------------------------------------------------------------------------
@@ -532,17 +616,11 @@ __global__ void alp_decode_kernel(const typename alp_traits<T>::int_t* __restric
                                   int32_t n_rows,
                                   T* __restrict__ out)
 {
-  using traits = alp_traits<T>;
-  int i        = blockIdx.x * blockDim.x + threadIdx.x;
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i >= n_rows) return;
-  int vec     = i / kAlpVectorSize;
-  int const d = static_cast<int>(metadata[vec]);
-  auto enc    = integers[i];
-  // v = enc * 10^-d, evaluated through the double-double reciprocal so a single
-  // rounded 10^-d never costs us an exception. Must stay bit-identical to the
-  // round-trip check in alp_encode_value.
-  T const encd = static_cast<T>(enc);
-  out[i]       = fma(encd, traits::rhi_(d), encd * traits::rlo_(d));
+  int const vec = i / kAlpVectorSize;
+  int const d   = static_cast<int>(metadata[vec]);
+  out[i]        = alp_decode_value<T>(integers[i], d);
 }
 
 // Exception scatter: fully data-parallel (G-ALP's key GPU optimisation).
@@ -573,8 +651,8 @@ std::unique_ptr<alp_compressed_representation> alp_compress_impl(cudf::column_vi
   if (n == 0) {
     auto empty_int = cudf::make_fixed_width_column(
       cudf::data_type(traits::int_type_id), 0, cudf::mask_state::UNALLOCATED, stream, mr);
-    auto empty_exc = cudf::make_fixed_width_column(
-      cudf::data_type(traits::value_type_id), 0, cudf::mask_state::UNALLOCATED, stream, mr);
+    auto empty_exc =
+      cudf::make_fixed_width_column(col.type(), 0, cudf::mask_state::UNALLOCATED, stream, mr);
     auto empty_pos = cudf::make_fixed_width_column(
       cudf::data_type(cudf::type_id::INT32), 0, cudf::mask_state::UNALLOCATED, stream, mr);
     auto empty_md = cudf::make_fixed_width_column(
@@ -609,8 +687,7 @@ std::unique_ptr<alp_compressed_representation> alp_compress_impl(cudf::column_vi
     d_flags.data());
 
   // Compact the per-row exception flags into (positions, exception values).
-  auto exc =
-    compact_exceptions<T>(d_flags.data(), n, col.data<T>(), traits::value_type_id, stream, mr);
+  auto exc = compact_exceptions<T>(d_flags.data(), n, col.data<T>(), col.type(), stream, mr);
 
   throw_if_cuda_error(cudaStreamSynchronize(stream.value()), "alp_compress_impl sync");
 
@@ -690,9 +767,12 @@ std::unique_ptr<cudf::column> alp_compressed_representation::decompress(
   switch (original_type.id()) {
     case cudf::type_id::FLOAT32: return alp_decompress_impl<float>(*this, stream, mr);
     case cudf::type_id::FLOAT64: return alp_decompress_impl<double>(*this, stream, mr);
+    case cudf::type_id::DECIMAL32: return alp_decompress_impl<int32_t>(*this, stream, mr);
+    case cudf::type_id::DECIMAL64: return alp_decompress_impl<int64_t>(*this, stream, mr);
     default:
-      throw std::runtime_error("alp: only FLOAT32 / FLOAT64 are supported (got " +
-                               type_id_to_name(original_type) + ")");
+      throw std::runtime_error(
+        "alp: only FLOAT32 / FLOAT64 / DECIMAL32 / DECIMAL64 are supported (got " +
+        type_id_to_name(original_type) + ")");
   }
 }
 
@@ -709,9 +789,16 @@ std::unique_ptr<compressed_representation> alp_compressor::compress(
   switch (dt.id()) {
     case cudf::type_id::FLOAT32: return alp_compress_impl<float>(column_to_compress, stream, mr);
     case cudf::type_id::FLOAT64: return alp_compress_impl<double>(column_to_compress, stream, mr);
+    // DECIMAL128's mantissa is __int128; there is no power-of-ten table or
+    // atomic support for it here, so it stays out.
+    case cudf::type_id::DECIMAL32:
+      return alp_compress_impl<int32_t>(column_to_compress, stream, mr);
+    case cudf::type_id::DECIMAL64:
+      return alp_compress_impl<int64_t>(column_to_compress, stream, mr);
     default:
-      throw std::runtime_error("alp: only FLOAT32 / FLOAT64 are supported (got " +
-                               type_id_to_name(dt) + "). Use alp_rd for non-decimal floats.");
+      throw std::runtime_error(
+        "alp: only FLOAT32 / FLOAT64 / DECIMAL32 / DECIMAL64 are supported (got " +
+        type_id_to_name(dt) + "). Use alp_rd for non-decimal floats.");
   }
 }
 

--- a/src/compression/simpatico_codegen/src/operators/alp_rd_compressor.cu
+++ b/src/compression/simpatico_codegen/src/operators/alp_rd_compressor.cu
@@ -452,7 +452,7 @@ std::unique_ptr<alp_rd_compressed_representation> alp_rd_compress_impl(
 
   // Step 4: compact exceptions into (positions, rejected left parts).
   auto exc = compact_exceptions<uint16_t>(
-    d_flags.data(), n, d_exception_left.data(), cudf::type_id::UINT16, stream, mr);
+    d_flags.data(), n, d_exception_left.data(), cudf::data_type{cudf::type_id::UINT16}, stream, mr);
 
   throw_if_cuda_error(cudaStreamSynchronize(stream.value()), "alp_rd_compress_impl sync");
 

--- a/src/compression/simpatico_codegen/src/plan/compress.cpp
+++ b/src/compression/simpatico_codegen/src/plan/compress.cpp
@@ -681,6 +681,7 @@ fused_op_channels canonical_fused_channels(std::string const& op)
   if (op == "delta") return {{"differences"}, {}};
   if (op == "rle") return {{"runs", "values"}, {}};
   if (op == "for") return {{"deltas"}, {"references"}};
+  if (op == "factor") return {{"quotients"}, {"divisors"}};
   return {};  // bitpack / zigzag: rep->named_channels() are already canonical
 }
 

--- a/src/compression/simpatico_codegen/src/plan/decompress.cpp
+++ b/src/compression/simpatico_codegen/src/plan/decompress.cpp
@@ -79,6 +79,7 @@ std::string codegen_kind_for_compressor(std::string const& c)
   if (c == "delta") return "delta";
   if (c == "rle") return "rle";
   if (c == "for") return "for";
+  if (c == "factor") return "factor";
   if (c == "zigzag") return "zigzag";
   return {};
 }
@@ -95,6 +96,7 @@ std::vector<std::string> consumed_slots(std::string const& kind)
   if (kind == "delta") return {"delta_first"};
   if (kind == "rle") return {"rle_runs_offsets"};
   if (kind == "for") return {"references"};
+  if (kind == "factor") return {"divisors"};
   if (kind == "zigzag") return {"zigzag"};
   if (kind == "RawFused") return {"data", "offsets"};
   return {};

--- a/src/compression/simpatico_codegen/src/plan/operator_registry.cpp
+++ b/src/compression/simpatico_codegen/src/plan/operator_registry.cpp
@@ -45,6 +45,7 @@ std::vector<OperatorInfo> const& operator_registry()
     {OpId::Bitpack,        "bitpack",         {"chunk_min", "chunk_count", "chunk_bits", "packed"},                   true,  false, false, true},
     {OpId::For,            "for",             {"deltas", "references"},                                               true,  false, true,  true},
     {OpId::Zigzag,         "zigzag",          {"zigzag"},                                                             true,  false, true,  true},
+    {OpId::Factor,         "factor",          {"quotients", "divisors"},                                              true,  false, true,  true},
     {OpId::Dictionary,     "dictionary",      {},                                                                     true,  false, false, false},
     {OpId::Alp,            "alp",             {"integers", "exceptions", "exception_positions", "metadata"},          true,  false, true,  false},
     {OpId::AlpRd,          "alp_rd",          {"right_parts", "dict_indices", "dict", "metadata", "exceptions", "exception_positions"}, true, false, true, false},
@@ -195,6 +196,7 @@ std::unique_ptr<compressor> make_compressor(std::string const& name)
     case OpId::Rle:
     case OpId::Bitpack:
     case OpId::For:
+    case OpId::Factor:
     case OpId::Zigzag: return nullptr;
   }
   return nullptr;

--- a/src/compression/simpatico_codegen/src/plan/representation_factory.cpp
+++ b/src/compression/simpatico_codegen/src/plan/representation_factory.cpp
@@ -244,18 +244,21 @@ std::unique_ptr<compressed_representation> alp_compressed_representation::from_o
   auto metadata            = std::move(outputs[3]);
 
   // Type validation. The (integers, exceptions) pair must match a supported
-  // (int_t, value_t) combination from alp_traits: INT32+FLOAT32 for f32
-  // input, INT64+FLOAT64 for f64. The other two outputs are precision-
-  // independent.
-  bool const is_f32 = integers->type().id() == cudf::type_id::INT32 &&
-                      exceptions->type().id() == cudf::type_id::FLOAT32;
-  bool const is_f64 = integers->type().id() == cudf::type_id::INT64 &&
-                      exceptions->type().id() == cudf::type_id::FLOAT64;
-  if (!is_f32 && !is_f64) {
+  // (int_t, value_t) combination from alp_traits: INT32 pairs with FLOAT32 or
+  // DECIMAL32, INT64 with FLOAT64 or DECIMAL64. (The fixed-point pairs are the
+  // decimal path, where the encoded integer is the mantissa divided by a power
+  // of ten.) The other two outputs are precision-independent.
+  auto const int_id = integers->type().id();
+  auto const exc_id = exceptions->type().id();
+  bool const is_32  = int_id == cudf::type_id::INT32 &&
+                     (exc_id == cudf::type_id::FLOAT32 || exc_id == cudf::type_id::DECIMAL32);
+  bool const is_64 = int_id == cudf::type_id::INT64 &&
+                     (exc_id == cudf::type_id::FLOAT64 || exc_id == cudf::type_id::DECIMAL64);
+  if (!is_32 && !is_64) {
     if (error_out)
       *error_out =
-        "alp (integers, exceptions) must be (INT32,FLOAT32) or "
-        "(INT64,FLOAT64)";
+        "alp (integers, exceptions) must be (INT32,FLOAT32|DECIMAL32) or "
+        "(INT64,FLOAT64|DECIMAL64)";
     return nullptr;
   }
   if (exception_positions->type().id() != cudf::type_id::INT32) {
@@ -273,8 +276,9 @@ std::unique_ptr<compressed_representation> alp_compressed_representation::from_o
 
   cudf::size_type num_rows    = integers->size();
   cudf::size_type num_vectors = metadata->size();
-  // The exceptions column's type IS the original float type by construction
-  // (alp_traits stores exceptions as the source value_t).
+  // The exceptions column's type IS the original column type by construction
+  // (compress builds it from the source column's data_type), which is also how
+  // a fixed-point column's scale survives the round trip.
   cudf::data_type original_type = exceptions->type();
 
   return std::make_unique<alp_compressed_representation>(original_type,

--- a/src/compression/simpatico_codegen/src/plan/representation_factory.cpp
+++ b/src/compression/simpatico_codegen/src/plan/representation_factory.cpp
@@ -245,9 +245,8 @@ std::unique_ptr<compressed_representation> alp_compressed_representation::from_o
 
   // Type validation. The (integers, exceptions) pair must match a supported
   // (int_t, value_t) combination from alp_traits: INT32 pairs with FLOAT32 or
-  // DECIMAL32, INT64 with FLOAT64 or DECIMAL64. (The fixed-point pairs are the
-  // decimal path, where the encoded integer is the mantissa divided by a power
-  // of ten.) The other two outputs are precision-independent.
+  // DECIMAL32, INT64 with FLOAT64 or DECIMAL64. The other two outputs are
+  // precision-independent.
   auto const int_id = integers->type().id();
   auto const exc_id = exceptions->type().id();
   bool const is_32  = int_id == cudf::type_id::INT32 &&
@@ -276,9 +275,8 @@ std::unique_ptr<compressed_representation> alp_compressed_representation::from_o
 
   cudf::size_type num_rows    = integers->size();
   cudf::size_type num_vectors = metadata->size();
-  // The exceptions column's type IS the original column type by construction
-  // (compress builds it from the source column's data_type), which is also how
-  // a fixed-point column's scale survives the round trip.
+  // The exceptions column's type IS the original column type by construction,
+  // which is also how a fixed-point column's scale survives the round trip.
   cudf::data_type original_type = exceptions->type();
 
   return std::make_unique<alp_compressed_representation>(original_type,

--- a/src/compression/simpatico_codegen/src/plan/representation_factory.cpp
+++ b/src/compression/simpatico_codegen/src/plan/representation_factory.cpp
@@ -619,6 +619,7 @@ std::unique_ptr<compressed_representation> reconstruct_representation(
     case OpId::Delta:
     case OpId::Rle:
     case OpId::For:
+    case OpId::Factor:
     case OpId::Zigzag: return unsupported();
   }
   return unsupported();

--- a/src/compression/simpatico_codegen/tests/test_compress_with_plan_roundtrip.cpp
+++ b/src/compression/simpatico_codegen/tests/test_compress_with_plan_roundtrip.cpp
@@ -373,6 +373,39 @@ int main()
     }
 
     {
+      // ALP on DECIMAL64 — the fixed-point path, where the mantissa is already
+      // an integer and the scale search is exact integer divisibility rather
+      // than float round-tripping. Three shapes: a clean common power of ten,
+      // one with a fraction of values that do NOT divide (so the exception
+      // machinery runs on the decimal path), and one with no power of ten
+      // available at all (scale collapses to 10^0, an exact identity).
+      auto clean = make_decimal64_table(2, 4096, 21, 100, 0);
+      std::string dsl =
+        "input -> alp\n"
+        "---\n"
+        "input -> alp\n";
+      roundtrip_once(clean->view(), dsl, 1, "alp_decimal64");
+      roundtrip_once(clean->view(), dsl, 2, "alp_decimal64_mt");
+
+      auto with_exc = make_decimal64_table(2, 4096, 23, 100, 37);
+      roundtrip_once(with_exc->view(), dsl, 1, "alp_decimal64_exceptions");
+
+      auto no_factor = make_decimal64_table(2, 4096, 29, 1, 0);
+      roundtrip_once(no_factor->view(), dsl, 1, "alp_decimal64_no_scale");
+
+      // Composed with bitpack on the integers channel — the shape that makes
+      // the decimal path worth having.
+      std::string dsl_bp =
+        "input -> alp -> integers, exceptions, exception_positions, metadata\n"
+        "alp.integers -> bitpack\n"
+        "---\n"
+        "input -> alp -> integers, exceptions, exception_positions, metadata\n"
+        "alp.integers -> bitpack\n";
+      roundtrip_once(clean->view(), dsl_bp, 1, "alp_decimal64_bitpack");
+      roundtrip_once(with_exc->view(), dsl_bp, 1, "alp_decimal64_bitpack_exceptions");
+    }
+
+    {
       // ALP-RD (Right-Dictionary), FLOAT32 — the non-decimal float path.
       auto t = make_f32_table(2, 4096, 33);
       std::string dsl =

--- a/src/compression/simpatico_codegen/tests/test_compress_with_plan_roundtrip.cpp
+++ b/src/compression/simpatico_codegen/tests/test_compress_with_plan_roundtrip.cpp
@@ -487,6 +487,81 @@ int main()
     }
 
     {
+      // FACTOR at the region root with no fused child: `quotients` drains to a
+      // synthesized Raw passthrough (fixed stride) and `divisors` is the
+      // boundary channel on the op's own rep.  Values are all multiples of 100
+      // so the per-chunk GCD is a real divisor, not the 1 no-op.
+      auto t = make_scaled_int64_table(2, 2048, 11, 100);
+      std::string dsl =
+        "input -> factor -> quotients, divisors\n"
+        "---\n"
+        "input -> factor -> quotients, divisors\n";
+      roundtrip_once(t->view(), dsl, 1, "factor_only");
+      roundtrip_once(t->view(), dsl, 2, "factor_only_mt");
+    }
+
+    {
+      // FACTOR -> Bitpack (FUSED): the shape that makes the operator worth
+      // having — dividing out the common factor narrows the range bitpack has
+      // to cover.  int64 (decimal storage width) and int32.
+      auto t64 = make_scaled_int64_table(2, 4096, 13, 1000);
+      std::string dsl64 =
+        "input -> factor -> quotients, divisors\n"
+        "factor.quotients -> bitpack\n"
+        "---\n"
+        "input -> factor -> quotients, divisors\n"
+        "factor.quotients -> bitpack\n";
+      roundtrip_once(t64->view(), dsl64, 1, "jit_factor_bp_int64");
+      roundtrip_once(t64->view(), dsl64, 2, "jit_factor_bp_int64_mt");
+
+      // Non-factorable input (consecutive residues => per-chunk GCD collapses
+      // to 1): exercises the divisor == 1 identity path end to end.
+      auto t32 = make_int32_table(2, 4096, 17);
+      std::string dsl32 =
+        "input -> factor -> quotients, divisors\n"
+        "factor.quotients -> bitpack\n"
+        "---\n"
+        "input -> factor -> quotients, divisors\n"
+        "factor.quotients -> bitpack\n";
+      roundtrip_once(t32->view(), dsl32, 1, "jit_factor_bp_int32_gcd1");
+      roundtrip_once(t32->view(), dsl32, 2, "jit_factor_bp_int32_gcd1_mt");
+    }
+
+    {
+      // FACTOR with `divisors` routed to a non-fused op, mirroring the
+      // for.references -> identity case: the boundary channel must survive
+      // being stored by a separate leaf.
+      auto t = make_scaled_int64_table(2, 4096, 19, 250);
+      std::string dsl =
+        "input -> factor -> quotients, divisors\n"
+        "factor.quotients -> bitpack\n"
+        "factor.divisors -> identity\n"
+        "---\n"
+        "input -> factor -> quotients, divisors\n"
+        "factor.quotients -> bitpack\n"
+        "factor.divisors -> identity\n";
+      roundtrip_once(t->view(), dsl, 1, "jit_factor_div_identity_int64");
+      roundtrip_once(t->view(), dsl, 2, "jit_factor_div_identity_int64_mt");
+    }
+
+    {
+      // Delta -> FACTOR -> Bitpack (FUSED): FACTOR nested BELOW another
+      // transformer, so decode must materialise its child through the generic
+      // slab path rather than the closed-form leaf path.
+      auto t = make_scaled_int64_table(2, 4096, 23, 100);
+      std::string dsl =
+        "input -> delta -> differences\n"
+        "delta.differences -> factor -> quotients, divisors\n"
+        "delta.differences.quotients -> bitpack\n"
+        "---\n"
+        "input -> delta -> differences\n"
+        "delta.differences -> factor -> quotients, divisors\n"
+        "delta.differences.quotients -> bitpack\n";
+      roundtrip_once(t->view(), dsl, 1, "jit_delta_factor_bp_int64");
+      roundtrip_once(t->view(), dsl, 2, "jit_delta_factor_bp_int64_mt");
+    }
+
+    {
       // ZigZag leaf at the region root — stored as its own fixed-stride
       // `zigzag` channel.  int32 and int64.
       auto t32 = make_int32_table(2, 4096, 71);

--- a/src/compression/simpatico_codegen/tests/test_compress_with_plan_roundtrip.cpp
+++ b/src/compression/simpatico_codegen/tests/test_compress_with_plan_roundtrip.cpp
@@ -373,12 +373,9 @@ int main()
     }
 
     {
-      // ALP on DECIMAL64 — the fixed-point path, where the mantissa is already
-      // an integer and the scale search is exact integer divisibility rather
-      // than float round-tripping. Three shapes: a clean common power of ten,
-      // one with a fraction of values that do NOT divide (so the exception
-      // machinery runs on the decimal path), and one with no power of ten
-      // available at all (scale collapses to 10^0, an exact identity).
+      // ALP on DECIMAL64 — the fixed-point path. Three shapes: a clean common
+      // power of ten, a fraction of values that do not divide (exceptions on
+      // the decimal path), and none available at all (scale 10^0, an identity).
       auto clean = make_decimal64_table(2, 4096, 21, 100, 0);
       std::string dsl =
         "input -> alp\n"
@@ -522,8 +519,7 @@ int main()
     {
       // FACTOR at the region root with no fused child: `quotients` drains to a
       // synthesized Raw passthrough (fixed stride) and `divisors` is the
-      // boundary channel on the op's own rep.  Values are all multiples of 100
-      // so the per-chunk GCD is a real divisor, not the 1 no-op.
+      // boundary channel on the op's own rep.
       auto t = make_scaled_int64_table(2, 2048, 11, 100);
       std::string dsl =
         "input -> factor -> quotients, divisors\n"
@@ -534,9 +530,7 @@ int main()
     }
 
     {
-      // FACTOR -> Bitpack (FUSED): the shape that makes the operator worth
-      // having — dividing out the common factor narrows the range bitpack has
-      // to cover.  int64 (decimal storage width) and int32.
+      // FACTOR -> Bitpack (FUSED): int64 (decimal storage width) and int32.
       auto t64 = make_scaled_int64_table(2, 4096, 13, 1000);
       std::string dsl64 =
         "input -> factor -> quotients, divisors\n"

--- a/src/compression/simpatico_codegen/tests/test_compressed_table_io.cpp
+++ b/src/compression/simpatico_codegen/tests/test_compressed_table_io.cpp
@@ -280,6 +280,32 @@ void test_alp_f32()
   io_roundtrip("alp_f32", t->view(), "input -> alp\n");
 }
 
+// ALP on DECIMAL64: the only operator that stores a leaf buffer with a
+// FIXED-POINT type (its `exceptions` channel carries the source column's own
+// type). Every other decimal plan reaches the file as integer buffers via the
+// codegen path, so this is the one case that exercises reconstructing a
+// non-numeric leaf buffer on read. Covered with and without exceptions, since
+// a zero-exception column stores that channel empty.
+void test_alp_decimal64()
+{
+  auto clean = make_decimal64_table(1, 4096, 17, 100, 0);
+  io_roundtrip("alp_decimal64", clean->view(), "input -> alp\n");
+
+  auto with_exc = make_decimal64_table(1, 4096, 19, 100, 37);
+  io_roundtrip("alp_decimal64_exceptions", with_exc->view(), "input -> alp\n");
+}
+
+// The `factor` operator through the file path: `divisors` is a boundary
+// channel on the op's own rep, so it must survive describe/rebuild.
+void test_factor_bitpack()
+{
+  auto t = make_scaled_int64_table(1, 4096, 23, 100);
+  io_roundtrip("factor_bitpack",
+               t->view(),
+               "input -> factor -> quotients, divisors\n"
+               "factor.quotients -> bitpack\n");
+}
+
 // Bitextract: multi-output op whose planes are terminal channel leaves,
 // exercising per-node output_names + terminal-slot attachment on read.
 void test_bitextract_f32()
@@ -661,6 +687,8 @@ int main()
     {"for_only", test_for_only},
     {"zigzag", test_zigzag},
     {"alp_f32", test_alp_f32},
+    {"alp_decimal64", test_alp_decimal64},
+    {"factor_bitpack", test_factor_bitpack},
     {"bitextract_f32", test_bitextract_f32},
     {"bitjoin_f32", test_bitjoin_f32},
     {"alp_rd_f64", test_alp_rd_f64},

--- a/src/compression/simpatico_codegen/tests/test_compressed_table_io.cpp
+++ b/src/compression/simpatico_codegen/tests/test_compressed_table_io.cpp
@@ -280,12 +280,9 @@ void test_alp_f32()
   io_roundtrip("alp_f32", t->view(), "input -> alp\n");
 }
 
-// ALP on DECIMAL64: the only operator that stores a leaf buffer with a
-// FIXED-POINT type (its `exceptions` channel carries the source column's own
-// type). Every other decimal plan reaches the file as integer buffers via the
-// codegen path, so this is the one case that exercises reconstructing a
-// non-numeric leaf buffer on read. Covered with and without exceptions, since
-// a zero-exception column stores that channel empty.
+// ALP on DECIMAL64: the only operator storing a leaf buffer with a fixed-point
+// type, so the one case that exercises reconstructing a non-numeric leaf on
+// read. With and without exceptions -- a zero-exception column stores it empty.
 void test_alp_decimal64()
 {
   auto clean = make_decimal64_table(1, 4096, 17, 100, 0);

--- a/src/compression/simpatico_codegen/tests/test_operator_sweep.cpp
+++ b/src/compression/simpatico_codegen/tests/test_operator_sweep.cpp
@@ -182,10 +182,8 @@ std::unique_ptr<cudf::table> make_uint16_table(int num_rows, int seed)
 // lockstep with build_fixtures() below — the orchestrator sizes/labels work by
 // index into this list, so a shorter list silently drops the trailing fixtures
 // from the sweep.
-// MUST stay in the same order as build_fixtures(): build_work() indexes into
-// the fixture vector by position in this array, so a name added to one and not
-// the other silently attributes every later fixture's chains to the wrong
-// column.
+// MUST stay in the same order as build_fixtures(); build_work() indexes the
+// fixture vector by position in this array.
 constexpr std::array<char const*, 12> kFixtureNames = {"i16",
                                                        "i32",
                                                        "i64",
@@ -219,8 +217,7 @@ std::vector<fixture> build_fixtures(rmm::cuda_stream_view stream, int n)
   add_numeric("i16", make_int16_table(n, 9));
   add_numeric("i32", make_int32_table(1, n, 1));
   add_numeric("i64", make_int64_table(1, n, 2));
-  // Values sharing a common factor -- the shape `factor` exists to exploit, and
-  // the only fixture on which it is not an identity.
+  // The only fixture on which `factor` is not an identity.
   add_numeric("i64_scaled", make_scaled_int64_table(1, n, 12, 100));
   add_numeric("u16", make_uint16_table(n, 10));
   add_numeric("u32", make_uint32_table(1, n, 7));
@@ -476,9 +473,8 @@ int run_shard(unsigned shard_idx, unsigned n_shards)
   auto fixtures = build_fixtures(stream, n);
   auto work     = build_work();
 
-  // build_work() addresses fixtures positionally; if the two lists ever drift,
-  // every chain after the insertion point runs against the wrong column and
-  // still "passes". Check the correspondence instead of trusting the comment.
+  // Drift here runs every later fixture's chains against the wrong column and
+  // still reports "passed", so check rather than trust the comment above.
   if (fixtures.size() != kFixtureNames.size()) {
     throw std::runtime_error("fixture count " + std::to_string(fixtures.size()) +
                              " != kFixtureNames size " + std::to_string(kFixtureNames.size()));
@@ -521,18 +517,11 @@ int run_shard(unsigned shard_idx, unsigned n_shards)
     must_apply("date", {"delta", "rle", "for", "zigzag", "bitpack", "ans", "bitcomp"});
     must_apply("i64_scaled", {"factor", "delta", "bitpack"});
 
-    // `factor` self-reports whether it did anything, via the no_benefit flag on
-    // the trial. The explorer relies on this to stop carrying an identity
-    // `factor` through the beam: on its own the op measures ~0.999x on ANY
-    // input (the quotients keep the source width and `divisors` adds bytes), so
-    // byte size alone cannot tell a useful application from a useless one, and
-    // preprocessing ops are deliberately exempt from the must-shrink rule.
-    //
-    // Both directions matter. A false positive silently drops the one operator
-    // that can exploit a factorable column; a false negative puts the waiver
-    // back where it was. Note this is NOT an applicability failure -- the op
-    // succeeds either way, so that an explicit plan naming `factor` still
-    // compresses correctly on a column whose GCD happens to be 1.
+    // `factor` measures ~0.999x on any input, so only its own no_benefit flag
+    // separates a useful application from an identity. Both directions matter:
+    // a false positive drops the operator on the columns it exists for, a false
+    // negative restores the wasted beam slots. Not an applicability failure --
+    // the op succeeds either way.
     auto no_benefit_is = [&](char const* fixture_name, bool expected) {
       for (auto const& f : fixtures) {
         if (f.name != fixture_name) continue;

--- a/src/compression/simpatico_codegen/tests/test_operator_sweep.cpp
+++ b/src/compression/simpatico_codegen/tests/test_operator_sweep.cpp
@@ -182,8 +182,22 @@ std::unique_ptr<cudf::table> make_uint16_table(int num_rows, int seed)
 // lockstep with build_fixtures() below — the orchestrator sizes/labels work by
 // index into this list, so a shorter list silently drops the trailing fixtures
 // from the sweep.
-constexpr std::array<char const*, 11> kFixtureNames = {
-  "i16", "i32", "i64", "u16", "u32", "u64", "f32", "f64", "u8_binary", "date", "string"};
+// MUST stay in the same order as build_fixtures(): build_work() indexes into
+// the fixture vector by position in this array, so a name added to one and not
+// the other silently attributes every later fixture's chains to the wrong
+// column.
+constexpr std::array<char const*, 12> kFixtureNames = {"i16",
+                                                       "i32",
+                                                       "i64",
+                                                       "i64_scaled",
+                                                       "u16",
+                                                       "u32",
+                                                       "u64",
+                                                       "f32",
+                                                       "f64",
+                                                       "u8_binary",
+                                                       "date",
+                                                       "string"};
 
 struct fixture {
   std::string name;
@@ -205,6 +219,9 @@ std::vector<fixture> build_fixtures(rmm::cuda_stream_view stream, int n)
   add_numeric("i16", make_int16_table(n, 9));
   add_numeric("i32", make_int32_table(1, n, 1));
   add_numeric("i64", make_int64_table(1, n, 2));
+  // Values sharing a common factor -- the shape `factor` exists to exploit, and
+  // the only fixture on which it is not an identity.
+  add_numeric("i64_scaled", make_scaled_int64_table(1, n, 12, 100));
   add_numeric("u16", make_uint16_table(n, 10));
   add_numeric("u32", make_uint32_table(1, n, 7));
   add_numeric("u64", make_uint64_table(1, n, 8));
@@ -459,6 +476,20 @@ int run_shard(unsigned shard_idx, unsigned n_shards)
   auto fixtures = build_fixtures(stream, n);
   auto work     = build_work();
 
+  // build_work() addresses fixtures positionally; if the two lists ever drift,
+  // every chain after the insertion point runs against the wrong column and
+  // still "passes". Check the correspondence instead of trusting the comment.
+  if (fixtures.size() != kFixtureNames.size()) {
+    throw std::runtime_error("fixture count " + std::to_string(fixtures.size()) +
+                             " != kFixtureNames size " + std::to_string(kFixtureNames.size()));
+  }
+  for (std::size_t i = 0; i < fixtures.size(); ++i) {
+    if (fixtures[i].name != kFixtureNames[i]) {
+      throw std::runtime_error("fixture " + std::to_string(i) + " is '" + fixtures[i].name +
+                               "' but kFixtureNames says '" + kFixtureNames[i] + "'");
+    }
+  }
+
   // Minimum applicability: the sweep treats any op failure as "inapplicable"
   // and skips silently, so a regression that breaks a whole (op, dtype) class
   // would otherwise just shrink coverage. Assert on shard 0 that the ops each
@@ -488,6 +519,38 @@ int run_shard(unsigned shard_idx, unsigned n_shards)
     must_apply("f64", {"alp", "alp_rd", "for", "bitpack"});
     must_apply("u8_binary", {"delta", "rle", "for", "zigzag", "bitpack"});
     must_apply("date", {"delta", "rle", "for", "zigzag", "bitpack", "ans", "bitcomp"});
+    must_apply("i64_scaled", {"factor", "delta", "bitpack"});
+
+    // `factor` self-reports whether it did anything, via the no_benefit flag on
+    // the trial. The explorer relies on this to stop carrying an identity
+    // `factor` through the beam: on its own the op measures ~0.999x on ANY
+    // input (the quotients keep the source width and `divisors` adds bytes), so
+    // byte size alone cannot tell a useful application from a useless one, and
+    // preprocessing ops are deliberately exempt from the must-shrink rule.
+    //
+    // Both directions matter. A false positive silently drops the one operator
+    // that can exploit a factorable column; a false negative puts the waiver
+    // back where it was. Note this is NOT an applicability failure -- the op
+    // succeeds either way, so that an explicit plan naming `factor` still
+    // compresses correctly on a column whose GCD happens to be 1.
+    auto no_benefit_is = [&](char const* fixture_name, bool expected) {
+      for (auto const& f : fixtures) {
+        if (f.name != fixture_name) continue;
+        auto trial = simpatico::try_operator("factor", f.view, stream, mr);
+        if (!trial.success) {
+          throw std::runtime_error(std::string("factor failed on fixture '") + fixture_name +
+                                   "': " + trial.error_message);
+        }
+        if (trial.no_benefit != expected) {
+          throw std::runtime_error(std::string("factor no_benefit on fixture '") + fixture_name +
+                                   "': expected " + (expected ? "true" : "false") + ", got " +
+                                   (trial.no_benefit ? "true" : "false"));
+        }
+      }
+    };
+    no_benefit_is("i64_scaled", false);  // every value a multiple of 100
+    no_benefit_is("i64", true);          // consecutive residues -> per-chunk GCD 1
+    no_benefit_is("i32", true);
   }
 
   std::vector<sweep_stats> per_fixture(fixtures.size());

--- a/src/compression/simpatico_codegen/tests/test_utils.hpp
+++ b/src/compression/simpatico_codegen/tests/test_utils.hpp
@@ -185,6 +185,37 @@ inline std::unique_ptr<cudf::table> make_f64_table(int num_cols, int num_rows, i
 // Single-column chrono table (DATE32 days / int64 timestamps / durations),
 // bit-identical to its integer storage. A mild upward drift with small jitter
 // makes delta/bitpack meaningful, like real event times.
+// DECIMAL64 mantissas at scale -2 (money), all multiples of `mantissa_factor`
+// so a power-of-ten scale is actually available to find, plus a `1 / exc_every`
+// fraction of values that are NOT multiples -- those are the rows ALP has to
+// bank as exceptions, and the case that distinguishes it from `factor`, whose
+// GCD would collapse to 1 the moment one such value appears. exc_every <= 0
+// disables them.
+inline std::unique_ptr<cudf::table> make_decimal64_table(
+  int num_cols, int num_rows, int seed, std::int64_t mantissa_factor, int exc_every)
+{
+  auto const dt = cudf::data_type{cudf::type_id::DECIMAL64, -2};
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.reserve(static_cast<std::size_t>(num_cols));
+  for (int c = 0; c < num_cols; ++c) {
+    std::vector<std::int64_t> host(static_cast<std::size_t>(num_rows));
+    for (int r = 0; r < num_rows; ++r) {
+      std::int64_t m =
+        (static_cast<std::int64_t>((r * 17 + c * 1013 + seed) % 1000) - 500) * mantissa_factor;
+      if (exc_every > 0 && (r % exc_every) == 0) m += 1;
+      host[static_cast<std::size_t>(r)] = m;
+    }
+    auto col = cudf::make_fixed_width_column(dt, num_rows, cudf::mask_state::UNALLOCATED);
+    if (cudaMemcpy(col->mutable_view().head<void>(),
+                   host.data(),
+                   host.size() * sizeof(std::int64_t),
+                   cudaMemcpyHostToDevice) != cudaSuccess)
+      throw std::runtime_error("make_decimal64_table: cudaMemcpy failed");
+    cols.push_back(std::move(col));
+  }
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
 inline std::unique_ptr<cudf::table> make_chrono_table(cudf::type_id id, int num_rows, int seed)
 {
   auto const dt = cudf::data_type{id};

--- a/src/compression/simpatico_codegen/tests/test_utils.hpp
+++ b/src/compression/simpatico_codegen/tests/test_utils.hpp
@@ -45,6 +45,34 @@ inline std::unique_ptr<cudf::table> make_int32_table(int num_cols, int num_rows,
   return std::make_unique<cudf::table>(std::move(cols));
 }
 
+// Values that all share the common factor `scale`, spanning both signs and
+// hitting zero — the shape the `factor` operator exists to exploit (a decimal
+// column whose mantissas are all multiples of a power of ten). gcd(0, x) == x,
+// so the embedded zeros also exercise the reduction's identity element.
+inline std::unique_ptr<cudf::table> make_scaled_int64_table(int num_cols,
+                                                            int num_rows,
+                                                            int seed,
+                                                            std::int64_t scale)
+{
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.reserve(static_cast<std::size_t>(num_cols));
+  for (int c = 0; c < num_cols; ++c) {
+    std::vector<std::int64_t> host(static_cast<std::size_t>(num_rows));
+    for (int r = 0; r < num_rows; ++r)
+      host[static_cast<std::size_t>(r)] =
+        (static_cast<std::int64_t>((r * 17 + c * 1013 + seed) % 1000) - 500) * scale;
+    auto col = cudf::make_numeric_column(
+      cudf::data_type{cudf::type_id::INT64}, num_rows, cudf::mask_state::UNALLOCATED);
+    if (cudaMemcpy(col->mutable_view().head<std::int64_t>(),
+                   host.data(),
+                   host.size() * sizeof(std::int64_t),
+                   cudaMemcpyHostToDevice) != cudaSuccess)
+      throw std::runtime_error("make_scaled_int64_table: cudaMemcpy failed");
+    cols.push_back(std::move(col));
+  }
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
 inline std::unique_ptr<cudf::table> make_int64_table(int num_cols, int num_rows, int seed)
 {
   std::vector<std::unique_ptr<cudf::column>> cols;

--- a/src/compression/simpatico_codegen/tests/test_utils.hpp
+++ b/src/compression/simpatico_codegen/tests/test_utils.hpp
@@ -45,10 +45,8 @@ inline std::unique_ptr<cudf::table> make_int32_table(int num_cols, int num_rows,
   return std::make_unique<cudf::table>(std::move(cols));
 }
 
-// Values that all share the common factor `scale`, spanning both signs and
-// hitting zero — the shape the `factor` operator exists to exploit (a decimal
-// column whose mantissas are all multiples of a power of ten). gcd(0, x) == x,
-// so the embedded zeros also exercise the reduction's identity element.
+// Values sharing the common factor `scale`, spanning both signs and hitting
+// zero — gcd(0, x) == x, so the zeros exercise the reduction's identity.
 inline std::unique_ptr<cudf::table> make_scaled_int64_table(int num_cols,
                                                             int num_rows,
                                                             int seed,
@@ -185,12 +183,9 @@ inline std::unique_ptr<cudf::table> make_f64_table(int num_cols, int num_rows, i
 // Single-column chrono table (DATE32 days / int64 timestamps / durations),
 // bit-identical to its integer storage. A mild upward drift with small jitter
 // makes delta/bitpack meaningful, like real event times.
-// DECIMAL64 mantissas at scale -2 (money), all multiples of `mantissa_factor`
-// so a power-of-ten scale is actually available to find, plus a `1 / exc_every`
-// fraction of values that are NOT multiples -- those are the rows ALP has to
-// bank as exceptions, and the case that distinguishes it from `factor`, whose
-// GCD would collapse to 1 the moment one such value appears. exc_every <= 0
-// disables them.
+// DECIMAL64 mantissas at scale -2, all multiples of `mantissa_factor`, plus a
+// 1/exc_every fraction that are not -- the rows ALP banks as exceptions.
+// exc_every <= 0 disables them.
 inline std::unique_ptr<cudf::table> make_decimal64_table(
   int num_cols, int num_rows, int seed, std::int64_t mantissa_factor, int exc_every)
 {


### PR DESCRIPTION
## Description
Adds a new operator to simpatico (technically a feature, but it improves performance), that detects a common divisor so it can be applied before bitpack. This allows bitpack to function much more effectively on l_quantity, which has a common divisor of 100:

```
  ┌─────────────────────────┬─────────┬───────────┬───────────┐
  │                         │  ratio  │ compress  │  decode   │
  ├─────────────────────────┼─────────┼───────────┼───────────┤
  │ old (bitpack)           │ 4.885x  │ 1367 GB/s │ 2918 GB/s │
  ├─────────────────────────┼─────────┼───────────┼───────────┤
  │ new (factor -> bitpack) │ 10.383x │ 697 GB/s  │ 2938 GB/s │
  └─────────────────────────┴─────────┴───────────┴───────────┘
```

In addition, this PR enables ALP to operate on decimal data and has various improvements to its implementation. However, it is still not chosen over bitpack for any of the input columns. There may be additional improvements possible.

## Checklist
- [ ] Read CONTRIBUTING.md and ensure PR meets "reviewability" checklist
- [ ] Cover changes with new or existing tests
- [ ] Document configuration changes in code and summarize in the description above
- [ ] Update human and agent documentation (README.md, docs/, skills, CLAUDE.md)

## References