### PR TITLE
chore(bench): add TPC-H harness and GPU/MIG placement

### DIFF
--- a/bench/common/gen-tpch.sh
+++ b/bench/common/gen-tpch.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Generate a TPC-H parquet dataset at any scale factor.
+#
+# Defaults to f64 monetary columns. decimal128 activates Sirius's decimal-lowering drift,
+# which scores ~11/22 against a DuckDB oracle instead of ~21/22, so f64 is what the
+# benchmark baselines use. Pass --decimal only when you are deliberately testing that path.
+set -euo pipefail
+
+SCALE=""
+DECIMAL_TYPE=f64
+OUT=""
+ROOT=${TPCH_ROOT:-/opt/dlami/nvme/tpch}
+GEN=${TPCHGEN:-$ROOT/tpchgen-rs/target/release/tpchgen-cli}
+PYTHON=${TPCH_PYTHON:-$ROOT/venv/bin/python}
+TARGET_PART_GB=${TARGET_PART_GB:-4.3}
+FORCE=0
+VERIFY=1
+
+usage() {
+    cat <<USAGE
+usage: gen-tpch.sh -s <scale> [options]
+
+  -s, --scale <N>       scale factor (required)
+  -o, --output <dir>    output directory
+                        (default: \$TPCH_ROOT/tpch_parquet_sf<N>[_f64])
+      --decimal         decimal128 monetary columns (default: f64)
+      --force           overwrite an existing output directory
+      --no-verify       skip the row-count check
+  -h, --help
+
+env: TPCH_ROOT (default /opt/dlami/nvme/tpch), TPCHGEN, TPCH_PYTHON, TARGET_PART_GB
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -s|--scale)   SCALE=${2:?}; shift 2 ;;
+        -o|--output)  OUT=${2:?}; shift 2 ;;
+        --decimal)    DECIMAL_TYPE=decimal128; shift ;;
+        --force)      FORCE=1; shift ;;
+        --no-verify)  VERIFY=0; shift ;;
+        -h|--help)    usage; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+die() { echo "FATAL: $*" >&2; exit 1; }
+
+[ -n "$SCALE" ] || { usage >&2; die "-s/--scale is required"; }
+[[ "$SCALE" =~ ^[0-9]+$ ]] && [ "$SCALE" -gt 0 ] || die "scale must be a positive integer, got '$SCALE'"
+[ -x "$GEN" ] || die "tpchgen-cli not executable at $GEN (set TPCHGEN)"
+
+if [ -z "$OUT" ]; then
+    OUT=$ROOT/tpch_parquet_sf$SCALE
+    [ "$DECIMAL_TYPE" = f64 ] && OUT=${OUT}_f64
+fi
+
+if [ -e "$OUT" ] && [ -n "$(ls -A "$OUT" 2>/dev/null)" ]; then
+    [ "$FORCE" = 1 ] || die "$OUT exists and is not empty; pass --force to overwrite"
+    rm -rf "$OUT"
+fi
+mkdir -p "$OUT"
+
+# Approximate compressed GB per unit of scale factor, measured from the SF300 and SF500 sets.
+# Part counts derived from these reproduce the existing SF100/SF300/SF500 layouts.
+gb_per_sf() {
+    case "$1" in
+        lineitem) echo 0.258 ;;
+        orders)   echo 0.075 ;;
+        partsupp) echo 0.047 ;;
+        customer) echo 0.0138 ;;
+        part)     echo 0.0068 ;;
+        supplier) echo 0.0009 ;;
+        *)        echo 0 ;;
+    esac
+}
+
+parts_for() {
+    local table=$1
+    case "$table" in nation|region) echo 1; return ;; esac
+    "$PYTHON" - "$(gb_per_sf "$table")" "$SCALE" "$TARGET_PART_GB" <<'PY'
+import sys
+per_sf, scale, target = float(sys.argv[1]), float(sys.argv[2]), float(sys.argv[3])
+print(max(1, round(per_sf * scale / target)))
+PY
+}
+
+TABLES="region nation supplier part customer partsupp orders lineitem"
+
+echo "scale=$SCALE  decimal=$DECIMAL_TYPE  out=$OUT"
+for t in $TABLES; do
+    n=$(parts_for "$t")
+    echo "[$(date +%T)] $t parts=$n"
+    "$GEN" -s "$SCALE" -T "$t" -f parquet --parts "$n" \
+           --decimal-column-type "$DECIMAL_TYPE" -o "$OUT"
+done
+
+cat > "$OUT/gen-info.json" <<JSON
+{
+  "scale_factor": $SCALE,
+  "decimal_column_type": "$DECIMAL_TYPE",
+  "target_part_gb": $TARGET_PART_GB,
+  "generated_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "generator": "$($GEN --version 2>/dev/null | head -1)"
+}
+JSON
+
+echo "[$(date +%T)] generated $(find "$OUT" -name '*.parquet' | wc -l) files, $(du -sh "$OUT" | cut -f1)"
+
+[ "$VERIFY" = 1 ] || { echo "verification skipped"; exit 0; }
+[ -x "$PYTHON" ] || die "no python with duckdb at $PYTHON (set TPCH_PYTHON or pass --no-verify)"
+
+# Every table but lineitem has an exact per-SF row count. lineitem's varies slightly with the
+# generator's data distribution, so it is checked against a tolerance instead.
+"$PYTHON" - "$OUT" "$SCALE" "$DECIMAL_TYPE" <<'PY'
+import sys, duckdb
+out, scale, dtype = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+exact = {"orders":1500000,"customer":150000,"part":200000,"partsupp":800000,"supplier":10000}
+con, bad = duckdb.connect(), []
+for t, per in sorted(exact.items()):
+    n = con.sql(f"select count(*) from read_parquet('{out}/{t}/*.parquet')").fetchone()[0]
+    e = per*scale
+    ok = n == e
+    bad += [] if ok else [t]
+    print(f"{t:10s} {n:>15,} expected {e:>15,} {'OK' if ok else 'MISMATCH'}")
+for t, e in (("nation",25),("region",5)):
+    n = con.sql(f"select count(*) from read_parquet('{out}/{t}/*.parquet')").fetchone()[0]
+    bad += [] if n == e else [t]
+    print(f"{t:10s} {n:>15,} expected {e:>15,} {'OK' if n==e else 'MISMATCH'}")
+n = con.sql(f"select count(*) from read_parquet('{out}/lineitem/*.parquet')").fetchone()[0]
+e = 6001215*scale
+ok = abs(n-e)/e < 0.001
+bad += [] if ok else ["lineitem"]
+print(f"{'lineitem':10s} {n:>15,} ~expected {e:>15,} ({(n-e)/e*100:+.3f}%) {'OK' if ok else 'MISMATCH'}")
+
+want = "DOUBLE" if dtype == "f64" else "DECIMAL"
+got = dict(con.sql(
+    f"select column_name, column_type from (describe select * from "
+    f"read_parquet('{out}/lineitem/*.parquet')) "
+    f"where column_name in ('l_quantity','l_extendedprice','l_discount','l_tax')").fetchall())
+wrong = [c for c, t in got.items() if want not in t]
+print(f"monetary columns: {sorted(set(got.values()))} expected {want}")
+if wrong: bad.append("column-types")
+if bad:
+    print("FAILED: " + ", ".join(sorted(set(bad)))); sys.exit(1)
+print("all row counts and column types OK")
+PY

--- a/experimental/starrocks/benchmarks/cluster8.sh
+++ b/experimental/starrocks/benchmarks/cluster8.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Bring up 1 FE + N Sirius GPU compute nodes, one CN per GPU, cross-node exchange over nixl.
+#
+# The `cluster2` pixi task generalized to a loop. Two CNs could offset their ports by +2; at
+# eight the heartbeat range would collide with the thrift range, so each CN instead gets a
+# contiguous 10-port block based at $PORT_BASE -- clear of the FE's ports (8030/9010/9020/9030)
+# and of the CN defaults (9050/9060/8040/8060/9070).
+#
+# Two identities must stay unique across CNs: the FE keys a node by
+# (advertise_host, heartbeat_port), and the nixl agent is named {advertise_host}:{brpc_port}.
+#
+# Usage:  ./benchmarks/cluster8.sh
+#         NUM_CNS=4 GPU_MEM=48GiB ./benchmarks/cluster8.sh
+#         SIRIUS_QUERY_WATCHDOG_SECS=60 NUM_CNS=4 ./benchmarks/cluster8.sh
+#
+# Run it in its own terminal or as its own background task -- never chained behind `&` inside
+# another shell command, or the cluster dies with that shell.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SR_DIR=$(cd "$HERE/.." && pwd)              # experimental/starrocks
+REPO_ROOT=$(cd "$SR_DIR/../.." && pwd)
+TOOLS_DIR=${TOOLS_DIR:-$(cd "$REPO_ROOT/.." && pwd)/tools}
+
+NUM_CNS=${NUM_CNS:-8}
+PORT_BASE=${PORT_BASE:-9100}
+PORT_STRIDE=${PORT_STRIDE:-10}
+# The staging arena sits OUTSIDE --gpu-memory-limit, so a CN really occupies
+# GPU_MEM + STAGING + CUDA context. On an 80GiB A100 that is ~75 of 80 GiB.
+GPU_MEM=${GPU_MEM:-64GiB}
+HOST_MEM=${HOST_MEM:-128GiB}
+STAGING=${STAGING:-8GiB}
+
+CN_BIN=$SR_DIR/target/release/sirius-starrocks-cn
+FE_BIN=$SR_DIR/starrocks/output/fe/bin/start_fe.sh
+
+[ -x "$CN_BIN" ] || { echo "no CN binary at $CN_BIN -- run: pixi run cn-build" >&2; exit 1; }
+[ -x "$FE_BIN" ] || { echo "no packaged FE at $FE_BIN -- run: pixi run fe-check" >&2; exit 1; }
+
+# NIXL_PREFIX / NIXL_PLUGIN_DIR / LD_LIBRARY_PATH (engine .so + pixi env lib + nixl + UCX) /
+# UCX_TLS, all derived from the repo and $TOOLS_DIR locations; fails loudly when nixl is
+# absent rather than continuing misconfigured.
+# shellcheck source=../scripts/cn-env.sh
+source "$SR_DIR/scripts/cn-env.sh"
+
+export SIRIUS_EXCHANGE_STAGING_BYTES=${SIRIUS_EXCHANGE_STAGING_BYTES:-$STAGING}
+
+# Each CN is pinned to its GPU with --gpu-device. An exported CUDA_VISIBLE_DEVICES wins over
+# that flag at the driver level -- every CN on one GPU, a cluster that still answers queries and
+# still records numbers -- which is why the CN refuses to start when the two disagree. Clear it
+# here instead of relying on the operator's shell being clean.
+unset CUDA_VISIBLE_DEVICES
+
+# Engine stall watchdog: seconds of zero scheduling progress before a query is failed loudly
+# instead of wedging the CN (0 = off, the engine default). Exported explicitly so the knob
+# reaches every CN; sweeps that would otherwise record a silent wedge as a timeout set it to 60.
+export SIRIUS_QUERY_WATCHDOG_SECS=${SIRIUS_QUERY_WATCHDOG_SECS:-0}
+
+avail=$(nvidia-smi --query-gpu=index --format=csv,noheader | wc -l)
+[ "$avail" -ge "$NUM_CNS" ] || {
+    echo "asked for $NUM_CNS CNs but only $avail GPUs are visible" >&2; exit 1; }
+
+pids=()
+cleanup() {
+    status=$?
+    trap - EXIT INT TERM
+    kill "${pids[@]}" 2>/dev/null || true
+    wait "${pids[@]}" 2>/dev/null || true
+    exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+cd "$SR_DIR"
+"$FE_BIN" --logconsole &
+pids+=("$!")
+
+for i in $(seq 0 $((NUM_CNS - 1))); do
+    base=$((PORT_BASE + i * PORT_STRIDE))
+    "$CN_BIN" \
+        --gpu-device "$i" \
+        --heartbeat-port "$base" \
+        --thrift-port    "$((base + 1))" \
+        --brpc-port      "$((base + 2))" \
+        --http-port      "$((base + 3))" \
+        --starlet-port   "$((base + 4))" \
+        --gpu-memory-limit "$GPU_MEM" \
+        --host-memory-limit "$HOST_MEM" \
+        --engine-dir ".cn$i" &
+    pids+=("$!")
+    echo "CN$i gpu=$i heartbeat=$base brpc=$((base + 2)) pid=${pids[-1]}"
+done
+
+echo "FE + $NUM_CNS CNs launched; each CN self-registers with the FE on :9030"
+# Any child exiting means the cluster is broken -- fall through to cleanup rather than
+# leaving a half-cluster that the benchmark would silently measure.
+wait -n "${pids[@]}"

--- a/experimental/starrocks/benchmarks/cluster8.sh
+++ b/experimental/starrocks/benchmarks/cluster8.sh
@@ -59,8 +59,17 @@ export SIRIUS_QUERY_WATCHDOG_SECS=${SIRIUS_QUERY_WATCHDOG_SECS:-0}
 # GPU_DEVICES="0,0" places CN i on the i-th listed device instead of device i, so two CNs can
 # share one card on a single-GPU box (each must then carve out a GPU_MEM + STAGING slice that
 # fits alongside the other's). Default: one CN per GPU.
+# MIG_DEVICES="MIG-<uuid>,MIG-<uuid>" places CN i on the i-th MIG instance. A MIG instance is only
+# reachable through CUDA_VISIBLE_DEVICES=<uuid>, and the CN rejects a UUID next to --gpu-device, so
+# each CN is launched with the variable exported and without the flag.
 avail=$(nvidia-smi --query-gpu=index --format=csv,noheader | wc -l)
-if [ -n "${GPU_DEVICES:-}" ]; then
+mig_of_cn=()
+if [ -n "${MIG_DEVICES:-}" ]; then
+    IFS=, read -r -a mig_of_cn <<< "$MIG_DEVICES"
+    [ "${#mig_of_cn[@]}" -ge "$NUM_CNS" ] || {
+        echo "MIG_DEVICES=$MIG_DEVICES lists ${#mig_of_cn[@]} instances for $NUM_CNS CNs" >&2; exit 1; }
+    gpu_of_cn=()
+elif [ -n "${GPU_DEVICES:-}" ]; then
     IFS=, read -r -a gpu_of_cn <<< "$GPU_DEVICES"
     [ "${#gpu_of_cn[@]}" -ge "$NUM_CNS" ] || {
         echo "GPU_DEVICES=$GPU_DEVICES lists ${#gpu_of_cn[@]} devices for $NUM_CNS CNs" >&2; exit 1; }
@@ -86,9 +95,13 @@ pids+=("$!")
 
 for i in $(seq 0 $((NUM_CNS - 1))); do
     base=$((PORT_BASE + i * PORT_STRIDE))
-    gpu=${gpu_of_cn[$i]}
+    if [ "${#mig_of_cn[@]}" -gt 0 ]; then
+        gpu=${mig_of_cn[$i]}; gpu_args=(); export CUDA_VISIBLE_DEVICES=$gpu
+    else
+        gpu=${gpu_of_cn[$i]}; gpu_args=(--gpu-device "$gpu"); unset CUDA_VISIBLE_DEVICES
+    fi
     "$CN_BIN" \
-        --gpu-device "$gpu" \
+        "${gpu_args[@]}" \
         --heartbeat-port "$base" \
         --thrift-port    "$((base + 1))" \
         --brpc-port      "$((base + 2))" \

--- a/experimental/starrocks/benchmarks/cluster8.sh
+++ b/experimental/starrocks/benchmarks/cluster8.sh
@@ -56,9 +56,19 @@ unset CUDA_VISIBLE_DEVICES
 # reaches every CN; sweeps that would otherwise record a silent wedge as a timeout set it to 60.
 export SIRIUS_QUERY_WATCHDOG_SECS=${SIRIUS_QUERY_WATCHDOG_SECS:-0}
 
+# GPU_DEVICES="0,0" places CN i on the i-th listed device instead of device i, so two CNs can
+# share one card on a single-GPU box (each must then carve out a GPU_MEM + STAGING slice that
+# fits alongside the other's). Default: one CN per GPU.
 avail=$(nvidia-smi --query-gpu=index --format=csv,noheader | wc -l)
-[ "$avail" -ge "$NUM_CNS" ] || {
-    echo "asked for $NUM_CNS CNs but only $avail GPUs are visible" >&2; exit 1; }
+if [ -n "${GPU_DEVICES:-}" ]; then
+    IFS=, read -r -a gpu_of_cn <<< "$GPU_DEVICES"
+    [ "${#gpu_of_cn[@]}" -ge "$NUM_CNS" ] || {
+        echo "GPU_DEVICES=$GPU_DEVICES lists ${#gpu_of_cn[@]} devices for $NUM_CNS CNs" >&2; exit 1; }
+else
+    [ "$avail" -ge "$NUM_CNS" ] || {
+        echo "asked for $NUM_CNS CNs but only $avail GPUs are visible" >&2; exit 1; }
+    gpu_of_cn=($(seq 0 $((NUM_CNS - 1))))
+fi
 
 pids=()
 cleanup() {
@@ -76,8 +86,9 @@ pids+=("$!")
 
 for i in $(seq 0 $((NUM_CNS - 1))); do
     base=$((PORT_BASE + i * PORT_STRIDE))
+    gpu=${gpu_of_cn[$i]}
     "$CN_BIN" \
-        --gpu-device "$i" \
+        --gpu-device "$gpu" \
         --heartbeat-port "$base" \
         --thrift-port    "$((base + 1))" \
         --brpc-port      "$((base + 2))" \
@@ -87,7 +98,7 @@ for i in $(seq 0 $((NUM_CNS - 1))); do
         --host-memory-limit "$HOST_MEM" \
         --engine-dir ".cn$i" &
     pids+=("$!")
-    echo "CN$i gpu=$i heartbeat=$base brpc=$((base + 2)) pid=${pids[-1]}"
+    echo "CN$i gpu=$gpu heartbeat=$base brpc=$((base + 2)) pid=${pids[-1]}"
 done
 
 echo "FE + $NUM_CNS CNs launched; each CN self-registers with the FE on :9030"

--- a/experimental/starrocks/benchmarks/tpch/QUERY-DEVIATIONS.md
+++ b/experimental/starrocks/benchmarks/tpch/QUERY-DEVIATIONS.md
@@ -1,0 +1,64 @@
+# TPC-H query deviations from the stock text
+
+Every deviation from the stock TPC-H query text, why it exists, and what it costs.
+
+**These notes live here and NOT as `--` comments inside the `.sql` files.** `bench.sh` runs each
+query as `mysql -e "$Q"`, which collapses newlines — a leading `--` comment therefore swallows the
+entire statement and the query fails with a syntax error. Verified the hard way.
+
+---
+
+## q08, q09 — `FROM` clause reordered (2026-08-19)
+
+```diff
+     FROM
+         part,
+-        supplier,
+-        lineitem,
++        lineitem,
++        supplier,
+         orders,          -- q08
+         partsupp,        -- q09
+```
+
+Semantically identical: these are inner joins, which commute. **But it is not the stock text, so
+both engines in an A/B comparison must use THIS text or the comparison is invalid.**
+
+### Why
+
+The FE has **no statistics for `FILES()` external scans** — every node in the plan reports
+`cardinality: 1` (see `plans/q08.verbose.txt`). With no cost signal the CBO joins `part` and
+`supplier` first: they are adjacent in the stock `FROM` and share **no predicate** (both keys
+route through `lineitem`). The result is `4:NESTLOOP JOIN / join op: CROSS JOIN`.
+
+That build side is **real, not a bad estimate**:
+
+| Query | HASH_JOIN requested | Decomposition |
+|---|---|---|
+| q08 | 537,032,000,000 B | ÷4 = 134,258 × 10⁶ = filtered_part × supplier |
+| q09 | 2,694,604,000,000 B | ÷4 = 673,651 × 10⁶ = filtered_part × supplier |
+
+The `× 10⁶` is simply SF100's supplier row count. The join OOMs after 100 retries, and
+`engine.rs`'s blanket `parked.clear()` then wipes every parked sender output — so the FE reported
+the collateral `no parked sender output to export for SenderSlot` error and the real cause was
+discarded. (That masking is fixed separately; the wipe now records and reports the true cause.)
+
+Reordering so every adjacent pair shares a predicate removes the cross join entirely: 0 NESTLOOP,
+7 HASH JOIN for q08. **No session variables are required** — with `cardinality: 1` everywhere the
+CBO has nothing to reorder with, so it follows the written order.
+
+### Measured (2× RTX PRO 6000, 2 CNs, SF100)
+
+| Query | Before | After | vs DuckDB oracle |
+|---|---|---|---|
+| q08 | never completed | **1897 ms** | MATCH, max rel diff 3.7e-05 |
+| q09 | never completed | **2115 ms** | 175/175 rows, all LOW by ~0.147 % (the known decimal-lowering defect) |
+
+Full sweep went from 19/22 to **20/22**, no timing regression (−0.4 % total).
+
+### The principled fix
+
+Give the CBO real cardinalities — then the stock text plans correctly and this deviation can be
+reverted. Options not yet evaluated: `ANALYZE` on the external scans, an external catalog with
+statistics, or injected stats. All may require a load step, which would break the benchmark's
+"read parquet directly, no load" property. Until then this reorder is the documented workaround.

--- a/experimental/starrocks/benchmarks/tpch/QUERY-DEVIATIONS.md
+++ b/experimental/starrocks/benchmarks/tpch/QUERY-DEVIATIONS.md
@@ -8,6 +8,19 @@ entire statement and the query fails with a syntax error. Verified the hard way.
 
 ---
 
+## q11 — fraction scaled by SF, `ORDER BY value DESC, ps_partkey` (2026-09-05)
+
+The HAVING fraction is `0.0001 / __TPCH_SF__` (substituted from `$TPCH_SF`, default 1), which is
+the spec's `0.0001 / SF`; the stock constant returns zero rows at SF1000 on every engine.
+
+The spec orders by `value DESC` only. At SF1000 the query returns 936,989 rows and thousands of
+them share a `value`, so two correct engines order the ties differently and a row-order-sensitive
+compare (`tools/compare.py`) reports `VALUES-DIFFER` with a huge `maxreldiff` on nothing but tie
+order (arm W1-1cn: 12,790 mismatched cells, every one a swapped tie). `ps_partkey` is unique per
+output row, so appending it makes the order total. Same text on both engines, same result set.
+
+---
+
 ## q08, q09 — `FROM` clause reordered (2026-08-19)
 
 ```diff

--- a/experimental/starrocks/benchmarks/tpch/README.md
+++ b/experimental/starrocks/benchmarks/tpch/README.md
@@ -59,6 +59,13 @@ with double-precision summation order — that is what the relative tolerance is
 line runs the compare step at the end of the sweep instead of as a separate command, and
 the sweep then exits with compare.py's status; the oracle still has to be produced first.
 
+**CTE reuse.** The FE inlines a CTE once per reference unless its cost model prefers reuse
+(`cbo_cte_reuse_rate`, default 1.15). q15's `revenue` CTE is referenced twice, so by default
+lineitem is scanned twice and the join compares two independent evaluations of the same sum.
+`SET GLOBAL cbo_cte_reuse_rate = 0` forces reuse: the FE computes the CTE once and fans it out
+through a `MULTI_CAST_DATA_STREAM_SINK`, which the CN runs as one parked output with one local
+consumer per sink. Run it once after the FE is up (the SF1000 arms pass it as `FE_SETUP_SQL`).
+
 A two-CN smoke test on one GPU is `pixi run cluster2` with `MIN_BACKENDS=2`;
 [`DEMO.md`](../../DEMO.md) walks through a Q6-shaped query on that cluster (different date
 and discount bounds, so its `61567694.9502` is not q06's answer).

--- a/experimental/starrocks/benchmarks/tpch/README.md
+++ b/experimental/starrocks/benchmarks/tpch/README.md
@@ -1,0 +1,120 @@
+# TPC-H benchmark harness for Sirius GPU compute nodes
+
+Times TPC-H queries over external parquet against whatever FE answers on port 9030, then
+checks the answers against DuckDB. The queries scan the files through `FILES()` CTEs — no
+data loading step; the FE byte-splits large tables across the compute nodes.
+
+This tree ships q01 and q06, the two queries the one-CN-per-GPU proof runs. The harness
+takes any `queries/qNN.sql` written in the same shape.
+
+## Layout
+
+- `queries/qNN.sql` — the queries with `FILES()` preludes; `__TPCH_DATA__` is substituted
+  with `$TPCH_DATA` at run time (a directory holding `<table>/*.parquet`, the layout
+  [`bench/common/gen-tpch.sh`](../../../../bench/common/gen-tpch.sh) writes).
+- `bench.sh` — per-query sweep: 1 discarded warm-up + N timed runs, wall-clock ms
+  around `mysql -e`, medians taken later. Refusals (ERROR) are recorded once; hangs
+  are cut at `$QUERY_TIMEOUT` (default 30 s) and recorded as wedges. After either,
+  `$RESTART_CMD` runs — required for the Sirius CN (see caveat below).
+  **`--cold`** records the warm-up (run 0) instead of discarding it, tagged
+  `phase=cold` and cut at `$COLD_TIMEOUT` (default 180 s) — run 0 is the only run
+  that exercises first contact (plan-cache misses, first-touch allocation).
+  `--cold-restart` additionally restarts before each query so every run 0 is a true
+  cold cluster.
+- [`../../tools/oracle.py`](../../tools/oracle.py) — runs the same SQL through DuckDB on
+  the CPU over the same parquet and writes one `<q>.tsv` per query, formatted like
+  `mysql --batch`. Needs the `duckdb` Python package (the repo's pixi env has it).
+- [`../../tools/compare.py`](../../tools/compare.py) — diffs the sweep's `<q>.rN.out`
+  files against the oracle's TSVs: row count first, then cell by cell (relative
+  tolerance for numerics, exact match otherwise), and exits non-zero unless every
+  query matches. This is the harness's correctness gate; `bench.sh` alone times and
+  counts rows.
+- [`../cluster8.sh`](../cluster8.sh) — 1 FE + N Sirius CNs, one CN per GPU, cross-CN
+  exchange over nixl.
+
+## Run
+
+```bash
+# from experimental/starrocks/ — 1 FE + one CN per GPU (NUM_CNS defaults to 8).
+# Keep it in its own terminal or background task.
+NUM_CNS=4 GPU_MEM=48GiB STAGING=8GiB ./benchmarks/cluster8.sh
+
+# The sweep. MIN_BACKENDS is the real CN count (see below), not a floor.
+TPCH_DATA=/path/to/tpch_sf1 MIN_BACKENDS=4 QUERY_TIMEOUT=120 \
+  ./benchmarks/tpch/bench.sh /tmp/bench/A/timings.csv 3 q01 q06
+
+# The answers. oracle.py runs DuckDB over the same files; compare.py diffs the two.
+python3 tools/oracle.py benchmarks/tpch/queries /path/to/tpch_sf1 /tmp/bench/oracle q01 q06
+python3 tools/compare.py /tmp/bench/A /tmp/bench/oracle
+```
+
+At SF1, q01 returns 4 rows and q06 one row (`revenue` 123141078.2283, low digits varying
+with double-precision summation order — that is what the relative tolerance is for);
+`compare.py` reports `2/2 match`. Setting `ORACLE_DIR=/tmp/bench/oracle` on the `bench.sh`
+line runs the compare step at the end of the sweep instead of as a separate command, and
+the sweep then exits with compare.py's status; the oracle still has to be produced first.
+
+A two-CN smoke test on one GPU is `pixi run cluster2` with `MIN_BACKENDS=2`;
+[`DEMO.md`](../../DEMO.md) walks through a Q6-shaped query on that cluster (different date
+and discount bounds, so its `61567694.9502` is not q06's answer).
+
+**Caveat:** the CN does not implement `cancel_plan_fragment`, so a hung or
+mid-execution-failed query strands its fragments; the stranded fragments eventually starve
+the CNs and the FE reports "No available backends" for everything after. `RESTART_CMD` is
+therefore mandatory for a Sirius cluster — without it, every measurement after the first
+failure is invalid:
+
+```bash
+RESTART_CMD='pkill -f "[s]irius-starrocks-cn"; pkill -f "[S]tarRocksFE"; sleep 5; \
+  (cd <repo>/experimental/starrocks && NUM_CNS=4 nohup ./benchmarks/cluster8.sh >/tmp/cluster8.log 2>&1 &)'
+```
+
+## Multiple GPUs / more CNs
+
+`cluster2` starts two CNs on one GPU (each with its own memory carve-out).
+[`cluster8.sh`](../cluster8.sh) puts one CN per GPU: `NUM_CNS` CNs, each with a contiguous
+10-port block from `PORT_BASE`, its own `--gpu-device`, `GPU_MEM`/`HOST_MEM` limits and a
+`STAGING`-sized exchange arena. It clears an inherited `CUDA_VISIBLE_DEVICES` (which would
+otherwise win over `--gpu-device` and land every CN on one GPU) and exports
+`SIRIUS_QUERY_WATCHDOG_SECS` so a stalled query fails loudly instead of wedging a CN. Check
+that `nvidia-smi` shows exactly one CN process per GPU before measuring anything.
+
+The harness itself is topology-agnostic — it only talks to the FE; `wait_alive` accepts any
+mix of alive compute nodes/backends (the `Alive` column, resolved from the header row, not a
+`grep` over the whole row). Set `MIN_BACKENDS` to the real node count: it is the expected
+size, not a floor, and the sweep aborts if more nodes are alive than you declared (a
+threshold below the real topology can be satisfied mid-boot, and the sweep then measures a
+half-started cluster).
+
+Whether every CN actually did work is a separate question from whether the answer was
+right: [`../../scripts/cn-distribution.py`](../../scripts/cn-distribution.py) reads the
+per-CN telemetry under `.cn<N>/` and reports the per-CN split, carrying a CN that produced
+nothing as an explicit zero.
+
+## Before calling a query broken: check whether it was a transport timeout
+
+At SF500 and above, a *refused* query is often a healthy CN that ran out of clock, not a bug.
+The transport is serialized (one thread per CN, blocking round trips), so a peer's
+`request_staging_lease` queues behind whatever fragment its engine thread is currently running.
+The default 60 s bound then fails a query that would have completed — an SF100 q08 refused at
+60758 ms, just past the bound, was exactly this.
+
+Tell the two apart in the CN log:
+
+| | Looks like |
+|---|---|
+| Transport timeout | `request_staging_lease to <host>:<port>: failed to read reply frame: …` — names the peer and method, no peer-side status |
+| Real query failure | `… failed with status <code>: <messages>` — a `StatusPB` the peer actually sent |
+
+For the first, raise `SIRIUS_CN_RPC_TIMEOUT_SECS` and re-run before concluding anything. For
+the second, raising it will not help — the peer answered and refused.
+
+High-level knob list: [`../../docs/TUNABLES.md`](../../docs/TUNABLES.md).
+
+## Notes
+
+The harness only talks to the FE, so the same sweep times a stock StarRocks FE + BE cluster
+on port 9030 as a CPU baseline. Run one engine at a time: they share the FE port, the backend
+port pairs and the host CPUs. At small scale factors, fixed per-query overheads (fragment
+dispatch, first-touch allocation) matter as much as scan throughput. Results are indicative,
+not a TPC-compliant benchmark.

--- a/experimental/starrocks/benchmarks/tpch/README.md
+++ b/experimental/starrocks/benchmarks/tpch/README.md
@@ -4,14 +4,18 @@ Times TPC-H queries over external parquet against whatever FE answers on port 90
 checks the answers against DuckDB. The queries scan the files through `FILES()` CTEs — no
 data loading step; the FE byte-splits large tables across the compute nodes.
 
-This tree ships q01 and q06, the two queries the one-CN-per-GPU proof runs. The harness
-takes any `queries/qNN.sql` written in the same shape.
+This tree ships all 22 queries. Every departure from the stock TPC-H text is recorded in
+[`QUERY-DEVIATIONS.md`](QUERY-DEVIATIONS.md) (never as `--` comments inside the `.sql`
+files, which `mysql -e` would swallow). q11 keeps its `0.0001` fraction spec-correct at any
+scale through `__TPCH_SF__`, substituted with `$TPCH_SF` (default 1) by `bench.sh` and
+`oracle.py`; at SF1000 without it the query returns zero rows on every engine.
 
 ## Layout
 
 - `queries/qNN.sql` — the queries with `FILES()` preludes; `__TPCH_DATA__` is substituted
   with `$TPCH_DATA` at run time (a directory holding `<table>/*.parquet`, the layout
-  [`bench/common/gen-tpch.sh`](../../../../bench/common/gen-tpch.sh) writes).
+  [`bench/common/gen-tpch.sh`](../../../../bench/common/gen-tpch.sh) writes) and
+  `__TPCH_SF__` with `$TPCH_SF`.
 - `bench.sh` — per-query sweep: 1 discarded warm-up + N timed runs, wall-clock ms
   around `mysql -e`, medians taken later. Refusals (ERROR) are recorded once; hangs
   are cut at `$QUERY_TIMEOUT` (default 30 s) and recorded as wedges. After either,
@@ -24,11 +28,12 @@ takes any `queries/qNN.sql` written in the same shape.
 - [`../../tools/oracle.py`](../../tools/oracle.py) — runs the same SQL through DuckDB on
   the CPU over the same parquet and writes one `<q>.tsv` per query, formatted like
   `mysql --batch`. Needs the `duckdb` Python package (the repo's pixi env has it).
-- [`../../tools/compare.py`](../../tools/compare.py) — diffs the sweep's `<q>.rN.out`
-  files against the oracle's TSVs: row count first, then cell by cell (relative
-  tolerance for numerics, exact match otherwise), and exits non-zero unless every
-  query matches. This is the harness's correctness gate; `bench.sh` alone times and
-  counts rows.
+- [`../../tools/compare.py`](../../tools/compare.py) — diffs EVERY `<q>.rN.out` of the
+  sweep against the oracle's TSVs: row count first, then cell by cell (relative
+  tolerance for numerics, exact match otherwise). A query's verdict is the worst of its
+  runs, so a cold run that returned zero rows next to two matching warm runs is reported
+  as the flake it is; it exits non-zero unless every run of every query matches. This is
+  the harness's correctness gate; `bench.sh` alone times and counts rows.
 - [`../cluster8.sh`](../cluster8.sh) — 1 FE + N Sirius CNs, one CN per GPU, cross-CN
   exchange over nixl.
 

--- a/experimental/starrocks/benchmarks/tpch/README.md
+++ b/experimental/starrocks/benchmarks/tpch/README.md
@@ -10,6 +10,25 @@ files, which `mysql -e` would swallow). q11 keeps its `0.0001` fraction spec-cor
 scale through `__TPCH_SF__`, substituted with `$TPCH_SF` (default 1) by `bench.sh` and
 `oracle.py`; at SF1000 without it the query returns zero rows on every engine.
 
+## Runtime prerequisites
+
+This harness is useful as a reproducible workload and correctness gate now, but a real
+multi-CN Sirius run is not available on `dev` alone. It requires the CN bring-up work in
+#1714 (the `--gpu-device`, memory-carve-out and readiness behavior used by
+`cluster8.sh`), the stable exchange staging arena from #1693, and the follow-on
+distributed exchange runtime. Keep this PR as a Draft until that runtime is ready to
+land with it.
+
+`cluster8.sh` accepts `GPU_DEVICES=0,0` when two CNs intentionally share a GPU. Its
+`MIG_DEVICES` UUID branch is retained as future launcher plumbing, but is **not a
+supported launch on the current engine**: the engine's NVML device-count check fails
+under UUID-only visibility. On the current two-MIG box use whole-GPU ordinals such as
+`GPU_DEVICES=0,1` until that engine limitation is fixed. Each CN reserves `GPU_MEM`
+for the engine **plus** `STAGING` outside that limit, as well as a CUDA context; size
+every shared GPU or MIG slice for the total. For example, the default
+`GPU_MEM=64GiB STAGING=8GiB` needs about 72 GiB before context overhead per CN.
+`MIG_DEVICES` takes precedence over `GPU_DEVICES` when it becomes supported.
+
 ## Layout
 
 - `queries/qNN.sql` — the queries with `FILES()` preludes; `__TPCH_DATA__` is substituted

--- a/experimental/starrocks/benchmarks/tpch/bench.sh
+++ b/experimental/starrocks/benchmarks/tpch/bench.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# TPC-H timing sweep against whatever FE answers on $FE_PORT.
+#
+# Usage: bench.sh [--cold|--cold-restart] <out_csv> [runs] [q01 q02 ...]
+#   out_csv   where per-run timings land (CSV: query,run,phase,status,ms,rows)
+#   runs      timed repetitions per query after the warm-up (default 3)
+#   qNN...    subset of queries; default every queries/qNN.sql
+#
+# Cold-start mode (--cold, or COLD=1; the flag is optional so existing positional
+# callers keep working unchanged):
+#   Run 0 -- the first execution of a query on the current cluster -- is discarded as
+#   a warm-up by default, and it is the only run that exercises first contact
+#   (plan-cache misses, first-touch allocation). --cold RECORDS it tagged phase=cold;
+#   runs 1..N stay phase=warm, which keeps the cold outlier out of the warm medians
+#   while both land in one file.
+#   Cold runs are cut at $COLD_TIMEOUT (default 180 s) rather than $QUERY_TIMEOUT: a
+#   first-contact stall can run past a minute, and a 30 s cut records it as a generic
+#   wedge carrying no latency information.
+#   A failing COLD run does NOT trigger $RESTART_CMD -- a restart would only make the
+#   next run cold again -- so the warm runs continue on the same cluster and a
+#   cold-only failure is visible as such. A failing WARM run keeps the old behaviour
+#   (record, restart, skip the rest of that query).
+#
+# --cold-restart implies --cold and additionally runs $RESTART_CMD before every
+#   query, so every run 0 is a true cold-cluster first contact instead of only the
+#   sweep's first query. Requires $RESTART_CMD.
+#
+# Environment:
+#   TPCH_DATA          directory holding <table>/*.parquet (substituted into the
+#                      queries' FILES() paths; required)
+#   FE_PORT            FE MySQL port (default 9030)
+#   QUERY_TIMEOUT      per-run client timeout in seconds for warm runs (default 30;
+#                      SF1 passes finish in well under 2s, so anything near this is
+#                      a hang)
+#   COLD_TIMEOUT       per-run client timeout for run 0 (default 180)
+#   COLD               set to 1 for --cold without touching the argv
+#   MIN_BACKENDS       alive nodes wait_alive requires before proceeding (default 2).
+#                      Treated as the EXPECTED size of the cluster, not a floor: if
+#                      more nodes than this are alive the sweep aborts, because a
+#                      threshold below the real topology can be satisfied while nodes
+#                      are still joining and the sweep then measures a half-booted
+#                      cluster. Set it to the real node count.
+#   ALLOW_EXTRA_BACKENDS  set to 1 to downgrade that abort to a warning
+#   RESTART_CMD        command that fully restarts the cluster. The CN has no
+#                      cancel_plan_fragment yet, so a hung or failed query strands
+#                      its fragments and eventually starves the CNs ("No available
+#                      backends") -- without a restart every later measurement is
+#                      invalid. Leave empty only for engines that clean up after
+#                      themselves (e.g. stock StarRocks BEs).
+#   ORACLE_DIR         directory of <q>.tsv answers written by ../../tools/oracle.py over
+#                      the same TPCH_DATA. When set, ../../tools/compare.py diffs the last
+#                      run of every query against it once the sweep ends and its exit
+#                      status becomes the sweep's, so a fast wrong answer cannot pass as
+#                      a win. Optional: the two-step (bench, then compare) works without it.
+#
+# A refusal (ERROR on the first output line) is recorded once and not retried;
+# a timeout/empty result is recorded as a wedge.
+#
+# NOTE: this script times and counts rows only -- it does not check answers by
+# itself. Answers are checked by ../../tools/oracle.py (DuckDB over the same parquet)
+# and ../../tools/compare.py, which runs at the end of the sweep when ORACLE_DIR is set.
+set -u
+HERE=$(cd "$(dirname "$0")" && pwd)
+
+COLD=${COLD:-0}
+COLD_RESTART=${COLD_RESTART:-0}
+while [ $# -gt 0 ]; do
+  case $1 in
+    --cold)         COLD=1; shift ;;
+    --cold-restart) COLD=1; COLD_RESTART=1; shift ;;
+    --)             shift; break ;;
+    -*)             echo "unknown option: $1" >&2; exit 2 ;;
+    *)              break ;;
+  esac
+done
+
+OUT_CSV=${1:?usage: bench.sh [--cold|--cold-restart] <out_csv> [runs] [q01 q02 ...]}
+RUNS=${2:-3}
+shift $(( $# >= 2 ? 2 : 1 ))
+QUERIES=("$@")
+[ ${#QUERIES[@]} -eq 0 ] && QUERIES=($(cd "$HERE/queries" && ls q*.sql | sed 's/\.sql$//'))
+
+TPCH_DATA=${TPCH_DATA:?set TPCH_DATA to the directory holding <table>/*.parquet}
+FE_PORT=${FE_PORT:-9030}
+QUERY_TIMEOUT=${QUERY_TIMEOUT:-30}
+COLD_TIMEOUT=${COLD_TIMEOUT:-180}
+RESTART_CMD=${RESTART_CMD:-}
+MIN_BACKENDS=${MIN_BACKENDS:-2}
+ALLOW_EXTRA_BACKENDS=${ALLOW_EXTRA_BACKENDS:-0}
+ORACLE_DIR=${ORACLE_DIR:-}
+MYSQL="mysql --host 127.0.0.1 --port $FE_PORT --user root --batch --connect-timeout=5"
+OUT=$(dirname "$OUT_CSV")
+mkdir -p "$OUT"
+
+if [ "$COLD_RESTART" = 1 ] && [ -z "$RESTART_CMD" ]; then
+  echo "--cold-restart needs RESTART_CMD to make each run 0 cold" >&2
+  exit 2
+fi
+if [ -n "$ORACLE_DIR" ] && [ ! -d "$ORACLE_DIR" ]; then
+  echo "ORACLE_DIR=$ORACLE_DIR is not a directory (run ../../tools/oracle.py first)" >&2
+  exit 2
+fi
+
+# Number of rows whose Alive column is exactly "true".
+#
+# The old form -- `SHOW ... | grep -c true` -- matched the whole row, so any other
+# true-valued column (HasStoragePath, SystemDecommissioned) counted a node as alive
+# and $MIN_BACKENDS could be satisfied by a cluster that had not finished booting.
+#
+# Alive is column 9 of both statements: SHOW emits the ProcDir title lists verbatim
+# (ShowExecutor.visitShowComputeNodes / .visitShowBackendsStatement -> ...ProcDir
+# .getMetadata()), and the first nine titles of ComputeNodeProcDir.TITLE_NAMES and
+# of BackendsProcDir.TITLE_NAMES are identical: <Id>, IP, HeartbeatPort, BePort,
+# HttpPort, BrpcPort, LastStartTime, LastHeartbeat, Alive. (The shared-data variants
+# only append columns, so the index is stable there too.) The index is resolved from
+# the header row anyway, so a future column insertion cannot silently re-break this
+# the way the grep did; an unrecognised header yields 0 and the gate fails closed.
+alive_count() {
+  $MYSQL -e "$1" 2>/dev/null | awk -F'\t' '
+    NR == 1 { for (i = 1; i <= NF; i++) if ($i == "Alive") c = i; next }
+    c && $c == "true" { n++ }
+    END { print n + 0 }'
+}
+
+# Waits for >= $MIN_BACKENDS alive nodes AND for that count to hold across two
+# consecutive polls -- a single poll crossing the threshold can be a cluster that is
+# still adding nodes. Publishes the settled counts in $ALIVE_CN/$ALIVE_BE/$ALIVE_TOTAL.
+ALIVE_CN=0; ALIVE_BE=0; ALIVE_TOTAL=0
+wait_alive() {
+  local n=0 b=0 total=0 prev=-1
+  for _ in $(seq 1 150); do
+    n=$(alive_count "SHOW COMPUTE NODES;")
+    b=$(alive_count "SHOW BACKENDS;")
+    total=$((n + b))
+    ALIVE_CN=$n; ALIVE_BE=$b; ALIVE_TOTAL=$total
+    [ "$total" -ge "$MIN_BACKENDS" ] && [ "$total" -eq "$prev" ] && return 0
+    prev=$total
+    sleep 2
+  done
+  return 1
+}
+
+restart_cluster() {
+  [ -z "$RESTART_CMD" ] && return 0
+  echo "restarting cluster..."
+  eval "$RESTART_CMD"
+  wait_alive
+}
+
+wait_alive || {
+  echo "no cluster on port $FE_PORT (alive: $ALIVE_CN CN + $ALIVE_BE BE, need $MIN_BACKENDS)"
+  exit 1
+}
+if [ "$ALIVE_TOTAL" -gt "$MIN_BACKENDS" ]; then
+  echo "MIN_BACKENDS=$MIN_BACKENDS but $ALIVE_TOTAL nodes are alive ($ALIVE_CN CN + $ALIVE_BE BE)." >&2
+  echo "  MIN_BACKENDS is the gate that stops a sweep from starting against a partially" >&2
+  echo "  booted cluster; set below the real topology it can be satisfied while nodes are" >&2
+  echo "  still joining, and the sweep then measures the wrong cluster." >&2
+  if [ "$ALLOW_EXTRA_BACKENDS" = 1 ]; then
+    echo "  ALLOW_EXTRA_BACKENDS=1 -- continuing anyway." >&2
+  else
+    echo "  Re-run with MIN_BACKENDS=$ALIVE_TOTAL (or ALLOW_EXTRA_BACKENDS=1 to override)." >&2
+    exit 1
+  fi
+fi
+echo "cluster: $ALIVE_CN alive compute nodes + $ALIVE_BE alive backends (MIN_BACKENDS=$MIN_BACKENDS)"
+[ "$COLD" = 1 ] && echo "cold mode: run 0 is recorded (phase=cold, timeout ${COLD_TIMEOUT}s)"
+[ "$COLD_RESTART" = 1 ] && echo "cold-restart mode: RESTART_CMD runs before every query"
+
+echo "query,run,phase,status,ms,rows" > "$OUT_CSV"
+
+for q in "${QUERIES[@]}"; do
+  Q=$(sed "s|__TPCH_DATA__|$TPCH_DATA|g" "$HERE/queries/$q.sql")
+  if [ "$COLD_RESTART" = 1 ]; then
+    restart_cluster || { echo "cluster did not recover"; exit 1; }
+  fi
+  for r in $(seq 0 "$RUNS"); do   # run 0 = first contact: discarded unless --cold
+    if [ "$r" -eq 0 ]; then phase=cold; tmo=$COLD_TIMEOUT; else phase=warm; tmo=$QUERY_TIMEOUT; fi
+    f=$OUT/$q.r$r.out
+    t0=$(date +%s%3N)
+    timeout "$tmo" $MYSQL -e "${Q}" > "$f" 2>&1
+    rc=$?
+    t1=$(date +%s%3N)
+    ms=$((t1 - t0))
+    if [ $rc -eq 0 ] && [ -s "$f" ] && ! head -1 "$f" | grep -q ERROR; then
+      rows=$(($(wc -l < "$f") - 1))
+      if [ "$r" -gt 0 ] || [ "$COLD" = 1 ]; then
+        echo "$q,$r,$phase,pass,$ms,$rows" >> "$OUT_CSV"
+      fi
+      echo "$q r$r $phase pass ${ms}ms rows=$rows"
+      continue
+    fi
+    if head -1 "$f" 2>/dev/null | grep -q ERROR; then
+      echo "$q,$r,$phase,refused,$ms,0" >> "$OUT_CSV"
+      echo "$q r$r $phase REFUSED: $(head -c 160 "$f" | tr '\n' ' ')"
+    else
+      echo "$q,$r,$phase,wedge,$ms,0" >> "$OUT_CSV"
+      echo "$q r$r $phase WEDGE/TIMEOUT (rc=$rc, cut at ${tmo}s)"
+    fi
+    if [ "$COLD" = 1 ] && [ "$phase" = cold ]; then
+      # The cold failure IS the datapoint; keep going on the same cluster so the warm
+      # runs show whether it was first-contact-only. A restart here would just produce
+      # another cold failure.
+      echo "  (cold failure recorded; continuing to warm runs on the same cluster)"
+      continue
+    fi
+    restart_cluster || { echo "cluster did not recover"; exit 1; }
+    break
+  done
+done
+echo "== bench complete: $OUT_CSV =="
+if [ -n "$ORACLE_DIR" ]; then
+  exec python3 "$HERE/../../tools/compare.py" "$OUT" "$ORACLE_DIR"
+fi

--- a/experimental/starrocks/benchmarks/tpch/bench.sh
+++ b/experimental/starrocks/benchmarks/tpch/bench.sh
@@ -28,6 +28,8 @@
 # Environment:
 #   TPCH_DATA          directory holding <table>/*.parquet (substituted into the
 #                      queries' FILES() paths; required)
+#   TPCH_SF            scale factor of TPCH_DATA (default 1); substituted for
+#                      __TPCH_SF__, which q11 uses to scale its 0.0001 fraction
 #   FE_PORT            FE MySQL port (default 9030)
 #   QUERY_TIMEOUT      per-run client timeout in seconds for warm runs (default 30;
 #                      SF1 passes finish in well under 2s, so anything near this is
@@ -81,6 +83,7 @@ QUERIES=("$@")
 [ ${#QUERIES[@]} -eq 0 ] && QUERIES=($(cd "$HERE/queries" && ls q*.sql | sed 's/\.sql$//'))
 
 TPCH_DATA=${TPCH_DATA:?set TPCH_DATA to the directory holding <table>/*.parquet}
+TPCH_SF=${TPCH_SF:-1}
 FE_PORT=${FE_PORT:-9030}
 QUERY_TIMEOUT=${QUERY_TIMEOUT:-30}
 COLD_TIMEOUT=${COLD_TIMEOUT:-180}
@@ -170,7 +173,7 @@ echo "cluster: $ALIVE_CN alive compute nodes + $ALIVE_BE alive backends (MIN_BAC
 echo "query,run,phase,status,ms,rows" > "$OUT_CSV"
 
 for q in "${QUERIES[@]}"; do
-  Q=$(sed "s|__TPCH_DATA__|$TPCH_DATA|g" "$HERE/queries/$q.sql")
+  Q=$(sed -e "s|__TPCH_DATA__|$TPCH_DATA|g" -e "s|__TPCH_SF__|$TPCH_SF|g" "$HERE/queries/$q.sql")
   if [ "$COLD_RESTART" = 1 ]; then
     restart_cluster || { echo "cluster did not recover"; exit 1; }
   fi

--- a/experimental/starrocks/benchmarks/tpch/queries/q01.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q01.sql
@@ -1,0 +1,30 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    l_returnflag,
+    l_linestatus,
+    sum(l_quantity) AS sum_qty,
+    sum(l_extendedprice) AS sum_base_price,
+    sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+    avg(l_quantity) AS avg_qty,
+    avg(l_extendedprice) AS avg_price,
+    avg(l_discount) AS avg_disc,
+    count(*) AS count_order
+FROM
+    lineitem
+WHERE
+    l_shipdate <= CAST('1998-09-02' AS date)
+GROUP BY
+    l_returnflag,
+    l_linestatus
+ORDER BY
+    l_returnflag,
+    l_linestatus;

--- a/experimental/starrocks/benchmarks/tpch/queries/q02.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q02.sql
@@ -1,0 +1,52 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    s_acctbal,
+    s_name,
+    n_name,
+    p_partkey,
+    p_mfgr,
+    s_address,
+    s_phone,
+    s_comment
+FROM
+    part,
+    supplier,
+    partsupp,
+    nation,
+    region
+WHERE
+    p_partkey = ps_partkey
+    AND s_suppkey = ps_suppkey
+    AND p_size = 15
+    AND p_type LIKE '%BRASS'
+    AND s_nationkey = n_nationkey
+    AND n_regionkey = r_regionkey
+    AND r_name = 'EUROPE'
+    AND ps_supplycost = (
+        SELECT
+            min(ps_supplycost)
+        FROM
+            partsupp,
+            supplier,
+            nation,
+            region
+        WHERE
+            p_partkey = ps_partkey
+            AND s_suppkey = ps_suppkey
+            AND s_nationkey = n_nationkey
+            AND n_regionkey = r_regionkey
+            AND r_name = 'EUROPE')
+ORDER BY
+    s_acctbal DESC,
+    n_name,
+    s_name,
+    p_partkey
+LIMIT 100;

--- a/experimental/starrocks/benchmarks/tpch/queries/q03.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q03.sql
@@ -1,0 +1,32 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    l_orderkey,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue,
+    o_orderdate,
+    o_shippriority
+FROM
+    customer,
+    orders,
+    lineitem
+WHERE
+    c_mktsegment = 'BUILDING'
+    AND c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND o_orderdate < CAST('1995-03-15' AS date)
+    AND l_shipdate > CAST('1995-03-15' AS date)
+GROUP BY
+    l_orderkey,
+    o_orderdate,
+    o_shippriority
+ORDER BY
+    revenue DESC,
+    o_orderdate
+LIMIT 10;

--- a/experimental/starrocks/benchmarks/tpch/queries/q04.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q04.sql
@@ -1,0 +1,29 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    o_orderpriority,
+    count(*) AS order_count
+FROM
+    orders
+WHERE
+    o_orderdate >= CAST('1993-07-01' AS date)
+    AND o_orderdate < CAST('1993-10-01' AS date)
+    AND EXISTS (
+        SELECT
+            *
+        FROM
+            lineitem
+        WHERE
+            l_orderkey = o_orderkey
+            AND l_commitdate < l_receiptdate)
+GROUP BY
+    o_orderpriority
+ORDER BY
+    o_orderpriority;

--- a/experimental/starrocks/benchmarks/tpch/queries/q05.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q05.sql
@@ -1,0 +1,33 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    n_name,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue
+FROM
+    customer,
+    orders,
+    lineitem,
+    supplier,
+    nation,
+    region
+WHERE
+    c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND l_suppkey = s_suppkey
+    AND c_nationkey = s_nationkey
+    AND s_nationkey = n_nationkey
+    AND n_regionkey = r_regionkey
+    AND r_name = 'ASIA'
+    AND o_orderdate >= CAST('1994-01-01' AS date)
+    AND o_orderdate < CAST('1995-01-01' AS date)
+GROUP BY
+    n_name
+ORDER BY
+    revenue DESC;

--- a/experimental/starrocks/benchmarks/tpch/queries/q06.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q06.sql
@@ -1,0 +1,19 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    sum(l_extendedprice * l_discount) AS revenue
+FROM
+    lineitem
+WHERE
+    l_shipdate >= CAST('1994-01-01' AS date)
+    AND l_shipdate < CAST('1995-01-01' AS date)
+    AND l_discount BETWEEN 0.05
+    AND 0.07
+    AND l_quantity < 24;

--- a/experimental/starrocks/benchmarks/tpch/queries/q07.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q07.sql
@@ -1,0 +1,47 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    supp_nation,
+    cust_nation,
+    l_year,
+    sum(volume) AS revenue
+FROM (
+    SELECT
+        n1.n_name AS supp_nation,
+        n2.n_name AS cust_nation,
+        extract(year FROM l_shipdate) AS l_year,
+        l_extendedprice * (1 - l_discount) AS volume
+    FROM
+        supplier,
+        lineitem,
+        orders,
+        customer,
+        nation n1,
+        nation n2
+    WHERE
+        s_suppkey = l_suppkey
+        AND o_orderkey = l_orderkey
+        AND c_custkey = o_custkey
+        AND s_nationkey = n1.n_nationkey
+        AND c_nationkey = n2.n_nationkey
+        AND ((n1.n_name = 'FRANCE'
+                AND n2.n_name = 'GERMANY')
+            OR (n1.n_name = 'GERMANY'
+                AND n2.n_name = 'FRANCE'))
+        AND l_shipdate BETWEEN CAST('1995-01-01' AS date)
+        AND CAST('1996-12-31' AS date)) AS shipping
+GROUP BY
+    supp_nation,
+    cust_nation,
+    l_year
+ORDER BY
+    supp_nation,
+    cust_nation,
+    l_year;

--- a/experimental/starrocks/benchmarks/tpch/queries/q08.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q08.sql
@@ -1,0 +1,47 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    o_year,
+    sum(
+        CASE WHEN nation = 'BRAZIL' THEN
+            volume
+        ELSE
+            0
+        END) / sum(volume) AS mkt_share
+FROM (
+    SELECT
+        extract(year FROM o_orderdate) AS o_year,
+        l_extendedprice * (1 - l_discount) AS volume,
+        n2.n_name AS nation
+    FROM
+        part,
+        lineitem,
+        supplier,
+        orders,
+        customer,
+        nation n1,
+        nation n2,
+        region
+    WHERE
+        p_partkey = l_partkey
+        AND s_suppkey = l_suppkey
+        AND l_orderkey = o_orderkey
+        AND o_custkey = c_custkey
+        AND c_nationkey = n1.n_nationkey
+        AND n1.n_regionkey = r_regionkey
+        AND r_name = 'AMERICA'
+        AND s_nationkey = n2.n_nationkey
+        AND o_orderdate BETWEEN CAST('1995-01-01' AS date)
+        AND CAST('1996-12-31' AS date)
+        AND p_type = 'ECONOMY ANODIZED STEEL') AS all_nations
+GROUP BY
+    o_year
+ORDER BY
+    o_year;

--- a/experimental/starrocks/benchmarks/tpch/queries/q09.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q09.sql
@@ -1,0 +1,39 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    nation,
+    o_year,
+    sum(amount) AS sum_profit
+FROM (
+    SELECT
+        n_name AS nation,
+        extract(year FROM o_orderdate) AS o_year,
+        l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
+    FROM
+        part,
+        lineitem,
+        supplier,
+        partsupp,
+        orders,
+        nation
+    WHERE
+        s_suppkey = l_suppkey
+        AND ps_suppkey = l_suppkey
+        AND ps_partkey = l_partkey
+        AND p_partkey = l_partkey
+        AND o_orderkey = l_orderkey
+        AND s_nationkey = n_nationkey
+        AND p_name LIKE '%green%') AS profit
+GROUP BY
+    nation,
+    o_year
+ORDER BY
+    nation,
+    o_year DESC;

--- a/experimental/starrocks/benchmarks/tpch/queries/q10.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q10.sql
@@ -1,0 +1,41 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    c_custkey,
+    c_name,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue,
+    c_acctbal,
+    n_name,
+    c_address,
+    c_phone,
+    c_comment
+FROM
+    customer,
+    orders,
+    lineitem,
+    nation
+WHERE
+    c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND o_orderdate >= CAST('1993-10-01' AS date)
+    AND o_orderdate < CAST('1994-01-01' AS date)
+    AND l_returnflag = 'R'
+    AND c_nationkey = n_nationkey
+GROUP BY
+    c_custkey,
+    c_name,
+    c_acctbal,
+    c_phone,
+    n_name,
+    c_address,
+    c_comment
+ORDER BY
+    revenue DESC
+LIMIT 20;

--- a/experimental/starrocks/benchmarks/tpch/queries/q11.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q11.sql
@@ -33,4 +33,5 @@ HAVING
             AND s_nationkey = n_nationkey
             AND n_name = 'GERMANY')
 ORDER BY
-    value DESC;
+    value DESC,
+    ps_partkey;

--- a/experimental/starrocks/benchmarks/tpch/queries/q11.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q11.sql
@@ -1,0 +1,36 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    ps_partkey,
+    sum(ps_supplycost * ps_availqty) AS value
+FROM
+    partsupp,
+    supplier,
+    nation
+WHERE
+    ps_suppkey = s_suppkey
+    AND s_nationkey = n_nationkey
+    AND n_name = 'GERMANY'
+GROUP BY
+    ps_partkey
+HAVING
+    sum(ps_supplycost * ps_availqty) > (
+        SELECT
+            sum(ps_supplycost * ps_availqty) * (0.0001000000 / __TPCH_SF__)
+        FROM
+            partsupp,
+            supplier,
+            nation
+        WHERE
+            ps_suppkey = s_suppkey
+            AND s_nationkey = n_nationkey
+            AND n_name = 'GERMANY')
+ORDER BY
+    value DESC;

--- a/experimental/starrocks/benchmarks/tpch/queries/q12.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q12.sql
@@ -1,0 +1,39 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    l_shipmode,
+    sum(
+        CASE WHEN o_orderpriority = '1-URGENT'
+            OR o_orderpriority = '2-HIGH' THEN
+            1
+        ELSE
+            0
+        END) AS high_line_count,
+    sum(
+        CASE WHEN o_orderpriority <> '1-URGENT'
+            AND o_orderpriority <> '2-HIGH' THEN
+            1
+        ELSE
+            0
+        END) AS low_line_count
+FROM
+    orders,
+    lineitem
+WHERE
+    o_orderkey = l_orderkey
+    AND l_shipmode IN ('MAIL', 'SHIP')
+    AND l_commitdate < l_receiptdate
+    AND l_shipdate < l_commitdate
+    AND l_receiptdate >= CAST('1994-01-01' AS date)
+    AND l_receiptdate < CAST('1995-01-01' AS date)
+GROUP BY
+    l_shipmode
+ORDER BY
+    l_shipmode;

--- a/experimental/starrocks/benchmarks/tpch/queries/q13.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q13.sql
@@ -1,0 +1,28 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    c_count,
+    count(*) AS custdist
+FROM (
+    SELECT
+        c_custkey,
+        count(o_orderkey)
+    FROM
+        customer
+    LEFT OUTER JOIN orders ON c_custkey = o_custkey
+    AND o_comment NOT LIKE '%special%requests%'
+GROUP BY
+    c_custkey) AS c_orders (c_custkey,
+        c_count)
+GROUP BY
+    c_count
+ORDER BY
+    custdist DESC,
+    c_count DESC;

--- a/experimental/starrocks/benchmarks/tpch/queries/q14.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q14.sql
@@ -1,0 +1,23 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    100.00 * sum(
+        CASE WHEN p_type LIKE 'PROMO%' THEN
+            l_extendedprice * (1 - l_discount)
+        ELSE
+            0
+        END) / sum(l_extendedprice * (1 - l_discount)) AS promo_revenue
+FROM
+    lineitem,
+    part
+WHERE
+    l_partkey = p_partkey
+    AND l_shipdate >= date '1995-09-01'
+    AND l_shipdate < CAST('1995-10-01' AS date);

--- a/experimental/starrocks/benchmarks/tpch/queries/q15.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q15.sql
@@ -1,0 +1,39 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+,
+revenue AS (
+    SELECT
+        l_suppkey AS supplier_no,
+        sum(l_extendedprice * (1 - l_discount)) AS total_revenue
+    FROM
+        lineitem
+    WHERE
+        l_shipdate >= CAST('1996-01-01' AS date)
+      AND l_shipdate < CAST('1996-04-01' AS date)
+    GROUP BY
+        supplier_no
+)
+SELECT
+    s_suppkey,
+    s_name,
+    s_address,
+    s_phone,
+    total_revenue
+FROM
+    supplier,
+    revenue
+WHERE
+    s_suppkey = supplier_no
+    AND total_revenue = (
+        SELECT
+            max(total_revenue)
+        FROM revenue)
+ORDER BY
+    s_suppkey;

--- a/experimental/starrocks/benchmarks/tpch/queries/q16.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q16.sql
@@ -1,0 +1,38 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    p_brand,
+    p_type,
+    p_size,
+    count(DISTINCT ps_suppkey) AS supplier_cnt
+FROM
+    partsupp,
+    part
+WHERE
+    p_partkey = ps_partkey
+    AND p_brand <> 'Brand#45'
+    AND p_type NOT LIKE 'MEDIUM POLISHED%'
+    AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
+    AND ps_suppkey NOT IN (
+        SELECT
+            s_suppkey
+        FROM
+            supplier
+        WHERE
+            s_comment LIKE '%Customer%Complaints%')
+GROUP BY
+    p_brand,
+    p_type,
+    p_size
+ORDER BY
+    supplier_cnt DESC,
+    p_brand,
+    p_type,
+    p_size;

--- a/experimental/starrocks/benchmarks/tpch/queries/q17.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q17.sql
@@ -1,0 +1,25 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    sum(l_extendedprice) / 7.0 AS avg_yearly
+FROM
+    lineitem,
+    part
+WHERE
+    p_partkey = l_partkey
+    AND p_brand = 'Brand#23'
+    AND p_container = 'MED BOX'
+    AND l_quantity < (
+        SELECT
+            0.2 * avg(l_quantity)
+        FROM
+            lineitem
+        WHERE
+            l_partkey = p_partkey);

--- a/experimental/starrocks/benchmarks/tpch/queries/q18.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q18.sql
@@ -1,0 +1,42 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice,
+    sum(l_quantity)
+FROM
+    customer,
+    orders,
+    lineitem
+WHERE
+    o_orderkey IN (
+        SELECT
+            l_orderkey
+        FROM
+            lineitem
+        GROUP BY
+            l_orderkey
+        HAVING
+            sum(l_quantity) > 300)
+    AND c_custkey = o_custkey
+    AND o_orderkey = l_orderkey
+GROUP BY
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice
+ORDER BY
+    o_totalprice DESC,
+    o_orderdate
+LIMIT 100;

--- a/experimental/starrocks/benchmarks/tpch/queries/q19.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q19.sql
@@ -1,0 +1,38 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    sum(l_extendedprice * (1 - l_discount)) AS revenue
+FROM
+    lineitem,
+    part
+WHERE (p_partkey = l_partkey
+    AND p_brand = 'Brand#12'
+    AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+    AND l_quantity >= 1
+    AND l_quantity <= 1 + 10
+    AND p_size BETWEEN 1 AND 5
+    AND l_shipmode IN ('AIR', 'AIR REG')
+    AND l_shipinstruct = 'DELIVER IN PERSON')
+    OR (p_partkey = l_partkey
+        AND p_brand = 'Brand#23'
+        AND p_container IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+        AND l_quantity >= 10
+        AND l_quantity <= 10 + 10
+        AND p_size BETWEEN 1 AND 10
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON')
+    OR (p_partkey = l_partkey
+        AND p_brand = 'Brand#34'
+        AND p_container IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+        AND l_quantity >= 20
+        AND l_quantity <= 20 + 10
+        AND p_size BETWEEN 1 AND 15
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON');

--- a/experimental/starrocks/benchmarks/tpch/queries/q20.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q20.sql
@@ -1,0 +1,43 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    s_name,
+    s_address
+FROM
+    supplier,
+    nation
+WHERE
+    s_suppkey IN (
+        SELECT
+            ps_suppkey
+        FROM
+            partsupp
+        WHERE
+            ps_partkey IN (
+                SELECT
+                    p_partkey
+                FROM
+                    part
+                WHERE
+                    p_name LIKE 'forest%')
+                AND ps_availqty > (
+                    SELECT
+                        0.5 * sum(l_quantity)
+                    FROM
+                        lineitem
+                    WHERE
+                        l_partkey = ps_partkey
+                        AND l_suppkey = ps_suppkey
+                        AND l_shipdate >= CAST('1994-01-01' AS date)
+                        AND l_shipdate < CAST('1995-01-01' AS date)))
+            AND s_nationkey = n_nationkey
+            AND n_name = 'CANADA'
+        ORDER BY
+            s_name;

--- a/experimental/starrocks/benchmarks/tpch/queries/q21.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q21.sql
@@ -1,0 +1,47 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    s_name,
+    count(*) AS numwait
+FROM
+    supplier,
+    lineitem l1,
+    orders,
+    nation
+WHERE
+    s_suppkey = l1.l_suppkey
+    AND o_orderkey = l1.l_orderkey
+    AND o_orderstatus = 'F'
+    AND l1.l_receiptdate > l1.l_commitdate
+    AND EXISTS (
+        SELECT
+            *
+        FROM
+            lineitem l2
+        WHERE
+            l2.l_orderkey = l1.l_orderkey
+            AND l2.l_suppkey <> l1.l_suppkey)
+    AND NOT EXISTS (
+        SELECT
+            *
+        FROM
+            lineitem l3
+        WHERE
+            l3.l_orderkey = l1.l_orderkey
+            AND l3.l_suppkey <> l1.l_suppkey
+            AND l3.l_receiptdate > l3.l_commitdate)
+    AND s_nationkey = n_nationkey
+    AND n_name = 'SAUDI ARABIA'
+GROUP BY
+    s_name
+ORDER BY
+    numwait DESC,
+    s_name
+LIMIT 100;

--- a/experimental/starrocks/benchmarks/tpch/queries/q22.sql
+++ b/experimental/starrocks/benchmarks/tpch/queries/q22.sql
@@ -1,0 +1,40 @@
+WITH
+customer AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/customer/*.parquet","format"="parquet")),
+lineitem AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/lineitem/*.parquet","format"="parquet")),
+nation AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/nation/*.parquet","format"="parquet")),
+orders AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/orders/*.parquet","format"="parquet")),
+part AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/part/*.parquet","format"="parquet")),
+partsupp AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/partsupp/*.parquet","format"="parquet")),
+region AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/region/*.parquet","format"="parquet")),
+supplier AS (SELECT * FROM FILES("path"="file://__TPCH_DATA__/supplier/*.parquet","format"="parquet"))
+SELECT
+    cntrycode,
+    count(*) AS numcust,
+    sum(c_acctbal) AS totacctbal
+FROM (
+    SELECT
+        substring(c_phone, 1, 2) AS cntrycode,
+        c_acctbal
+    FROM
+        customer
+    WHERE
+        substring(c_phone, 1, 2) IN ('13', '31', '23', '29', '30', '18', '17')
+        AND c_acctbal > (
+            SELECT
+                avg(c_acctbal)
+            FROM
+                customer
+            WHERE
+                c_acctbal > 0.00
+                AND substring(c_phone, 1, 2) IN ('13', '31', '23', '29', '30', '18', '17'))
+            AND NOT EXISTS (
+                SELECT
+                    *
+                FROM
+                    orders
+                WHERE
+                    o_custkey = c_custkey)) AS custsale
+GROUP BY
+    cntrycode
+ORDER BY
+    cntrycode;

--- a/experimental/starrocks/scripts/cn-distribution.py
+++ b/experimental/starrocks/scripts/cn-distribution.py
@@ -1,0 +1,724 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Report how a query was distributed across Sirius StarRocks compute nodes (CNs).
+
+Reads the per-CN telemetry trees and answers one question: did every CN actually do work,
+or did the query land on a subset of them?
+
+    <dir>/<prefix><N>/telemetry/<run-uuid>/<record-type>/*.ndjson
+
+Telemetry is buffered in memory and flushed at engine shutdown, and every engine start mints
+a NEW run-uuid. A CN directory holding two run-uuids therefore holds two cluster lifetimes,
+and a failed cold run looks exactly like a healthy one once their records are pooled. Mixing
+them is how a distribution measurement gets contaminated, so this script analyses only the
+NEWEST run-uuid per CN by default and shouts if it finds more than one (--all-runs to
+override).
+
+A CN that produced NO telemetry is not skipped. It is carried through every table, the
+participation list and the balance verdict as an explicit zero, because "this CN never
+appeared" is the single most important answer this tool can give -- dropping it silently
+turns a 2-of-4 cluster into a "1.00x BALANCED" reading over the two survivors.
+
+ON-DISK SCHEMA
+--------------
+Every line is one event with a fixed envelope:
+
+    {"id": <entity-uuid>, "timestamp": <unix-ns>, "data": {...}}
+
+`id` is the ENTITY that emitted the event, not an event id -- one entity emits many lines as
+it changes state. Two payload shapes exist:
+
+  * declaration entities (operator, plan, port, worker, query_group, gpu_device, thread_group):
+        "data": {"Declaration": {...}}        # engine/worker use {"Init": ...} / {"Exit": ...}
+  * FSM entities (query, task, data_batch, channel, batch_placement, memory, ...):
+        "data": {"seq": <int>, "state": {"<StateName>": {...}}}
+    whose terminal transition is the BARE STRING "Exit", not an object:
+        "data": {"seq": 3, "state": "Exit"}
+
+CONSEQUENCE: a row count is an EVENT count, not a unit of work. In the reference capture
+`task` held 28,044 rows across 3,044 distinct task entities (9.2 rows each), and part of that
+multiplier is scheduling churn -- 6,088 Queued events for 3,044 tasks means tasks are requeued.
+Distinct entities are therefore the honest denominator for "how was the work placed", and are
+what the balance verdict uses by default (--metric rows to switch).
+
+Query attribution follows the reference graph. `query_id` as a literal field name appears on
+exactly ONE record type -- `plan` -- so a top-level key scan finds almost nothing; the chain
+below was measured at 100% coverage against a real capture:
+
+    plan.Declaration.parent.query_id      -> query id (== the `query` entity's own id)
+    operator.Declaration.plan_id          -> plan id
+    port.Declaration.operator_id          -> operator id
+    task.Created.pipeline_uuid            -> operator id
+    data_batch.Constructed.producer_pipeline_uuid   -> operator id
+    batch_placement.BatchRegistered.pipeline_uuid   -> operator id
+    batch_placement.BatchPackaged.task_uuid         -> task id
+
+Those names are NOT hard-coded. The graph is walked generically: any uuid-valued field is a
+candidate edge, and an entity inherits a query when its resolvable references agree. That
+generic walk was diffed against the explicit chain above over 88 queries / 11,544 entities and
+produced identical counts. Engine-scoped entities (engine, worker, thread_group, memory,
+task_queue, executor_thread, channel, ...) legitimately belong to no query and are reported as
+unattributed rather than forced into one.
+
+Everything else is schema-defensive: record types are discovered by listing directories, no
+field name is required to exist, and a malformed line is counted rather than fatal.
+
+Usage:
+    cn-distribution.py [--dir experimental/starrocks] [--prefix .cn] [--json]
+                       [--all-runs] [--metric entities|rows] [--headline task]
+                       [--tolerance 1.5] [--full-uuid] [--no-attribution]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+
+# Key names we accept as a direct query reference.
+QUERY_KEY_RE = re.compile(r"(?i)^(query_id|queryid|qid|query)$|_query_id$")
+UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+# Columns of the headline table, in order. Only those actually present are printed.
+DEFAULT_COLUMNS = ["operator", "task", "data_batch", "query", "channel"]
+# Cap on refs retained per entity, so a pathological plan cannot blow up memory.
+MAX_REFS_PER_ENTITY = 64
+MAX_RESOLVE_PASSES = 20
+
+
+# --------------------------------------------------------------------------- scanning
+
+
+def uuid_leaves(obj, trail):
+    """Yield (trail, key, uuid) for every uuid-valued field.
+
+    Only uuid-valued leaves matter, so the dotted path is assembled by the caller on a hit
+    instead of being built for every key of every line.
+    """
+    if isinstance(obj, dict):
+        for key, val in obj.items():
+            if isinstance(val, str):
+                if len(val) == 36 and UUID_RE.match(val):
+                    yield trail, key, val
+            elif isinstance(val, dict):
+                trail.append(key)
+                yield from uuid_leaves(val, trail)
+                trail.pop()
+            elif isinstance(val, list):
+                trail.append(key + "[]")
+                for item in val:
+                    yield from uuid_leaves(item, trail)
+                trail.pop()
+    elif isinstance(obj, list):
+        trail.append("[]")
+        for item in obj:
+            yield from uuid_leaves(item, trail)
+        trail.pop()
+
+
+def uuid7_millis(name):
+    """Decode the mint time of a uuidv7: its first 48 bits are a unix-ms timestamp."""
+    if not UUID_RE.match(name) or name[14] != "7":
+        return None
+    try:
+        return int(name[:8] + name[9:13], 16)
+    except ValueError:
+        return None
+
+
+def fmt_epoch_ms(ms):
+    if ms is None:
+        return "-"
+    try:
+        return _dt.datetime.fromtimestamp(ms / 1000.0, _dt.timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S")
+    except (OverflowError, OSError, ValueError):
+        return "?"
+
+
+class RunScan:
+    """Counts and reference graph for one <cn>/telemetry/<run-uuid> directory.
+
+    `missing=True` marks a CN that produced no telemetry at all; it still occupies a row in
+    every table so it cannot vanish from the verdict.
+    """
+
+    def __init__(self, cn, run_uuid, path, missing=False, reason=""):
+        self.cn = cn
+        self.run_uuid = run_uuid
+        self.path = path
+        self.missing = missing
+        self.reason = reason
+        self.rows = Counter()            # record type -> event lines
+        self.entities = defaultdict(set)  # record type -> distinct entity ids
+        self.parse_errors = Counter()    # record type -> malformed lines
+        self.files = Counter()           # record type -> ndjson files
+        self.query_key_paths = Counter()  # dotted path -> hits (diagnostic)
+        self.refs = defaultdict(set)     # entity id -> referenced uuids
+        self.entity_type = {}            # entity id -> record type
+        self.direct_query = {}           # entity id -> query id (explicit field)
+        self.sidecars = []               # non-directory entries, e.g. model.qmi
+        self.ts_min = None
+        self.ts_max = None
+        self.unattributed = 0
+        self.owner = {}
+
+    # -- accessors used by the report; `missing` scans answer 0 for everything -----------
+    def n_rows(self, rtype):
+        return self.rows.get(rtype, 0)
+
+    def n_entities(self, rtype):
+        return len(self.entities.get(rtype, ()))
+
+    def count(self, rtype, metric):
+        return self.n_entities(rtype) if metric == "entities" else self.n_rows(rtype)
+
+    def record_types(self):
+        return sorted(set(self.rows) | set(self.entities))
+
+    @property
+    def started_ms(self):
+        return uuid7_millis(self.run_uuid) if self.run_uuid else None
+
+    @property
+    def span_s(self):
+        if self.ts_min is None or self.ts_max is None:
+            return None
+        return (self.ts_max - self.ts_min) / 1e9
+
+    def scan(self):
+        if self.missing:
+            return self
+        try:
+            entries = sorted(os.listdir(self.path))
+        except OSError as exc:
+            print(f"cn-distribution: cannot read {self.path}: {exc}", file=sys.stderr)
+            return self
+        for entry in entries:
+            full = os.path.join(self.path, entry)
+            if not os.path.isdir(full):
+                # model.qmi is a provenance sidecar file, not a record type.
+                self.sidecars.append(entry)
+                continue
+            self._scan_type(entry, full)
+        return self
+
+    def _scan_type(self, rtype, dirpath):
+        try:
+            names = sorted(n for n in os.listdir(dirpath) if n.endswith(".ndjson"))
+        except OSError:
+            return
+        self.files[rtype] = len(names)
+        # Ensure the type shows up even with zero rows.
+        self.rows.setdefault(rtype, 0)
+        self.entities.setdefault(rtype, set())
+
+        for name in names:
+            try:
+                handle = open(os.path.join(dirpath, name), "r", encoding="utf-8",
+                              errors="replace")
+            except OSError:
+                continue
+            with handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    self.rows[rtype] += 1
+                    try:
+                        obj = json.loads(line)
+                    except (ValueError, RecursionError):
+                        self.parse_errors[rtype] += 1
+                        continue
+                    if not isinstance(obj, dict):
+                        self.parse_errors[rtype] += 1
+                        continue
+                    self._ingest(rtype, obj)
+
+    def _ingest(self, rtype, obj):
+        ent = obj.get("id")
+        if isinstance(ent, str):
+            self.entities[rtype].add(ent)
+            self.entity_type.setdefault(ent, rtype)
+
+        ts = obj.get("timestamp")
+        if isinstance(ts, int):
+            if self.ts_min is None or ts < self.ts_min:
+                self.ts_min = ts
+            if self.ts_max is None or ts > self.ts_max:
+                self.ts_max = ts
+
+        refs = self.refs[ent] if isinstance(ent, str) else None
+        for trail, key, val in uuid_leaves(obj, []):
+            if QUERY_KEY_RE.search(key):
+                self.query_key_paths[".".join(trail + [key])] += 1
+                if isinstance(ent, str):
+                    self.direct_query.setdefault(ent, val)
+            if refs is not None and val != ent and not (not trail and key == "id"):
+                if len(refs) < MAX_REFS_PER_ENTITY:
+                    refs.add(val)
+
+    def resolve_queries(self):
+        """Attribute each entity to a query by walking the reference graph to a fixpoint.
+
+        Seeds are (a) every `query` entity -- its own id IS the query id -- and (b) any entity
+        carrying an explicit query-id-like field. A query id that is only ever REFERENCED is
+        also a seed: in a distributed run the `query` entity may live on the coordinator CN
+        while this CN holds only the plan that points at it.
+        """
+        owner = {}
+        for qid in self.entities.get("query", ()):
+            owner[qid] = qid
+        for ent, qid in self.direct_query.items():
+            owner.setdefault(ent, qid)
+        for qid in self.direct_query.values():
+            owner.setdefault(qid, qid)
+
+        pending = [e for e in self.refs if e not in owner]
+        for _ in range(MAX_RESOLVE_PASSES):
+            progressed = False
+            still = []
+            for ent in pending:
+                cands = {owner[r] for r in self.refs[ent] if r in owner}
+                if len(cands) == 1:
+                    owner[ent] = next(iter(cands))
+                    progressed = True
+                else:
+                    still.append(ent)
+            pending = still
+            if not progressed or not pending:
+                break
+
+        table = defaultdict(lambda: defaultdict(int))  # query id -> rtype -> entities
+        attributed = 0
+        for ent, rtype in self.entity_type.items():
+            qid = owner.get(ent)
+            if qid is None:
+                continue
+            table[qid][rtype] += 1
+            attributed += 1
+        self.owner = owner
+        self.unattributed = len(self.entity_type) - attributed
+        return table
+
+
+# --------------------------------------------------------------------------- discovery
+
+
+def newest_mtime(path):
+    best = 0.0
+    for root, _dirs, files in os.walk(path):
+        try:
+            best = max(best, os.path.getmtime(root))
+        except OSError:
+            pass
+        for name in files:
+            try:
+                best = max(best, os.path.getmtime(os.path.join(root, name)))
+            except OSError:
+                pass
+    return best
+
+
+def discover_cns(base, prefix):
+    """Return [(cn_name, telemetry_dir_or_None)] sorted by trailing CN number."""
+    found = []
+    try:
+        entries = os.listdir(base)
+    except OSError as exc:
+        print(f"cn-distribution: cannot list {base}: {exc}", file=sys.stderr)
+        return found
+    for entry in sorted(entries):
+        if not entry.startswith(prefix):
+            continue
+        suffix = entry[len(prefix):]
+        if not suffix.isdigit():
+            continue
+        cn_dir = os.path.join(base, entry)
+        if not os.path.isdir(cn_dir):
+            continue
+        tele = os.path.join(cn_dir, "telemetry")
+        found.append((entry, int(suffix), tele if os.path.isdir(tele) else None))
+    found.sort(key=lambda t: t[1])
+    return [(name, tele) for name, _num, tele in found]
+
+
+def discover_runs(tele_dir):
+    """Return run-uuid dir names, newest last.
+
+    Prefers the uuidv7 mint time embedded in the directory name over mtime: telemetry is
+    flushed at shutdown, so mtime records when a lifetime ENDED (and is rewritten by any
+    copy or rsync), whereas the uuid records when it STARTED.
+    """
+    if not tele_dir:
+        return []
+    try:
+        names = [n for n in os.listdir(tele_dir)
+                 if os.path.isdir(os.path.join(tele_dir, n))]
+    except OSError:
+        return []
+    if names and all(uuid7_millis(n) is not None for n in names):
+        return sorted(names, key=lambda n: (uuid7_millis(n), n))
+    return sorted(names, key=lambda n: (newest_mtime(os.path.join(tele_dir, n)), n))
+
+
+# --------------------------------------------------------------------------- reporting
+
+
+def ratio_str(values):
+    """max/min across CNs, guarding the zero-denominator case."""
+    if not values:
+        return "n/a", None
+    hi, lo = max(values), min(values)
+    if lo == 0:
+        zeros = sum(1 for v in values if v == 0)
+        if hi == 0:
+            return "n/a (all zero)", None
+        return f"inf ({zeros} CN{'s' if zeros != 1 else ''} at zero)", float("inf")
+    return f"{hi / lo:.2f}x", hi / lo
+
+
+def abbrev(uuid, full):
+    """Shorten a uuid but keep BOTH ends.
+
+    uuidv7s minted in the same run share a long time-ordered prefix, so a prefix-only
+    abbreviation renders distinct ids identically -- which would silently merge two queries
+    into one row.
+    """
+    if full or not uuid or len(uuid) <= 21:
+        return uuid or "-"
+    return uuid[:13] + ".." + uuid[-6:]
+
+
+def main(argv=None):
+    here = os.path.dirname(os.path.abspath(__file__))
+    default_dir = os.path.dirname(here)  # experimental/starrocks
+
+    ap = argparse.ArgumentParser(
+        description="Per-CN telemetry distribution analyzer for Sirius StarRocks compute nodes.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--dir", default=default_dir,
+                    help="directory holding the <prefix>N engine dirs (default: %(default)s)")
+    ap.add_argument("--prefix", default=".cn", help="engine dir prefix (default: %(default)s)")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    ap.add_argument("--all-runs", action="store_true",
+                    help="analyze every run-uuid per CN (default: newest only)")
+    ap.add_argument("--metric", choices=("entities", "rows"), default="entities",
+                    help="unit for share%% and the verdict: distinct entities (real units of "
+                         "work) or raw event rows (default: %(default)s)")
+    ap.add_argument("--headline", default="task",
+                    help="record type used for the balance verdict (default: %(default)s)")
+    ap.add_argument("--tolerance", type=float, default=1.5,
+                    help="max/min below this is called BALANCED (default: %(default)s)")
+    ap.add_argument("--full-uuid", action="store_true", help="print run-uuids unabbreviated")
+    ap.add_argument("--no-attribution", action="store_true",
+                    help="skip the per-query-id breakdown")
+    args = ap.parse_args(argv)
+
+    base = os.path.abspath(args.dir)
+    cns = discover_cns(base, args.prefix)
+    if not cns:
+        print(f"cn-distribution: no {args.prefix}<N> directories under {base}")
+        return 1
+
+    scans = []
+    multi_run = []
+    for cn, tele in cns:
+        runs = discover_runs(tele)
+        if not runs:
+            # Keep the CN in the report as an explicit zero -- see module docstring.
+            reason = ("no telemetry/ directory" if tele is None
+                      else "telemetry/ exists but holds no run directory")
+            scans.append(RunScan(cn, None, None, missing=True, reason=reason))
+            continue
+        if len(runs) > 1:
+            multi_run.append((cn, runs))
+        chosen = runs if args.all_runs else runs[-1:]
+        for run in chosen:
+            scans.append(RunScan(cn, run, os.path.join(tele, run)).scan())
+
+    live = [s for s in scans if not s.missing]
+    dead = [s for s in scans if s.missing]
+
+    per_query = {}
+    if not args.no_attribution:
+        for scan in live:
+            per_query[(scan.cn, scan.run_uuid)] = scan.resolve_queries()
+
+    if args.json:
+        return emit_json(base, args, scans, multi_run, per_query)
+
+    metric = args.metric
+    unit = "distinct entities" if metric == "entities" else "event rows"
+
+    print(f"cn-distribution: {base}   prefix={args.prefix}   "
+          f"mode={'ALL runs' if args.all_runs else 'newest run per CN'}   metric={metric}")
+    print()
+
+    if not live:
+        print(f"  found {len(cns)} CN dir(s) but NO telemetry run directories at all.")
+        for s in dead:
+            print(f"    {s.cn}: {s.reason}")
+        print("  Nothing to analyze -- telemetry is flushed only at engine shutdown, so a")
+        print("  cluster that is still running (or was killed mid-query) writes nothing.")
+        return 1
+
+    # ---- contamination warning ------------------------------------------------------
+    if multi_run:
+        bar = "!" * 88
+        print(bar)
+        print("!! CONTAMINATION WARNING -- more than one run-uuid found")
+        for cn, runs in multi_run:
+            print(f"!!   {cn} holds {len(runs)} run-uuids (that many cluster lifetimes):")
+            prev = None
+            for r in runs:
+                ms = uuid7_millis(r)
+                gap = ""
+                if ms is not None and prev is not None:
+                    gap = f"   (+{(ms - prev) / 1000.0:,.1f}s after previous)"
+                prev = ms if ms is not None else prev
+                print(f"!!     {r}  started {fmt_epoch_ms(ms)}{gap}")
+        if not args.all_runs:
+            print("!! Analyzing the NEWEST uuid per CN only. Re-run with --all-runs to see them")
+            print("!! all, or clean first (with the cluster down):  rm -rf .cn*/telemetry/*")
+        else:
+            print("!! --all-runs given: rows below MIX cluster lifetimes and the verdict is NOT")
+            print("!! a single-run distribution measurement.")
+        print(bar)
+        print()
+
+    # ---- runs analyzed ---------------------------------------------------------------
+    uw = max([len(abbrev(s.run_uuid, args.full_uuid)) for s in scans] + [8])
+    cw = max([len(s.cn) for s in scans] + [4])
+
+    print("RUNS ANALYZED")
+    rhdr = (f"  {'CN':<{cw}}  {'run-uuid':<{uw}}  {'engine start (UTC)':<19}  "
+            f"{'events span':>11}  {'ndjson':>7}")
+    print(rhdr)
+    print("  " + "-" * (len(rhdr) - 2))
+    for s in scans:
+        if s.missing:
+            print(f"  {s.cn:<{cw}}  {'-':<{uw}}  {'-':<19}  {'-':>11}  {'-':>7}"
+                  f"   <-- {s.reason}")
+            continue
+        span = f"{s.span_s:,.1f}s" if s.span_s is not None else "-"
+        print(f"  {s.cn:<{cw}}  {abbrev(s.run_uuid, args.full_uuid):<{uw}}  "
+              f"{fmt_epoch_ms(s.started_ms):<19}  {span:>11}  {sum(s.files.values()):>7,}")
+    print()
+
+    # ---- headline table --------------------------------------------------------------
+    all_types = sorted({t for s in scans for t in s.record_types()})
+    cols = [c for c in DEFAULT_COLUMNS if c in all_types]
+    if args.headline in all_types and args.headline not in cols:
+        cols.append(args.headline)
+    headline = args.headline
+
+    def emit_counts(title, getter):
+        totals = [getter(s, headline) for s in scans]
+        grand = sum(totals)
+        hdr = (f"{'CN':<{cw}}  {'run-uuid':<{uw}}  "
+               + "  ".join(f"{c:>11}" for c in cols)
+               + f"  {'share%':>8}")
+        print(title)
+        print(hdr)
+        print("-" * len(hdr))
+        for s in scans:
+            share = (getter(s, headline) / grand * 100) if grand else 0.0
+            mark = "  <-- NO TELEMETRY" if s.missing else ""
+            row = f"{s.cn:<{cw}}  {abbrev(s.run_uuid, args.full_uuid):<{uw}}  "
+            row += "  ".join(f"{getter(s, c):>11,}" for c in cols)
+            row += f"  {share:>7.1f}%"
+            print(row + mark)
+        print(f"{'TOTAL':<{cw}}  {'':<{uw}}  "
+              + "  ".join(f"{sum(getter(s, c) for s in scans):>11,}" for c in cols))
+        print()
+        return hdr
+
+    emit_counts(f"WORK DISTRIBUTION -- distinct entities (the real unit of work; "
+                f"share% on '{headline}')",
+                lambda s, c: s.n_entities(c))
+    emit_counts("EVENT ROWS -- state transitions (one entity emits many; inflated vs above)",
+                lambda s, c: s.n_rows(c))
+
+    # ---- other record types ----------------------------------------------------------
+    others = [t for t in all_types if t not in cols]
+    if others:
+        print(f"OTHER RECORD TYPES ({unit})")
+        ow = max(len(t) for t in others)
+        labels = [f"{s.cn}" if not args.all_runs else
+                  f"{s.cn}/{(s.run_uuid or '-')[:8]}" for s in scans]
+        lw = max(max(len(x) for x in labels), 10)
+        line = f"{'record type':<{ow}}  " + "  ".join(f"{x:>{lw}}" for x in labels)
+        print(line)
+        print("-" * len(line))
+        for t in others:
+            print(f"{t:<{ow}}  "
+                  + "  ".join(f"{s.count(t, metric):>{lw},}" for s in scans))
+        print()
+
+    # ---- parse errors ----------------------------------------------------------------
+    errs = [(s, t, n) for s in scans for t, n in s.parse_errors.items() if n]
+    if errs:
+        print("MALFORMED LINES (counted, not fatal)")
+        for scan, t, n in errs:
+            print(f"  {scan.cn} {abbrev(scan.run_uuid, args.full_uuid)} {t}: {n}")
+        print()
+
+    # ---- the sharp signal ------------------------------------------------------------
+    print("PARTICIPATION (zero query + zero channel records == this CN never joined the")
+    print("query/exchange machinery at all)")
+    for s in scans:
+        q = s.count("query", metric)
+        ch = s.count("channel", metric)
+        if s.missing:
+            verdict = f"NEVER STARTED / NEVER FLUSHED  <-- {s.reason}"
+        elif q == 0 and ch == 0:
+            verdict = "NEVER JOINED  <-- zero query AND zero channel records"
+        elif q == 0:
+            verdict = "no query records (channel present)"
+        elif ch == 0:
+            verdict = "no channel records (query present)"
+        else:
+            verdict = "participated"
+        print(f"  {s.cn:<{cw}} {abbrev(s.run_uuid, args.full_uuid):<{uw}}  "
+              f"query={q:<7,} channel={ch:<7,}  {verdict}")
+    print()
+
+    # ---- per-query breakdown ---------------------------------------------------------
+    if not args.no_attribution:
+        qids = sorted({q for tbl in per_query.values() for q in tbl})
+        direct = sorted({p for s in scans for p in s.query_key_paths})
+        if not qids:
+            print("PER-QUERY BREAKDOWN: unavailable -- no query-id-like field and no `query`")
+            print("  entities were found, so events cannot be attributed to a query id.")
+            print()
+        else:
+            print(f"PER-QUERY BREAKDOWN (distinct entities attributed via the reference "
+                  f"graph; {len(qids)} query id(s))")
+            if direct:
+                print(f"  explicit query-id field found at: {', '.join(direct)}")
+            qcols = [c for c in cols if c != "query"]
+            qw = max(len(abbrev(q, args.full_uuid)) for q in qids)
+            line = (f"{'query id':<{qw}}  {'CN':<{cw}}  "
+                    + "  ".join(f"{c:>11}" for c in qcols))
+            print(line)
+            print("-" * len(line))
+            for qid in qids:
+                for scan in live:
+                    counts = per_query.get((scan.cn, scan.run_uuid), {}).get(qid)
+                    if not counts:
+                        continue
+                    print(f"{abbrev(qid, args.full_uuid):<{qw}}  {scan.cn:<{cw}}  "
+                          + "  ".join(f"{counts.get(c, 0):>11,}" for c in qcols))
+            unattr = sum(s.unattributed for s in live)
+            if unattr:
+                print(f"  ({unattr} entities tied to no query -- engine/worker/thread level "
+                      "entities exist outside any query)")
+            print()
+
+    # ---- verdict ---------------------------------------------------------------------
+    print(f"VERDICT (max/min across {len(scans)} CNs)")
+    for c in cols + others:
+        ev = [s.n_entities(c) for s in scans]
+        rv = [s.n_rows(c) for s in scans]
+        etxt, _ = ratio_str(ev)
+        rtxt, _ = ratio_str(rv)
+        print(f"  {c:<24} entities {min(ev):>7,} .. {max(ev):<7,} -> {etxt:<26}"
+              f" rows {min(rv):>8,} .. {max(rv):<8,} -> {rtxt}")
+
+    hv = [s.count(headline, metric) for s in scans]
+    txt, num = ratio_str(hv)
+    zero = [s.cn for s in scans if s.count(headline, metric) == 0]
+    print()
+    if max(hv, default=0) == 0:
+        call = f"NO DATA -- every CN reported zero '{headline}' {unit}"
+    elif num == float("inf"):
+        call = (f"IMBALANCED (inf) -- {len(zero)} of {len(scans)} CNs did ZERO "
+                f"'{headline}' work: {', '.join(zero)}")
+    elif num < args.tolerance:
+        call = (f"BALANCED ({txt} spread on '{headline}' {unit} across {len(scans)} CNs)")
+    else:
+        call = f"IMBALANCED ({txt} on '{headline}' {unit} across {len(scans)} CNs)"
+    print(f"  ==> {call}")
+    if args.all_runs and multi_run:
+        print("  NOTE: --all-runs mixes cluster lifetimes; this is not a single-run reading.")
+    return 0
+
+
+def emit_json(base, args, scans, multi_run, per_query):
+    out = {
+        "dir": base,
+        "prefix": args.prefix,
+        "mode": "all-runs" if args.all_runs else "newest-per-cn",
+        "metric": args.metric,
+        "headline": args.headline,
+        "multi_run_warning": [
+            {"cn": cn,
+             "runs": [{"run_uuid": r, "started_utc": fmt_epoch_ms(uuid7_millis(r))}
+                      for r in runs]}
+            for cn, runs in multi_run],
+        "cns": [],
+    }
+    for s in scans:
+        tbl = per_query.get((s.cn, s.run_uuid), {})
+        out["cns"].append({
+            "cn": s.cn,
+            "run_uuid": s.run_uuid,
+            "missing": s.missing,
+            "reason": s.reason or None,
+            "started_utc": fmt_epoch_ms(s.started_ms),
+            "events_span_s": s.span_s,
+            "rows": dict(s.rows),
+            "entities": {t: len(v) for t, v in s.entities.items()},
+            "files": dict(s.files),
+            "parse_errors": {k: v for k, v in s.parse_errors.items() if v},
+            "sidecars": s.sidecars,
+            "query_key_paths": dict(s.query_key_paths),
+            "zero_query": s.count("query", args.metric) == 0,
+            "zero_channel": s.count("channel", args.metric) == 0,
+            "per_query": {q: dict(c) for q, c in tbl.items()},
+            "unattributed_entities": s.unattributed,
+        })
+    types = sorted({t for s in scans for t in s.record_types()})
+    verdict = {}
+    for t in types:
+        ev = [s.n_entities(t) for s in scans]
+        rv = [s.n_rows(t) for s in scans]
+        etxt, enum = ratio_str(ev)
+        rtxt, rnum = ratio_str(rv)
+        verdict[t] = {
+            "entities": {"min": min(ev), "max": max(ev), "ratio": etxt,
+                         "ratio_value": None if enum in (None, float("inf")) else enum},
+            "rows": {"min": min(rv), "max": max(rv), "ratio": rtxt,
+                     "ratio_value": None if rnum in (None, float("inf")) else rnum},
+        }
+    hv = [s.count(args.headline, args.metric) for s in scans]
+    txt, num = ratio_str(hv)
+    if max(hv, default=0) == 0:
+        call = "NO_DATA"
+    elif num == float("inf") or (num is not None and num >= args.tolerance):
+        call = "IMBALANCED"
+    else:
+        call = "BALANCED"
+    out["verdict"] = verdict
+    out["balance"] = {
+        "call": call,
+        "ratio": txt,
+        "metric": args.metric,
+        "zero_cns": [s.cn for s in scans if s.count(args.headline, args.metric) == 0],
+        "missing_cns": [s.cn for s in scans if s.missing],
+    }
+    json.dump(out, sys.stdout, indent=2, sort_keys=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experimental/starrocks/tools/compare.py
+++ b/experimental/starrocks/tools/compare.py
@@ -1,20 +1,30 @@
 #!/usr/bin/env python3
-"""Diff Sirius TSV results against the DuckDB oracle.
+"""Diff Sirius TSV results against the DuckDB oracle, every run of every query.
 
 Compares row count, then cell by cell. Numeric cells compare with a relative tolerance
 (decimal lowering drifts slightly); non-numeric cells must match exactly. Row ORDER is
 compared as-is when the query has an ORDER BY, which every TPC-H query that cares does.
 
+Every `<q>.rN.out` is compared, not only the last one: a query whose cold run returned zero
+rows and whose warm runs matched is a flake, and a flake is a failure. The per-query verdict
+is the worst verdict over its runs; the per-run verdicts are printed under it when they
+differ.
+
 Usage: compare.py <sirius_out_dir> <oracle_dir> [rel_tol]
   sirius_out_dir holds <q>.r<N>.out (mysql --batch), oracle_dir holds <q>.tsv
-Exits 0 only when every query is a MATCH, so a sweep can use it as a gate.
+Exits 0 only when every run of every query is a MATCH, so a sweep can use it as a gate.
 """
 import glob
 import os
+import re
 import sys
 
 sdir, odir = sys.argv[1], sys.argv[2]
 TOL = float(sys.argv[3]) if len(sys.argv) > 3 else 1e-6
+
+# Worst first. NO-ORACLE is not a run verdict; it is reported per query and never counts as
+# a MATCH.
+SEVERITY = ["NO-RESULT", "ERROR", "EMPTY", "ROWS-DIFFER", "VALUES-DIFFER", "MATCH"]
 
 
 def num(s):
@@ -32,60 +42,76 @@ def read_tsv(path):
     return lines[0].split("\t"), [ln.split("\t") for ln in lines[1:]]
 
 
-rows = []
+def run_index(path):
+    m = re.search(r"\.r(\d+)\.out$", path)
+    return int(m.group(1)) if m else -1
+
+
+def compare_run(spath, orows):
+    """One run against the oracle rows: (verdict, detail)."""
+    with open(spath) as f:
+        head = f.readline()
+    if head.startswith("ERROR"):
+        return "ERROR", head.strip()[:90]
+    shdr, srows = read_tsv(spath)
+    if shdr is None:
+        return "EMPTY", "no output"
+    if len(srows) != len(orows):
+        return "ROWS-DIFFER", f"sirius={len(srows)} oracle={len(orows)}"
+    bad, worst = 0, 0.0
+    for si, oi in zip(srows, orows):
+        if len(si) != len(oi):
+            bad += 1
+            continue
+        for a, b in zip(si, oi):
+            fa, fb = num(a), num(b)
+            if fa is not None and fb is not None:
+                d = abs(fa - fb) / max(abs(fb), 1e-12) if fb != 0 else abs(fa)
+                worst = max(worst, d)
+                if d > TOL:
+                    bad += 1
+            elif a.strip() != b.strip():
+                bad += 1
+    verdict = "MATCH" if bad == 0 else "VALUES-DIFFER"
+    detail = f"rows={len(srows)} maxreldiff={worst:.3e}" + (
+        f" badcells={bad}" if bad else ""
+    )
+    return verdict, detail
+
+
+summary = []  # (query, verdict, detail, [(run, verdict, detail), ...])
 for q in sorted(
     {os.path.basename(p).split(".")[0] for p in glob.glob(os.path.join(sdir, "q*.out"))}
 ):
-    # prefer the last warm run
-    cands = sorted(glob.glob(os.path.join(sdir, f"{q}.r*.out")))
+    cands = sorted(glob.glob(os.path.join(sdir, f"{q}.r*.out")), key=run_index)
     opath = os.path.join(odir, f"{q}.tsv")
     if not os.path.exists(opath):
-        rows.append((q, "NO-ORACLE", "", "", ""))
+        summary.append((q, "NO-ORACLE", "", []))
         continue
+    _, orows = read_tsv(opath)
+    runs = [(run_index(p),) + compare_run(p, orows) for p in cands]
+    if not runs:
+        summary.append((q, "NO-RESULT", "no runs", []))
+        continue
+    worst = min(runs, key=lambda r: SEVERITY.index(r[1]))
+    detail = worst[2]
+    if len({r[1] for r in runs}) > 1:
+        bad_runs = ",".join(f"r{r[0]}" for r in runs if r[1] != "MATCH")
+        detail = f"{detail} ({bad_runs} of {len(runs)} runs)"
+    summary.append((q, worst[1], detail, runs))
 
-    ohdr, orows = read_tsv(opath)
-    verdict, detail, sn = "NO-RESULT", "", ""
-    for spath in reversed(cands):
-        with open(spath) as f:
-            head = f.readline()
-        if head.startswith("ERROR"):
-            verdict, detail = "ERROR", head.strip()[:90]
-            continue
-        shdr, srows = read_tsv(spath)
-        if shdr is None:
-            verdict, detail = "EMPTY", "no output"
-            continue
-        sn = len(srows)
-        if len(srows) != len(orows):
-            verdict = "ROWS-DIFFER"
-            detail = f"sirius={len(srows)} oracle={len(orows)}"
-            break
-        bad, worst = 0, 0.0
-        for si, oi in zip(srows, orows):
-            if len(si) != len(oi):
-                bad += 1
-                continue
-            for a, b in zip(si, oi):
-                fa, fb = num(a), num(b)
-                if fa is not None and fb is not None:
-                    d = abs(fa - fb) / max(abs(fb), 1e-12) if fb != 0 else abs(fa)
-                    worst = max(worst, d)
-                    if d > TOL:
-                        bad += 1
-                elif a.strip() != b.strip():
-                    bad += 1
-        verdict = "MATCH" if bad == 0 else "VALUES-DIFFER"
-        detail = f"rows={len(srows)} maxreldiff={worst:.3e}" + (
-            f" badcells={bad}" if bad else ""
-        )
-        break
-    rows.append((q, verdict, detail, str(sn), str(len(orows))))
-
-w = max(len(r[1]) for r in rows)
+w = max(len(r[1]) for r in summary)
 print(f"{'query':6} {'verdict':{w}}  detail")
-for q, v, d, sn, on in rows:
+for q, v, d, runs in summary:
     print(f"{q:6} {v:{w}}  {d}")
+    if len({r[1] for r in runs}) > 1:
+        for run, rv, rd in runs:
+            print(f"  r{run:<3} {rv:{w}}  {rd}")
 
-nmatch = sum(1 for r in rows if r[1] == "MATCH")
-print(f"\n{nmatch}/{len(rows)} match the DuckDB oracle within rel tol {TOL:g}")
-sys.exit(0 if nmatch == len(rows) else 1)
+nmatch = sum(1 for r in summary if r[1] == "MATCH")
+nruns = sum(len(r[3]) for r in summary)
+print(
+    f"\n{nmatch}/{len(summary)} queries match the DuckDB oracle within rel tol {TOL:g} "
+    f"on every run ({nruns} runs compared)"
+)
+sys.exit(0 if nmatch == len(summary) else 1)

--- a/experimental/starrocks/tools/compare.py
+++ b/experimental/starrocks/tools/compare.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Diff Sirius TSV results against the DuckDB oracle.
+
+Compares row count, then cell by cell. Numeric cells compare with a relative tolerance
+(decimal lowering drifts slightly); non-numeric cells must match exactly. Row ORDER is
+compared as-is when the query has an ORDER BY, which every TPC-H query that cares does.
+
+Usage: compare.py <sirius_out_dir> <oracle_dir> [rel_tol]
+  sirius_out_dir holds <q>.r<N>.out (mysql --batch), oracle_dir holds <q>.tsv
+Exits 0 only when every query is a MATCH, so a sweep can use it as a gate.
+"""
+import glob
+import os
+import sys
+
+sdir, odir = sys.argv[1], sys.argv[2]
+TOL = float(sys.argv[3]) if len(sys.argv) > 3 else 1e-6
+
+
+def num(s):
+    try:
+        return float(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def read_tsv(path):
+    with open(path) as f:
+        lines = [ln.rstrip("\n") for ln in f if ln.strip() != ""]
+    if not lines:
+        return None, []
+    return lines[0].split("\t"), [ln.split("\t") for ln in lines[1:]]
+
+
+rows = []
+for q in sorted(
+    {os.path.basename(p).split(".")[0] for p in glob.glob(os.path.join(sdir, "q*.out"))}
+):
+    # prefer the last warm run
+    cands = sorted(glob.glob(os.path.join(sdir, f"{q}.r*.out")))
+    opath = os.path.join(odir, f"{q}.tsv")
+    if not os.path.exists(opath):
+        rows.append((q, "NO-ORACLE", "", "", ""))
+        continue
+
+    ohdr, orows = read_tsv(opath)
+    verdict, detail, sn = "NO-RESULT", "", ""
+    for spath in reversed(cands):
+        with open(spath) as f:
+            head = f.readline()
+        if head.startswith("ERROR"):
+            verdict, detail = "ERROR", head.strip()[:90]
+            continue
+        shdr, srows = read_tsv(spath)
+        if shdr is None:
+            verdict, detail = "EMPTY", "no output"
+            continue
+        sn = len(srows)
+        if len(srows) != len(orows):
+            verdict = "ROWS-DIFFER"
+            detail = f"sirius={len(srows)} oracle={len(orows)}"
+            break
+        bad, worst = 0, 0.0
+        for si, oi in zip(srows, orows):
+            if len(si) != len(oi):
+                bad += 1
+                continue
+            for a, b in zip(si, oi):
+                fa, fb = num(a), num(b)
+                if fa is not None and fb is not None:
+                    d = abs(fa - fb) / max(abs(fb), 1e-12) if fb != 0 else abs(fa)
+                    worst = max(worst, d)
+                    if d > TOL:
+                        bad += 1
+                elif a.strip() != b.strip():
+                    bad += 1
+        verdict = "MATCH" if bad == 0 else "VALUES-DIFFER"
+        detail = f"rows={len(srows)} maxreldiff={worst:.3e}" + (
+            f" badcells={bad}" if bad else ""
+        )
+        break
+    rows.append((q, verdict, detail, str(sn), str(len(orows))))
+
+w = max(len(r[1]) for r in rows)
+print(f"{'query':6} {'verdict':{w}}  detail")
+for q, v, d, sn, on in rows:
+    print(f"{q:6} {v:{w}}  {d}")
+
+nmatch = sum(1 for r in rows if r[1] == "MATCH")
+print(f"\n{nmatch}/{len(rows)} match the DuckDB oracle within rel tol {TOL:g}")
+sys.exit(0 if nmatch == len(rows) else 1)

--- a/experimental/starrocks/tools/oracle.py
+++ b/experimental/starrocks/tools/oracle.py
@@ -6,7 +6,8 @@ SAME SQL through DuckDB over the same parquet and writes one TSV per query, form
 match the mysql --batch output so the two can be diffed directly.
 
 Usage: oracle.py <queries_dir> <tpch_data> <out_dir> [qNN ...]
-Env:   ORACLE_THREADS, ORACLE_MEM (DuckDB memory_limit), ORACLE_TMP (spill directory;
+Env:   TPCH_SF (scale factor substituted for __TPCH_SF__, which q11 needs; default 1),
+       ORACLE_THREADS, ORACLE_MEM (DuckDB memory_limit), ORACLE_TMP (spill directory;
        defaults to a duckdb-oracle/ directory under the system temp dir, $TMPDIR if set)
 """
 import decimal
@@ -61,7 +62,12 @@ os.makedirs(_tmp, exist_ok=True)
 con.execute("SET temp_directory='%s'" % _tmp)
 
 for n in names:
-    sql = open(os.path.join(qdir, f"{n}.sql")).read().replace("__TPCH_DATA__", data)
+    sql = (
+        open(os.path.join(qdir, f"{n}.sql"))
+        .read()
+        .replace("__TPCH_DATA__", data)
+        .replace("__TPCH_SF__", os.environ.get("TPCH_SF", "1"))
+    )
     sql = FILES.sub(lambda m: f"read_parquet('{m.group(1)}')", sql).strip().rstrip(";")
     t0 = time.time()
     try:

--- a/experimental/starrocks/tools/oracle.py
+++ b/experimental/starrocks/tools/oracle.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""DuckDB CPU oracle for the TPC-H sweep.
+
+The bench harness times queries and counts rows; it never checks answers. This runs the
+SAME SQL through DuckDB over the same parquet and writes one TSV per query, formatted to
+match the mysql --batch output so the two can be diffed directly.
+
+Usage: oracle.py <queries_dir> <tpch_data> <out_dir> [qNN ...]
+Env:   ORACLE_THREADS, ORACLE_MEM (DuckDB memory_limit), ORACLE_TMP (spill directory;
+       defaults to a duckdb-oracle/ directory under the system temp dir, $TMPDIR if set)
+"""
+import decimal
+import glob
+import os
+import re
+import sys
+import tempfile
+import time
+
+import duckdb
+
+qdir, data, out = sys.argv[1], sys.argv[2], sys.argv[3]
+only = sys.argv[4:]
+os.makedirs(out, exist_ok=True)
+
+# FILES("path"="file:///d/tbl/*.parquet","format"="parquet") -> read_parquet('/d/tbl/*.parquet')
+FILES = re.compile(
+    r'FILES\(\s*"path"\s*=\s*"file://([^"]+)"\s*,\s*"format"\s*=\s*"parquet"\s*\)',
+    re.I,
+)
+
+
+def fmt(v):
+    """Match mysql --batch rendering closely enough to diff."""
+    if v is None:
+        return "NULL"
+    if isinstance(v, decimal.Decimal):
+        # strip trailing zeros but keep an integer looking like an integer
+        s = format(v.normalize(), "f")
+        return s
+    if isinstance(v, float):
+        return repr(v)
+    return str(v)
+
+
+names = sorted(
+    os.path.basename(p)[:-4] for p in glob.glob(os.path.join(qdir, "q*.sql"))
+)
+if only:
+    names = [n for n in names if n in only]
+
+con = duckdb.connect()
+con.execute("PRAGMA threads=%d" % int(os.environ.get("ORACLE_THREADS", "48")))
+con.execute("SET preserve_insertion_order=false")
+# Large scale factors spill; point ORACLE_TMP at a volume with room for it.
+con.execute("SET memory_limit='%s'" % os.environ.get("ORACLE_MEM", "380GB"))
+_tmp = os.environ.get(
+    "ORACLE_TMP", os.path.join(tempfile.gettempdir(), "duckdb-oracle")
+)
+os.makedirs(_tmp, exist_ok=True)
+con.execute("SET temp_directory='%s'" % _tmp)
+
+for n in names:
+    sql = open(os.path.join(qdir, f"{n}.sql")).read().replace("__TPCH_DATA__", data)
+    sql = FILES.sub(lambda m: f"read_parquet('{m.group(1)}')", sql).strip().rstrip(";")
+    t0 = time.time()
+    try:
+        rel = con.sql(sql)
+        cols = rel.columns
+        rows = rel.fetchall()
+        with open(os.path.join(out, f"{n}.tsv"), "w") as f:
+            f.write("\t".join(cols) + "\n")
+            for r in rows:
+                f.write("\t".join(fmt(v) for v in r) + "\n")
+        print(f"{n} ok rows={len(rows)} {time.time()-t0:.1f}s", flush=True)
+    except Exception as e:
+        with open(os.path.join(out, f"{n}.err"), "w") as f:
+            f.write(str(e))
+        print(f"{n} FAILED {type(e).__name__}: {str(e)[:200]}", flush=True)


### PR DESCRIPTION
## Summary

Add one reproducible StarRocks/Sirius TPC-H workflow:

- a parquet generator, FE/CN launcher, DuckDB oracle, result comparator, and per-CN distribution report;
- all 22 `FILES()`-based query texts, including the scale-correct q11 and the CTE-reuse guidance;
- `GPU_DEVICES` for shared-GPU development and future `MIG_DEVICES` launcher plumbing.

`cluster8.sh` documents the resource contract explicitly: each CN consumes `GPU_MEM` plus its `STAGING` arena outside that limit, plus CUDA context overhead. The README now states that an actual multi-CN run still requires #1714's CN bring-up/flags, #1693's stable staging arena, and the follow-on distributed exchange runtime.
It also marks UUID-based `MIG_DEVICES` unsupported on the current engine because its NVML device-count check fails under UUID-only visibility; use whole-GPU ordinals such as `GPU_DEVICES=0,1` on that box for now.

## Why one PR

The scripts, query kit, oracle/comparator, and topology launcher form one reproducible measurement and correctness workflow. Splitting them would leave a reviewer unable to run or validate the workflow end to end. The source commits are preserved as six cherry-picks, followed by a documentation-only prerequisite clarification.

## Validation

- `pixi run bash -n` for `gen-tpch.sh`, `cluster8.sh`, and `bench.sh`
- `pixi run python -m py_compile` for `cn-distribution.py`, `compare.py`, and `oracle.py`
- Comparator fixture: a wrong cold run (`r0`) is rejected while a correct warm run (`r1`) passes; the overall comparator exits non-zero.

Known gate limitation, intentionally not changed here: `compare.py` currently treats `nan` versus a finite oracle value as a match because its `d > tolerance` comparison is false for NaN. A focused follow-up should reject non-finite numeric values before using this as a strict correctness gate.

## Draft status and runtime scope

This remains a Draft because `dev` does not yet contain the distributed runtime needed for real multi-CN execution. The harness and documentation are ready to review independently; runtime measurements should wait for the prerequisite series.