### PR TITLE
feat: add Codex PR digest skill

### DIFF
--- a/.agents/skills/pr-digest/SKILL.md
+++ b/.agents/skills/pr-digest/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: pr-digest
-description: Create a navigable Markdown learning digest for a GitHub pull request, explaining what changed, why, and where it lives with line-accurate links and trimmed diffs. Use when a user wants to understand, summarize, review, walk through, or get up to speed on a GitHub PR. This maps the change without critiquing it; use a separate code-review pass when findings or an approval recommendation are requested.
+description: Create a context-first, navigable Markdown learning digest for a GitHub pull request, explaining the before/after behavior, change flow, key changes, and where they live with line-accurate links and trimmed diffs. Use when a user wants to understand, summarize, review, walk through, or get up to speed on a GitHub PR. This maps the change without critiquing it; use a separate code-review pass when findings or an approval recommendation are requested.
 ---
 
 # PR Digest
 
-Turns a GitHub PR link into a digest document a reviewer can actually learn from: ranked key
-changes, each with what/why/where-invoked/diff, all cross-referenced with clickable links into
-the actual checked-out source.
+Turns a GitHub PR link into a digest document a reviewer can actually learn from: an opening
+before/after example and flowchart establish the mental model, then ranked key changes explain
+what/why/where-invoked/diff with clickable links into the actual checked-out source.
 
 Comprehension is the whole job here. This skill does not judge the PR — no bug-hunting, no "is
 this a race condition" adversarial pass, no verdict on whether the change is good. That's a
@@ -122,11 +122,52 @@ important than a small new file that IS the actual feature.
   distinct *concepts* does it change? A 100-file PR implementing one idea can be 1–2 key changes;
   a 10-file PR bundling five unrelated fixes needs five.
 - Pure file-relocation diffs (moved with no logic change) don't deserve a key-change slot — they
-  get their own dedicated section instead (Step 8).
+  get their own dedicated section instead (Step 9).
 
-## Step 6 — Write the key-change overview list
+## Step 6 — Orient the reader with a before/after example and a diagram
 
-Immediately after the plain-language summary, before any detailed section, list the key changes
+Immediately after the plain-language summary, add two short orientation sections. Both are
+required and must appear before "Key changes at a glance" so a reader sees the behavior and flow
+before encountering implementation vocabulary.
+
+### Before and after
+
+Show one concrete scenario twice: the same query, plan shape, request, input rows, configuration,
+or error path before the PR and after it. Prefer an example supplied by the PR author or its tests.
+If none exists, synthesize the smallest example supported by code you traced, label it
+**Illustrative**, and cite the supporting code anchors. Never invent an API, benchmark result,
+production symptom, or semantic guarantee.
+
+Use a compact table or paired snippets. Make these four facts easy to find:
+
+- the unchanged starting condition;
+- what happened before;
+- what happens after;
+- what stays unchanged or what fallback still applies.
+
+Keep the example at the user-visible, query-plan-visible, or data-flow-visible level. Detailed
+class and function names belong in the later key-change sections.
+
+### Flow at a glance
+
+Add one Mermaid diagram using the diagram type that best explains the change: usually `flowchart`
+for control/data flow, `sequenceDiagram` for interactions over time, or `stateDiagram-v2` for a
+lifecycle. The diagram should:
+
+- contain roughly 4–10 nodes or participants and fit on one screen;
+- make the old stopping point and new path visible, or show the full new flow when a comparison
+  would be misleading;
+- use plain conceptual labels rather than filenames and full function signatures;
+- distinguish decisions/fallbacks that materially affect behavior;
+- avoid branches that were not verified from the PR description, diff, or checked-out code.
+
+Immediately below the diagram, add a short **Code anchors** list linking 2–5 diagram concepts to
+their exact source lines. The diagram is orientation, not evidence by itself; the links make its
+claims inspectable. Keep Mermaid labels simple and quoted so GitHub renders the block reliably.
+
+## Step 7 — Write the key-change overview list
+
+Immediately after the two orientation sections, before any detailed section, list the key changes
 you're about to cover — each as a heading-matching title plus **1–3 sentences**. This is the
 digest's table of contents in prose form: a reader should be able to stop after this list and
 already know what the PR does and roughly how it's structured, then choose which detailed sections
@@ -136,7 +177,8 @@ Keep each entry genuinely short. The temptation is to front-load explanation her
 detailed section redundant — resist it. The overview answers "what is this change and why should I
 care", the detailed section answers "how does it work and where does it live".
 
-...` heading), and link each entry to its section so the reader can jump straight there.
+Use a `## Key changes at a glance` heading. Make each entry's title match its detailed section and
+link it to that section so the reader can jump straight there.
 
 After the glance list, add a **"Suggested reading order"**: 5–8 numbered steps naming which
 files and functions to open, in which order, for someone reviewing this PR for the first time.
@@ -145,7 +187,7 @@ the guards. Tag the load-bearing line each step exists to protect ("this emit ma
 line the rest depends on") so the reader knows what to slow down for. This is pedagogy, not a
 verdict — no severity labels, no "must fix", no approval language.
 
-## Step 7 — Write each key change
+## Step 8 — Write each key change
 
 For every key change, in this order:
 
@@ -185,10 +227,14 @@ diff. Trimming is expected and good (a 300-line file diff in the middle of a dig
 purpose), but say so explicitly right before the fence: name what's elided (e.g. "license header
 and an ~90-case exhaustive switch elided") and mark cuts inline with a comment like
 `// ... elided: <what> ...`. Link the source file (with a line range if useful) immediately before
-the diff. The diff itself stays inside a normal ` ```diff ` fence — this is the one place a fence
-is correct, since real diffs need +/- coloring and don't contain links anyway.
+the diff. Put the diff inside a fenced code block whose info string is `diff`. Preserve the patch
+marker as the first character of every changed line: `+` for additions and `-` for removals, with
+one leading space for unchanged context. Do not use a plain code fence or strip the markers:
+rendered Markdown uses the `diff` language and those prefixes to color additions green and
+removals red. This is the one place a fence is correct, since diffs need syntax coloring and
+contain no links.
 
-## Step 8 — Audit moved code and files (its own section: "Relocations")
+## Step 9 — Audit moved code and files (its own section: "Relocations")
 
 Relocation is the single biggest source of wasted reviewer time on a large PR. A file moved from
 `src/op/foo.hpp` to `src/op/bar/foo.hpp` shows up as a 400-line delete plus a 400-line add, and a
@@ -223,7 +269,7 @@ If you couldn't verify a move (too large to diff carefully, ambiguous rename det
 here rather than claiming it's intact. An unverified "probably fine" that turns out to hide a logic
 change is worse than no claim at all.
 
-## Step 9 — Write "Not covered in this pass"
+## Step 10 — Write "Not covered in this pass"
 
 Close with an honest list of things you noticed but didn't trace through: a component only
 reachable via tests, gate/threshold logic the PR description mentions but you didn't read in
@@ -260,16 +306,18 @@ what keeps it honest instead of silently confident.
   3. Header table: PR number/link, title, author, branch (head → base), scope (commit/file
      count), closes, supersedes.
   4. The PR description, quoted.
-  5. A short plain-language summary in your own words — what problem this solves, one paragraph.
-     It must OPEN with a concrete, user-visible or plan-visible before/after taken from the PR —
-     a query, a row shape, a setting, an error message — and only then introduce type names,
-     file names, or API terms. A reader who knows nothing about this subsystem should get
-     the example before the vocabulary. If the PR contains no such example, say so explicitly and do not invent one.
-  6. "Key changes at a glance" — the numbered overview list, 1–3 sentences each, linked to the
-     detailed sections (Step 6).
-  7. Ranked key changes in detail (Steps 5, 7), separated by `---`.
-  8. "Relocations" — moved files/functions with intact-vs-changed classification (Step 8).
-  9. "Not covered in this pass" (Step 9).
+  5. A short plain-language summary in your own words — what problem this solves and the outcome,
+     in one paragraph without implementation detail.
+  6. "Before and after" — one grounded example comparing the same scenario on both sides of the
+     PR, including unchanged behavior or fallback (Step 6).
+  7. "Flow at a glance" — one compact Mermaid diagram plus 2–5 line-accurate code anchors
+     (Step 6).
+  8. "Key changes at a glance" — the numbered overview list, 1–3 sentences each, linked to the
+     detailed sections (Step 7).
+  9. "Suggested reading order" — the linked 5–8-step path through the code (Step 7).
+  10. Ranked key changes in detail (Steps 5, 8), separated by `---`.
+  11. "Relocations" — moved files/functions with intact-vs-changed classification (Step 9).
+  12. "Not covered in this pass" (Step 10).
 
 See `references/example_digest.md` in this skill directory for a full worked example (PR #1277 —
 sirius-db/sirius, "dynamic filters: SIP") showing the expected tone, link density, trimming style,

--- a/.agents/skills/pr-digest/SKILL.md
+++ b/.agents/skills/pr-digest/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: pr-digest
+description: Create a navigable Markdown learning digest for a GitHub pull request, explaining what changed, why, and where it lives with line-accurate links and trimmed diffs. Use when a user wants to understand, summarize, review, walk through, or get up to speed on a GitHub PR. This maps the change without critiquing it; use a separate code-review pass when findings or an approval recommendation are requested.
+---
+
+# PR Digest
+
+Turns a GitHub PR link into a digest document a reviewer can actually learn from: ranked key
+changes, each with what/why/where-invoked/diff, all cross-referenced with clickable links into
+the actual checked-out source.
+
+Comprehension is the whole job here. This skill does not judge the PR — no bug-hunting, no "is
+this a race condition" adversarial pass, no verdict on whether the change is good. That's a
+different kind of work with a different failure mode (a digest that editorializes tends to bury
+the explanation the reader actually came for), and other review skills cover it. If the user
+seems to expect a full critique from this alone, say plainly that this produces the map, not the
+verdict, and offer a separate code-review pass for the rest.
+
+## Input
+
+One required argument: a GitHub PR URL, e.g. `https://github.com/sirius-db/sirius/pull/1277`.
+Parse `owner`, `repo`, and PR number out of it.
+
+One optional flag: `--sandbox-bypass`. If the user passes it, request elevated execution for
+every `gh` call from the start rather than probing inside the sandbox first.
+
+## Step 1 — Confirm `gh` access before doing anything else
+
+Everything downstream depends on `gh` reaching the GitHub API, so check that first rather than
+discovering it's broken three steps in.
+
+Run `gh pr view <number> --repo <owner>/<repo> --json state`.
+
+- **Works** → continue to Step 2.
+- **Fails because network, sandbox, or OS-keyring access appears restricted** → rerun the exact
+  command using Codex's elevated execution mode (`sandbox_permissions: "require_escalated"`) and
+  include a concise approval question in `justification`. Do not send a separate permission
+  message before the tool's approval request.
+  - Elevated execution fixes it → tell the user plainly that this environment needs elevated
+    execution for `gh`, and use the same mode for every `gh` call for the rest of this run.
+    They can pass `--sandbox-bypass` next time to skip the failed probe.
+  - It still fails with an authentication error (for example, `HTTP 401`) → stop here. Tell the
+    user to run `gh auth login` or `gh auth status` to diagnose it. This skill cannot proceed
+    without read access to the PR's description, linked issues/PRs, commits, and file list.
+  - It still fails for a different reason → stop and report the exact failure without calling it
+    an authentication problem.
+- **User passed `--sandbox-bypass`** → start with elevated execution and use it for every `gh`
+  call.
+
+Do not default to elevated execution for everyone. Different environments authenticate and route
+network access differently, and probing first keeps the skill portable.
+
+## Step 2 — Resolve the PR
+
+```
+gh pr view <n> --repo <owner>/<repo> --json title,body,commits,files,headRefName,baseRefName,author,state,url
+```
+
+This is the single most important call: it's the ground truth for the file list and diff scope
+used throughout the rest of the digest (see the warning in Step 4 about why local `git diff`
+isn't a substitute).
+
+## Step 3 — Follow the references to other PRs and issues
+
+PR descriptions often name the work this PR sits inside of — "Supersedes #1179, #1193", "Closes
+#1010, #1125", "Stacked on #1244". Scan the body for `#<N>` references and resolve each one:
+
+```
+gh pr view <N> --repo <owner>/<repo> --json title,state,body,author
+# if that 404s, it's an issue, not a PR:
+gh issue view <N> --repo <owner>/<repo> --json title,state,body,author
+```
+
+Summarize each in a couple of lines in the digest — enough for the reader to understand the arc
+this PR is part of (what it closes, what it supersedes, what design doc it's stacked on). Don't
+write a full digest of each referenced item; that's scope creep.
+
+## Step 4 — Check out the PR branch locally
+
+Line-accurate `#L123` links need real file content, and that means having the branch checked out
+— `gh pr diff` line offsets alone aren't enough to point at, say, a function definition three
+lines below where its diff hunk started.
+
+**Safety first:** run `git status --porcelain`. If anything is uncommitted (tracked or
+untracked), **stop and tell the user** exactly what's dirty, and ask them to stash or commit
+before re-running the skill. Do not auto-stash — that's someone's in-progress work, not yours to
+move.
+
+If clean:
+
+```
+gh pr checkout <n> --repo <owner>/<repo>
+```
+
+Note which branch/commit the repo was on beforehand so you can mention it in the final summary —
+the user may want to switch back afterward, but don't do that automatically.
+
+**Why not just use local `git diff` against the base branch for everything?** On a branch that
+periodically merged the base branch back in (common on long-running PRs), the local three-dot
+diff's merge-base calculation can get confused by those merge commits and pull in unrelated files
+from work that landed on the base branch after this PR's diff was actually opened — this has
+happened in practice and silently made a digest describe files the PR never touched. `gh pr view
+--json files` / `gh pr diff` are the authoritative source for *which files and diff hunks belong
+to this PR*. Use the local checkout only to resolve current, exact line numbers for links — not
+to redetermine scope.
+
+## Step 5 — Identify the key changes, ranked by conceptual centrality
+
+This is the part that takes judgment, not the part to automate away. Rank by **what the PR is
+actually about**, not by diff size — a file that's large because it got relocated is not more
+important than a small new file that IS the actual feature.
+
+- Start from the PR description's own framing of what it does — usually the strongest signal for
+  what the "main" change is.
+- Use `gh pr view --json files` sorted by `additions+deletions` as a triage starting point only,
+  never as the ranking itself.
+- Group tightly-coupled files/functions that only make sense together into **one** key change
+  with multiple sub-diffs, rather than fragmenting a single mechanism into several top-level
+  entries. Only merge when they're genuinely one idea — don't over-merge unrelated changes just to
+  shorten the list.
+- Aim for roughly 1–6 key changes, but let the actual number follow the PR: how many genuinely
+  distinct *concepts* does it change? A 100-file PR implementing one idea can be 1–2 key changes;
+  a 10-file PR bundling five unrelated fixes needs five.
+- Pure file-relocation diffs (moved with no logic change) don't deserve a key-change slot — they
+  get their own dedicated section instead (Step 8).
+
+## Step 6 — Write the key-change overview list
+
+Immediately after the plain-language summary, before any detailed section, list the key changes
+you're about to cover — each as a heading-matching title plus **1–3 sentences**. This is the
+digest's table of contents in prose form: a reader should be able to stop after this list and
+already know what the PR does and roughly how it's structured, then choose which detailed sections
+to actually read.
+
+Keep each entry genuinely short. The temptation is to front-load explanation here and leave the
+detailed section redundant — resist it. The overview answers "what is this change and why should I
+care", the detailed section answers "how does it work and where does it live".
+
+...` heading), and link each entry to its section so the reader can jump straight there.
+
+After the glance list, add a **"Suggested reading order"**: 5–8 numbered steps naming which
+files and functions to open, in which order, for someone reviewing this PR for the first time.
+Start from the artifact that defines the target shape (often a test), then the mechanism, then
+the guards. Tag the load-bearing line each step exists to protect ("this emit mapping is the
+line the rest depends on") so the reader knows what to slow down for. This is pedagogy, not a
+verdict — no severity labels, no "must fix", no approval language.
+
+## Step 7 — Write each key change
+
+For every key change, in this order:
+
+**What it does.** Plain description of the new feature/fix/modified class — write for someone
+unfamiliar with this part of the codebase, not for the PR author.
+
+**Why.** Pull from the PR description or code comments wherever they state it, and label every
+causal claim and failure mode by its evidence:
+
+- **Author-stated** — quoted from the PR body, a commit message, or a review comment. Keep it
+  quoted and attributed; never paraphrase it into the digest's own voice as established fact.
+- **Traced** — you read the code (in-diff or related) that shows it.
+- **Unverified** — neither stated by the author nor traced. List it under "Not covered in this
+  pass", phrased as "I did not check X". It must not appear in the opening summary.
+
+If the why is genuinely not stated, say so explicitly ("not stated in the PR description; best
+guess: ...") — never present a guess as a confirmed fact.
+**Where it's invoked.** The call chain from a recognizable entry point down to this
+function/class. Write this as a nested markdown bullet list with `→` for the tree structure —
+**never inside a triple-backtick fence**, because fenced code blocks don't render markdown links,
+and clickable links are the entire point of this format. Every function or file named in the list
+must be a link (see Link rules below), and **every line must carry one of three tags**:
+
+- **[new]** — this function/class did not exist before the PR
+- **[modified]** — it existed before; the PR changed its body or signature
+- **[existing]** — it was there before and the PR left it untouched; shown only so the reader can
+  follow the call chain through it
+
+Determine the tag by actually checking the diff for that file/function — new file means `[new]`;
+a diff hunk touching that function's lines means `[modified]`; no hunk there means `[existing]`.
+Don't guess from the function's vibe. Skip the tag on pure context that isn't Sirius/repo code
+(e.g. "DuckDB's own logical-plan dispatch" as an entry point). Put a one-line legend above the
+*first* such list in the digest so it doesn't need repeating in every section.
+
+**Diff.** A trimmed, relevant hunk — the changed function or class body, not the whole file's
+diff. Trimming is expected and good (a 300-line file diff in the middle of a digest defeats the
+purpose), but say so explicitly right before the fence: name what's elided (e.g. "license header
+and an ~90-case exhaustive switch elided") and mark cuts inline with a comment like
+`// ... elided: <what> ...`. Link the source file (with a line range if useful) immediately before
+the diff. The diff itself stays inside a normal ` ```diff ` fence — this is the one place a fence
+is correct, since real diffs need +/- coloring and don't contain links anyway.
+
+## Step 8 — Audit moved code and files (its own section: "Relocations")
+
+Relocation is the single biggest source of wasted reviewer time on a large PR. A file moved from
+`src/op/foo.hpp` to `src/op/bar/foo.hpp` shows up as a 400-line delete plus a 400-line add, and a
+reviewer who doesn't know it's a pure move will read all 800 lines looking for the change. The
+point of this section is to let them skip that entirely — but only where skipping is actually
+safe, which means you have to check rather than assume.
+
+Detect moves from the diff: `gh pr diff` marks pure renames as `rename from` / `rename to` with no
+hunks, but a move plus edits usually appears as a separate delete + add pair with near-identical
+content. `gh pr view --json files` paths compared against the base branch's tree will surface the
+latter. For each moved file or function, diff old content against new content and classify it:
+
+- **Logically intact** — content is byte-identical apart from things that can't change behavior:
+  the file's own path/include-guard, `#include` paths updated to follow the move, namespace
+  wrapping, and symbol/file renames. Say so plainly and give the reader permission to skip it.
+- **Renamed, logic intact** — same as above but the function or type also got a new name. Give
+  both names (old → new) so the reader can map their memory of the old code onto the new. A rename
+  is not a logic change; be explicit about that so it doesn't read as a hedge.
+- **Moved with logic changes** — content changed beyond the mechanical adjustments above. This is
+  the case that matters: describe exactly what changed and show a trimmed diff of just the changed
+  region, not the whole moved file. If a moved file has even one real logic change buried in
+  hundreds of relocated lines, that change is easy to miss and calling it out is the highest-value
+  thing this section does.
+
+Structure it as a table or list of `old path → new path`, one line per move, with the
+classification and a one-line note. Link both paths. Group runs of mechanically-identical moves
+(e.g. "18 files moved from `src/include/op/` to `src/include/op/dynamic_filter/`, all logically
+intact") rather than listing each separately — but only after you've actually checked each one, and
+say how you checked.
+
+If you couldn't verify a move (too large to diff carefully, ambiguous rename detection), say so
+here rather than claiming it's intact. An unverified "probably fine" that turns out to hide a logic
+change is worse than no claim at all.
+
+## Step 9 — Write "Not covered in this pass"
+
+Close with an honest list of things you noticed but didn't trace through: a component only
+reachable via tests, gate/threshold logic the PR description mentions but you didn't read in
+detail, etc. The digest should never imply more coverage than it actually did — this section is
+what keeps it honest instead of silently confident.
+
+## Link rules (all of this exists so the digest is actually navigable, not just readable)
+
+- Every file mention is a markdown link: `[filename.cpp](relative/path/to/filename.cpp)`. Never
+  leave a bare filename in backticks when a link is possible.
+- Never use `foo.{hpp,cpp}` shorthand for a header/source pair — always two separate links:
+  `[foo.hpp](path/foo.hpp)` and `[foo.cpp](path/foo.cpp)`.
+- Point at a specific line with `#L<N>`: `[foo.cpp](path/foo.cpp#L123)`.
+- Paths are relative to the digest's own location, `PR_digests/` (one level below repo root), so
+  a link to source looks like `../src/path/to/file.cpp#L123`. If the output location ever moves,
+  adjust the `../` depth to match.
+- Get line numbers by reading/grepping the real, checked-out file — not from memory, and not from
+  `gh pr diff` hunk headers alone (those are diff-relative, though they do coincide with absolute
+  file lines for a brand-new file).
+- Near the top of the digest, note that line numbers are accurate as of generation time and will
+  drift if the branch is later rebased or amended.
+
+## Output
+
+- Path: `PR_digests/PR_digest_<PR_NUMBER>.md`, relative to repo root. Create the `PR_digests/`
+  directory if it doesn't exist.
+- Add `PR_digests/` to the repo's `.gitignore` if it isn't already there — these are local review
+  artifacts, not something to commit. Check once per run; don't ask the user about it each time.
+- Structure, top to bottom:
+  1. Title + a one-line note that this digest explains what the PR does and where it lives, and
+     is not a critique or approval recommendation — so nobody mistakes "no concerns listed" for
+     "no concerns found."
+  2. A one-line caveat about line-number drift (see Link rules).
+  3. Header table: PR number/link, title, author, branch (head → base), scope (commit/file
+     count), closes, supersedes.
+  4. The PR description, quoted.
+  5. A short plain-language summary in your own words — what problem this solves, one paragraph.
+     It must OPEN with a concrete, user-visible or plan-visible before/after taken from the PR —
+     a query, a row shape, a setting, an error message — and only then introduce type names,
+     file names, or API terms. A reader who knows nothing about this subsystem should get
+     the example before the vocabulary. If the PR contains no such example, say so explicitly and do not invent one.
+  6. "Key changes at a glance" — the numbered overview list, 1–3 sentences each, linked to the
+     detailed sections (Step 6).
+  7. Ranked key changes in detail (Steps 5, 7), separated by `---`.
+  8. "Relocations" — moved files/functions with intact-vs-changed classification (Step 8).
+  9. "Not covered in this pass" (Step 9).
+
+See `references/example_digest.md` in this skill directory for a full worked example (PR #1277 —
+sirius-db/sirius, "dynamic filters: SIP") showing the expected tone, link density, trimming style,
+and tagging in practice. Read it before writing a digest if you want a concrete model to match.

--- a/.agents/skills/pr-digest/SKILL.md
+++ b/.agents/skills/pr-digest/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: pr-digest
-description: Create a context-first, navigable GitHub pull-request learning digest as Markdown plus a self-contained HTML preview, explaining the before/after behavior, change flow, key changes, and where they live with line-accurate links, diagrams, and trimmed color-coded diffs. Use when a user wants to understand, summarize, review, walk through, or get up to speed on a GitHub PR. This maps the change without critiquing it; use a separate code-review pass when findings or an approval recommendation are requested.
+description: Explain a GitHub pull request in straightforward language as a navigable Markdown digest plus an HTML preview. Start with the behavior before and after the change, define unavoidable technical terms, then connect the explanation to exact code lines and trimmed color-coded diffs. Use when a user wants to understand, summarize, review, walk through, or get up to speed on a GitHub PR. This maps the change without critiquing it; use a separate code-review pass when findings or an approval recommendation are requested.
 ---
 
 # PR Digest
 
-Turns a GitHub PR link into two companion artifacts a reviewer can actually learn from: canonical
-Markdown for portability and a self-contained HTML preview for reliable rendering in Codex. An
-opening before/after example and flowchart establish the mental model, then ranked key changes
-explain what/why/where-invoked/diff with clickable links into the actual checked-out source.
+Turns a GitHub PR link into two companion files a reviewer can learn from: editable Markdown and
+an HTML preview that renders reliably in Codex. A before/after example and flowchart explain the
+behavior first. Detailed sections then show what changed, why it matters, where it happens, and
+the relevant code.
 
 Comprehension is the whole job here. This skill does not judge the PR — no bug-hunting, no "is
 this a race condition" adversarial pass, no verdict on whether the change is good. That's a
@@ -16,6 +16,35 @@ different kind of work with a different failure mode (a digest that editorialize
 the explanation the reader actually came for), and other review skills cover it. If the user
 seems to expect a full critique from this alone, say plainly that this produces the map, not the
 verdict, and offer a separate code-review pass for the rest.
+
+## Write for a reader who is new to this part of the codebase
+
+Assume the reader understands software engineering but does not know this subsystem's vocabulary.
+The digest should save them from stopping to ask what a phrase means. Use descriptive,
+straightforward language even when it takes a few more words.
+
+- Lead with the familiar concept or action, then give the code's technical name in parentheses if
+  the name helps the reader find it. For example: "a bitmap that marks which original row
+  positions remain visible (the positional mask)."
+- Expand acronyms on first use and explain what they mean in this PR. Do not assume terms such as
+  MVCC, pushdown, materialization, dispatch, snapshot coverage, or zero-copy are self-explanatory.
+- Prefer sentences with an actor, action, and consequence: "The decoder applies both filters, so
+  it creates only the rows that survive" is better than "decode-side compaction is recovered."
+- Avoid compressed noun phrases in headings and summaries. Name the observable behavior, such as
+  "Reuse row-visibility information when the table has not changed."
+- Keep exact class, function, field, and file names in code font and links. Explain their purpose
+  in ordinary language before relying on the identifier.
+- Use a technical term again only after defining it. If a plain phrase remains clear, keep using
+  the plain phrase instead.
+- Prefer "uses the older path" over "falls back," "reports that it applied the mask" over
+  "consumes the mask," and "creates the output rows" over "materializes," unless the technical
+  word itself is the subject being explained.
+- Do not remove necessary technical detail. Translate it, then connect the translation to the
+  exact code name or source line.
+
+Before drafting any digest, read `references/plain_language.md` for PR-specific rewrite patterns
+and the final jargon check. Apply that guide throughout the Markdown; the HTML is generated from
+the same prose.
 
 ## Input
 
@@ -122,7 +151,7 @@ important than a small new file that IS the actual feature.
 - Aim for roughly 1–6 key changes, but let the actual number follow the PR: how many genuinely
   distinct *concepts* does it change? A 100-file PR implementing one idea can be 1–2 key changes;
   a 10-file PR bundling five unrelated fixes needs five.
-- Pure file-relocation diffs (moved with no logic change) don't deserve a key-change slot — they
+- Files that only moved without changing behavior don't deserve a key-change slot — they
   get their own dedicated section instead (Step 9).
 
 ## Step 6 — Orient the reader with a before/after example and a diagram
@@ -144,7 +173,7 @@ Use a compact table or paired snippets. Make these four facts easy to find:
 - the unchanged starting condition;
 - what happened before;
 - what happens after;
-- what stays unchanged or what fallback still applies.
+- what stays unchanged or which older behavior still applies when the new path cannot run.
 
 Keep the example at the user-visible, query-plan-visible, or data-flow-visible level. Detailed
 class and function names belong in the later key-change sections.
@@ -160,7 +189,7 @@ most one edge on each source line. The diagram should:
 - make the old stopping point and new path visible, or show the full new flow when a comparison
   would be misleading;
 - use plain conceptual labels rather than filenames and full function signatures;
-- distinguish decisions/fallbacks that materially affect behavior;
+- distinguish decisions and older paths that materially affect behavior;
 - avoid branches that were not verified from the PR description, diff, or checked-out code.
 
 Immediately below the diagram, add a short **Code anchors** list linking 2–5 diagram concepts to
@@ -179,36 +208,39 @@ Keep each entry genuinely short. The temptation is to front-load explanation her
 detailed section redundant — resist it. The overview answers "what is this change and why should I
 care", the detailed section answers "how does it work and where does it live".
 
-Use a `## Key changes at a glance` heading. Make each entry's title match its detailed section and
-link it to that section so the reader can jump straight there.
+Use a `## Key changes at a glance` heading. Make every title a plain description of the behavior,
+not an internal mechanism or identifier. Match it to the detailed section and link it so the
+reader can jump straight there.
 
 After the glance list, add a **"Suggested reading order"**: 5–8 numbered steps naming which
 files and functions to open, in which order, for someone reviewing this PR for the first time.
 Start from the artifact that defines the target shape (often a test), then the mechanism, then
-the guards. Tag the load-bearing line each step exists to protect ("this emit mapping is the
-line the rest depends on") so the reader knows what to slow down for. This is pedagogy, not a
+the guards. Identify the important line each step exists to protect ("this mapping is the line the
+rest depends on") so the reader knows what to slow down for. This is pedagogy, not a
 verdict — no severity labels, no "must fix", no approval language.
 
 ## Step 8 — Write each key change
 
 For every key change, in this order:
 
-**What it does.** Plain description of the new feature/fix/modified class — write for someone
-unfamiliar with this part of the codebase, not for the PR author.
+**What changed.** Start with the behavior in plain language. Introduce classes and functions only
+after the reader knows their purpose.
 
-**Why.** Pull from the PR description or code comments wherever they state it, and label every
-causal claim and failure mode by its evidence:
+**Why it matters.** Describe the previous cost, limitation, or incorrect behavior and the practical
+effect of the change. Pull from the PR description or code comments wherever they state it, and
+label every causal claim and failure mode by its evidence:
 
-- **Author-stated** — quoted from the PR body, a commit message, or a review comment. Keep it
+- **From the PR author** — quoted from the PR body, a commit message, or a review comment. Keep it
   quoted and attributed; never paraphrase it into the digest's own voice as established fact.
-- **Traced** — you read the code (in-diff or related) that shows it.
-- **Unverified** — neither stated by the author nor traced. List it under "Not covered in this
+- **Confirmed in code** — you read the code (in-diff or related) that shows it.
+- **Not verified** — neither stated by the author nor traced. List it under "Not covered in this
   pass", phrased as "I did not check X". It must not appear in the opening summary.
 
 If the why is genuinely not stated, say so explicitly ("not stated in the PR description; best
 guess: ...") — never present a guess as a confirmed fact.
-**Where it's invoked.** The call chain from a recognizable entry point down to this
-function/class. Write this as a nested markdown bullet list with `→` for the tree structure —
+**Where it happens.** Explain the route through the code from a recognizable entry point down to
+this function or class. Introduce it with one plain sentence, then write the exact call chain as a
+nested markdown bullet list with `→` for the tree structure —
 **never inside a triple-backtick fence**, because fenced code blocks don't render markdown links,
 and clickable links are the entire point of this format. Every function or file named in the list
 must be a link (see Link rules below), and **every line must carry one of three tags**:
@@ -224,10 +256,10 @@ Don't guess from the function's vibe. Skip the tag on pure context that isn't Si
 (e.g. "DuckDB's own logical-plan dispatch" as an entry point). Put a one-line legend above the
 *first* such list in the digest so it doesn't need repeating in every section.
 
-**Diff.** A trimmed, relevant hunk — the changed function or class body, not the whole file's
-diff. Trimming is expected and good (a 300-line file diff in the middle of a digest defeats the
-purpose), but say so explicitly right before the fence: name what's elided (e.g. "license header
-and an ~90-case exhaustive switch elided") and mark cuts inline with a comment like
+**Relevant diff.** A trimmed, relevant hunk — the changed function or class body, not the whole
+file's diff. Trimming is expected and good (a 300-line file diff in the middle of a digest defeats
+the purpose), but say so explicitly right before the fence: name what's elided (e.g. "license
+header and an ~90-case exhaustive switch elided") and mark cuts inline with a comment like
 `// ... elided: <what> ...`. Link the source file (with a line range if useful) immediately before
 the diff. Put the diff inside a fenced code block whose info string is `diff`. Preserve the patch
 marker as the first character of every changed line: `+` for additions and `-` for removals, with
@@ -236,9 +268,9 @@ renderers can recognize the additions and removals. This is the one place a fenc
 since diffs need syntax coloring and contain no links. Markdown viewers may choose their own
 syntax colors; the companion HTML preview always renders additions green and removals red.
 
-## Step 9 — Audit moved code and files (its own section: "Relocations")
+## Step 9 — Audit moved code and files (its own section: "Moved and renamed code")
 
-Relocation is the single biggest source of wasted reviewer time on a large PR. A file moved from
+Moved code is one of the biggest sources of wasted reviewer time on a large PR. A file moved from
 `src/op/foo.hpp` to `src/op/bar/foo.hpp` shows up as a 400-line delete plus a 400-line add, and a
 reviewer who doesn't know it's a pure move will read all 800 lines looking for the change. The
 point of this section is to let them skip that entirely — but only where skipping is actually
@@ -316,14 +348,15 @@ what keeps it honest instead of silently confident.
   5. A short plain-language summary in your own words — what problem this solves and the outcome,
      in one paragraph without implementation detail.
   6. "Before and after" — one grounded example comparing the same scenario on both sides of the
-     PR, including unchanged behavior or fallback (Step 6).
+     PR, including unchanged behavior or the older path used when the new one cannot run (Step 6).
   7. "Flow at a glance" — one compact Mermaid diagram plus 2–5 line-accurate code anchors
      (Step 6).
   8. "Key changes at a glance" — the numbered overview list, 1–3 sentences each, linked to the
      detailed sections (Step 7).
   9. "Suggested reading order" — the linked 5–8-step path through the code (Step 7).
   10. Ranked key changes in detail (Steps 5, 8), separated by `---`.
-  11. "Relocations" — moved files/functions with intact-vs-changed classification (Step 9).
+  11. "Moved and renamed code" — moved files/functions with intact-vs-changed classification
+      (Step 9).
   12. "Not covered in this pass" (Step 10).
 
 After the Markdown is complete, render its companion preview with the repository-local script:
@@ -343,5 +376,6 @@ In the final response, link both files and identify Markdown as the editable sou
 the rendered preview. Also mention the branch/commit that was checked out to generate the links.
 
 See `references/example_digest.md` in this skill directory for a full worked example (PR #1277 —
-sirius-db/sirius, "dynamic filters: SIP") showing the expected tone, link density, trimming style,
-and tagging in practice. Read it before writing a digest if you want a concrete model to match.
+sirius-db/sirius, "dynamic filters: SIP") showing the expected structure, link density, trimming
+style, and tagging. Use `references/plain_language.md` as the authority for prose style when the
+worked example uses denser technical language.

--- a/.agents/skills/pr-digest/SKILL.md
+++ b/.agents/skills/pr-digest/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: pr-digest
-description: Create a context-first, navigable Markdown learning digest for a GitHub pull request, explaining the before/after behavior, change flow, key changes, and where they live with line-accurate links and trimmed diffs. Use when a user wants to understand, summarize, review, walk through, or get up to speed on a GitHub PR. This maps the change without critiquing it; use a separate code-review pass when findings or an approval recommendation are requested.
+description: Create a context-first, navigable GitHub pull-request learning digest as Markdown plus a self-contained HTML preview, explaining the before/after behavior, change flow, key changes, and where they live with line-accurate links, diagrams, and trimmed color-coded diffs. Use when a user wants to understand, summarize, review, walk through, or get up to speed on a GitHub PR. This maps the change without critiquing it; use a separate code-review pass when findings or an approval recommendation are requested.
 ---
 
 # PR Digest
 
-Turns a GitHub PR link into a digest document a reviewer can actually learn from: an opening
-before/after example and flowchart establish the mental model, then ranked key changes explain
-what/why/where-invoked/diff with clickable links into the actual checked-out source.
+Turns a GitHub PR link into two companion artifacts a reviewer can actually learn from: canonical
+Markdown for portability and a self-contained HTML preview for reliable rendering in Codex. An
+opening before/after example and flowchart establish the mental model, then ranked key changes
+explain what/why/where-invoked/diff with clickable links into the actual checked-out source.
 
 Comprehension is the whole job here. This skill does not judge the PR — no bug-hunting, no "is
 this a race condition" adversarial pass, no verdict on whether the change is good. That's a
@@ -150,9 +151,10 @@ class and function names belong in the later key-change sections.
 
 ### Flow at a glance
 
-Add one Mermaid diagram using the diagram type that best explains the change: usually `flowchart`
-for control/data flow, `sequenceDiagram` for interactions over time, or `stateDiagram-v2` for a
-lifecycle. The diagram should:
+Add one Mermaid `flowchart` using `TD`, `TB`, `LR`, or `RL`, choosing the direction that best
+explains the control or data flow. Keep it to simple quoted nodes, decision nodes, labeled arrows,
+and optional `subgraph` groups so both GitHub and the bundled HTML renderer can display it. Put at
+most one edge on each source line. The diagram should:
 
 - contain roughly 4–10 nodes or participants and fit on one screen;
 - make the old stopping point and new path visible, or show the full new flow when a comparison
@@ -230,9 +232,9 @@ and an ~90-case exhaustive switch elided") and mark cuts inline with a comment l
 the diff. Put the diff inside a fenced code block whose info string is `diff`. Preserve the patch
 marker as the first character of every changed line: `+` for additions and `-` for removals, with
 one leading space for unchanged context. Do not use a plain code fence or strip the markers:
-rendered Markdown uses the `diff` language and those prefixes to color additions green and
-removals red. This is the one place a fence is correct, since diffs need syntax coloring and
-contain no links.
+renderers can recognize the additions and removals. This is the one place a fence is correct,
+since diffs need syntax coloring and contain no links. Markdown viewers may choose their own
+syntax colors; the companion HTML preview always renders additions green and removals red.
 
 ## Step 9 — Audit moved code and files (its own section: "Relocations")
 
@@ -294,8 +296,13 @@ what keeps it honest instead of silently confident.
 
 ## Output
 
-- Path: `PR_digests/PR_digest_<PR_NUMBER>.md`, relative to repo root. Create the `PR_digests/`
-  directory if it doesn't exist.
+- Produce both companion files, relative to the repo root:
+  - `PR_digests/PR_digest_<PR_NUMBER>.md` — canonical, editable source.
+  - `PR_digests/PR_digest_<PR_NUMBER>.html` — generated, self-contained preview with an inline SVG
+    flowchart and explicit green/red diff rows.
+- Create the `PR_digests/` directory if it doesn't exist. Write and verify the Markdown first,
+  then generate the HTML from it. Never hand-edit the HTML; regenerate it after every Markdown
+  change.
 - Add `PR_digests/` to the repo's `.gitignore` if it isn't already there — these are local review
   artifacts, not something to commit. Check once per run; don't ask the user about it each time.
 - Structure, top to bottom:
@@ -318,6 +325,22 @@ what keeps it honest instead of silently confident.
   10. Ranked key changes in detail (Steps 5, 8), separated by `---`.
   11. "Relocations" — moved files/functions with intact-vs-changed classification (Step 9).
   12. "Not covered in this pass" (Step 10).
+
+After the Markdown is complete, render its companion preview with the repository-local script:
+
+```sh
+pixi run python .agents/skills/pr-digest/scripts/render_digest_html.py \
+  PR_digests/PR_digest_<PR_NUMBER>.md \
+  PR_digests/PR_digest_<PR_NUMBER>.html
+```
+
+If `pixi` is unavailable, run the same script with `python3`; it uses only the Python standard
+library. Treat a renderer failure as an incomplete digest, not an optional preview. Check the
+reported counts against the Markdown's `diff` and Mermaid fences, confirm the HTML contains no
+remote assets, and open the HTML in Codex when a preview facility is available.
+
+In the final response, link both files and identify Markdown as the editable source and HTML as
+the rendered preview. Also mention the branch/commit that was checked out to generate the links.
 
 See `references/example_digest.md` in this skill directory for a full worked example (PR #1277 —
 sirius-db/sirius, "dynamic filters: SIP") showing the expected tone, link density, trimming style,

--- a/.agents/skills/pr-digest/agents/openai.yaml
+++ b/.agents/skills/pr-digest/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Digest"
+  short_description: "Create a navigable learning digest for a GitHub PR"
+  default_prompt: "Use $pr-digest to explain this GitHub pull request in a navigable learning digest."

--- a/.agents/skills/pr-digest/references/example_digest.md
+++ b/.agents/skills/pr-digest/references/example_digest.md
@@ -1,0 +1,617 @@
+# PR Digest — #1277: Dynamic filters: SIP (sideways information passing) across non-scan probes
+
+> **This digest explains what the PR does and where it lives — it is not a critique or an approval
+> recommendation.** Nothing here should be read as "no concerns found"; no concern-hunting was
+> performed.
+>
+> **A note on line numbers:** every `#LNNN` link below points at the file as it stands on the PR
+> branch (`kk/issue-1010-dynamic-filter-sip`) at the time this digest was written. Line numbers
+> drift as a branch gets rebased/amended — treat them as "accurate as of this digest," not as a
+> permanent address.
+
+| | |
+|---|---|
+| **PR** | [sirius-db/sirius#1277](https://github.com/sirius-db/sirius/pull/1277) |
+| **Title** | dynamic filters: SIP |
+| **Author** | Kevin Kristensen ([@kevkrist](https://github.com/kevkrist)) |
+| **Branch** | `kk/issue-1010-dynamic-filter-sip` → `dev` |
+| **Scope** | 59 commits, 100 files, +/- ~roughly evenly split between new planner/runtime code and tests |
+| **Closes** | #1010 ("extend pushdown to non-scan probes"), #1125 (SIP consumer roadmap C1a–C4) |
+| **Supersedes** | #1179 (design/delivery split), #1193 (abandoned planning-sidecar scaffold), #1244 (R1a — producer-key seam, now folded in), #1267 (R1b — live domain-coverage gate, now folded in) |
+
+## PR description (author's own words)
+
+> Decouples Sirius dynamic-filter routing from DuckDB planner metadata. Sirius now admits
+> equality keys and traces each key independently through safe projections, filters, grouping
+> keys, join sides, and scan or join-edge endpoints. This enables SIP across nested joins,
+> grouped inputs, correlated subqueries, and materialized CTEs while preserving type, null, and
+> outer-join boundaries.
+>
+> Discovery requires either visible build-side filtering or an opaque `CTE_REF`/`DELIM_GET` root
+> (optionally projection-wrapped). Unfiltered visible joins and aggregates therefore cannot
+> publish large no-op filters, while opaque Q11/Q17 routes remain eligible.
+>
+> The PR also adds the domain-coverage publication gate, marginal keep-ratio suppression,
+> publication counters, consolidated `enable_dynamic_filter` configuration, and end-to-end/
+> plan-shape coverage. DuckDB target discovery remains only as a test parity oracle.
+>
+> A significant part of the diff is file relocation into the dynamic-filter module.
+
+**Plain-language summary:** Phase‑1 dynamic filters only pruned a leaf table scan on the probe
+side of a join (build a hash table from the small side, derive a membership/zone-map filter,
+apply it at the scan feeding the probe side of the *same* join). This PR lets that filter also
+prune a probe input that is itself the output of another join, aggregate, or CTE — i.e. it can
+travel *sideways* through the plan tree to reach a fact-table scan that sits several operators
+below the join that actually produced the filter.
+
+## Key changes at a glance
+
+1. **[SIP-capable planning pipeline in `plan_comparison_join`](#key-change-1--sip-capable-planning-pipeline-in-plan_comparison_join-ranked-1-this-is-the-feature)** — Three new planner
+   components (key admission, target discovery, domain-coverage evidence) decide which join keys
+   can publish a filter and walk the probe subtree to find where that filter should attach. When
+   the walk lands somewhere other than a table scan, it splices a new filter operator into the
+   plan tree — that splice is the SIP feature.
+2. **[Publisher decoupled from DuckDB's `JoinFilterPushdownInfo`](#key-change-2--publisher-decoupled-from-duckdbs-joinfilterpushdowninfo-hardened-one-shot-publication-lifecycle)** — Runtime filter publication
+   now reads only the Sirius-owned plan built at planning time, not DuckDB's join metadata. The
+   publish hook also gained a GPU-replica residency check, out-of-memory handling that fails the
+   filter instead of the query, and a counters sink.
+3. **[Consolidated `enable_dynamic_filter` setting + shared threshold validator](#key-change-3--consolidated-enable_dynamic_filter-setting--shared-domain-coverage-threshold-validator)** — Renames
+   `enable_dynamic_filter_pushdown` to `enable_dynamic_filter` and routes both the YAML and SQL
+   `SET` config paths through one validation predicate. This closes a real gap where YAML accepted
+   a threshold value that would later fail planning on every GPU hash join.
+
+Roughly 60 further files moved into the new `dynamic_filter/` module — see
+[Relocations](#relocations) for which of those are pure moves you can safely skip and which hide
+real logic changes.
+
+---
+
+## Key Change 1 — SIP-capable planning pipeline in `plan_comparison_join` (ranked #1: this *is* the feature)
+
+### What it does
+
+Three new planner components, all wired together inside the existing join-planning entry point
+[`sirius_physical_plan_generator::plan_comparison_join`](../src/planner/sirius_plan_comparison_join.cpp#L399):
+
+1. **Key admission**
+   ([dynamic_filter_key_admission.hpp](../src/include/planner/dynamic_filter/dynamic_filter_key_admission.hpp),
+   [dynamic_filter_key_admission.cpp](../src/planner/dynamic_filter/dynamic_filter_key_admission.cpp))
+   — decides, per join condition, whether an equality key is statically eligible to become a
+   dynamic-filter producer at all (must be plain equality, non-cast/non-computed on both sides, a
+   supported build storage type).
+2. **Target discovery**
+   ([dynamic_filter_target_discovery.hpp](../src/include/planner/dynamic_filter/dynamic_filter_target_discovery.hpp),
+   [dynamic_filter_target_discovery.cpp](../src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp))
+   — walks the probe subtree *downward* from each admitted key's ordinal through projections,
+   filters, `GROUP BY` keys, unions, and join edges to find every place a consumer could attach.
+   If the walk reaches a `TABLE_SCAN`, the filter binds there as before (the "scan route"). If it
+   terminates somewhere else that safely tracks the key (e.g. above an intermediate join whose
+   probe side is another join's output), the code **splices a new `sirius_physical_dynamic_filter`
+   consumer operator directly into the probe subtree at that point** (the "direct route") — this
+   splice is the SIP mechanism.
+3. **Domain-coverage evidence**
+   ([build_key_domain.hpp](../src/include/planner/dynamic_filter/build_key_domain.hpp),
+   [build_key_domain.cpp](../src/planner/dynamic_filter/build_key_domain.cpp)) — before
+   `create_plan` consumes the logical children, walks the *build* side back to its base table and
+   records `NodeStatistics::max_cardinality` as a row-count upper bound for the key's column, used
+   later by the publisher to gate/suppress filters that wouldn't be selective (see Key Change 2).
+
+### Why (from PR description / issue #1010)
+
+> The highest-value follow-up is sideways information passing: let a build-side filter prune a
+> downstream join's probe input, so filters from dimension joins reach the fact table through
+> intermediate joins.
+
+Discovery is deliberately conservative:
+[`join_block_descent`](../src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp#L94) /
+[`descent_steps`](../src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp#L117) only
+continue descent through join types that provably don't null-pad or duplicate the traced side —
+see
+[`probe_block_is_value_preserving`](../src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp#L34)
+and
+[`build_block_is_value_preserving`](../src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp#L53)
+— so semantics (NULLs from outer joins, row multiplication) can't be silently broken by an
+inserted filter.
+
+### Where it's invoked
+
+*Provenance tag on every line: **[new]** = function/class didn't exist before this PR,
+**[modified]** = existing function whose body/signature this PR changed,
+**[existing]** = present before this PR and untouched by it (shown only for call-chain context).*
+
+- DuckDB logical plan (`LOGICAL_COMPARISON_JOIN`) — *(external DuckDB construct, not Sirius code — no tag)*
+  - → `sirius_physical_plan_generator::CreatePlan()` [dispatch switch] — **[existing]**, this `case` arm is untouched by the PR
+    - → [`plan_comparison_join(op)`](../src/planner/sirius_plan_comparison_join.cpp#L399) — **[modified]**
+      - → [`build_key_domain_cardinalities(op, ...)`](../src/planner/sirius_plan_comparison_join.cpp#L423) — **[new]** — domain evidence, gated on `build_evidence`
+      - → [`classify_join_key_shapes(op.conditions)`](../src/planner/sirius_plan_comparison_join.cpp#L439) — **[new]** — captures shape before materialization
+      - → [`admit_dynamic_filter_keys(...)`](../src/planner/sirius_plan_comparison_join.cpp#L488) — **[new]**
+      - → for each admitted key:
+        - → [`trace_probe_key(*left, key.probe_key_ordinal, policy)`](../src/planner/sirius_plan_comparison_join.cpp#L506) — **[new]** — scan-route attempt
+        - → [`place_endpoint(std::move(left), ...)`](../src/planner/sirius_plan_comparison_join.cpp#L555) — **[new]** — direct-route splice, only if the scan-route attempt found no scan terminal
+
+`plan_comparison_join` is also reached indirectly via
+[`sirius_plan_delim_join.cpp:76`](../src/planner/sirius_plan_delim_join.cpp#L76)
+(`plan_comparison_join(op)`) — **[existing]** call site, untouched by this PR, but it calls into
+the now-**[modified]** `plan_comparison_join` above — so `DELIM_JOIN`-shaped correlated-subquery
+plans get the same admission/discovery pass for free. This is what lets SIP reach through
+"materialized CTEs" per the PR description.
+
+### Diff — target discovery core (new file, trimmed)
+
+[dynamic_filter_target_discovery.cpp](../src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp)
+(new, 325 lines). **Trimmed**: license header and the exhaustive `SiriusPhysicalOperatorType`
+switch's ~90 pass-through `case` labels inside
+[`descent_steps`](../src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp#L117) are
+elided below.
+
+```diff
++std::optional<descent_step> join_block_descent(
++  duckdb::JoinType join_type,
++  std::vector<cudf::size_type> const& probe_block_output_columns,
++  std::vector<cudf::size_type> const& build_block_output_columns,
++  std::size_t output_ordinal,
++  descent_policy policy)
++{
++  auto const probe_block_size = probe_block_output_columns.size();
++  if (output_ordinal < probe_block_size) {
++    if (!probe_block_is_value_preserving(join_type)) { return std::nullopt; }
++    return descent_step{
++      .child_index   = 0,
++      .child_ordinal = static_cast<std::size_t>(probe_block_output_columns[output_ordinal])};
++  }
++  if (!policy.descend_build_blocks) { return std::nullopt; }
++  if (!build_block_is_value_preserving(join_type)) { return std::nullopt; }
++  auto const build_ordinal = output_ordinal - probe_block_size;
++  if (build_ordinal >= build_block_output_columns.size()) { return std::nullopt; }
++  return descent_step{
++    .child_index   = 1,
++    .child_ordinal = static_cast<std::size_t>(build_block_output_columns[build_ordinal])};
++}
++
++// ... descent_steps(): per-operator-type switch selecting the descent_step(s) for
++// PROJECTION / HASH_GROUP_BY / HASH_JOIN / FILTER / UNION / DYNAMIC_FILTER; every other
++// operator type returns {} (i.e. "stop here, this is a terminal") ...
++
++void trace_probe_key_into(sirius::op::sirius_physical_operator& node,
++                          std::size_t ordinal,
++                          descent_policy policy,
++                          std::vector<route_terminal>& terminals)
++{
++  auto const steps = descent_steps(node, ordinal, policy);
++  if (!steps_are_followable(node, steps)) {
++    terminals.push_back(route_terminal{.node = &node, .ordinal = ordinal});
++    return;
++  }
++  for (auto const& step : steps) {
++    trace_probe_key_into(*node.children[step.child_index], step.child_ordinal, policy, terminals);
++  }
++}
++
++endpoint_placement place_endpoint(duckdb::unique_ptr<sirius::op::sirius_physical_operator> subtree,
++                                  std::size_t a0,
++                                  descent_policy policy,
++                                  endpoint_factory const& make_endpoint)
++{
++  assert(subtree != nullptr);
++  auto const steps = descent_steps(*subtree, a0, policy);
++  if (steps_are_followable(*subtree, steps)) {
++    // Ascending child order keeps site ordinals aligned with trace_probe_key() terminals.
++    endpoint_placement result;
++    for (auto const& step : steps) {
++      auto& child_slot = subtree->children[step.child_index];
++      auto placed =
++        place_endpoint(std::move(child_slot), step.child_ordinal, policy, make_endpoint);
++      child_slot = std::move(placed.subtree);
++      result.site_ordinals.insert(
++        result.site_ordinals.end(), placed.site_ordinals.begin(), placed.site_ordinals.end());
++    }
++    result.subtree = std::move(subtree);
++    return result;
++  }
++  auto endpoint = make_endpoint(*subtree);
++  endpoint->children.push_back(std::move(subtree));
++  return endpoint_placement{.subtree = std::move(endpoint), .site_ordinals = {a0}};
++}
+```
+
+*(Full new-file diff: `gh pr diff 1277 -- src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp src/include/planner/dynamic_filter/dynamic_filter_target_discovery.hpp`.)*
+
+### Diff — key admission (new file, trimmed to the admission decision)
+
+[dynamic_filter_key_admission.cpp](../src/planner/dynamic_filter/dynamic_filter_key_admission.cpp),
+[`admit_scan_route_key`](../src/planner/dynamic_filter/dynamic_filter_key_admission.cpp#L57)
+(lines 57–101; the full function is shown, trimmed only inside its body where marked):
+
+```diff
++std::optional<op::dynamic_filter_publish_plan::admitted_key> admit_scan_route_key(
++  sirius::join_condition const& condition,
++  op::dynamic_filter_condition_shape shape,
++  std::size_t condition_index,
++  std::size_t domain_cardinality,
++  std::optional<std::size_t> build_side_unique_column)
++{
++  // Null-equal keys could turn a pruned LEFT join match into an accepted NULL-padded row.
++  if (condition.comparison != sirius::comparison_type::equal) { return std::nullopt; }
++  if (side_blocks_scan_route(shape.probe) || side_blocks_scan_route(shape.build)) {
++    return std::nullopt;
++  }
++  // ... elided: extract build_ref / probe_side references and their cudf storage types ...
++  return op::dynamic_filter_publish_plan::admitted_key{
++    .planner_condition_index      = condition_index,
++    .build_key_ordinal            = build_key_ordinal,
++    .probe_key_ordinal            = probe_key_ordinal,
++    .storage_type                 = *storage_type,
++    .probe_storage_type           = probe_storage_type,
++    .key_shape                    = shape,
++    .build_key_domain_cardinality = domain_cardinality,
++    .build_key_proven_unique =
++      build_side_unique_column == std::optional{static_cast<std::size_t>(build_key_ordinal)}};
++}
+```
+
+### Diff — call site wiring in `plan_comparison_join` (trimmed)
+
+[sirius_plan_comparison_join.cpp](../src/planner/sirius_plan_comparison_join.cpp), lines
+[483](../src/planner/sirius_plan_comparison_join.cpp#L483)–[555](../src/planner/sirius_plan_comparison_join.cpp#L555).
+**Trimmed**: the scan-route binding loop body and its `SIRIUS_LOG_WARN` calls are elided.
+
+```diff
+     auto const build_side_unique_column =
+       build_side_unique_cols.size() == 1
+         ? std::optional<std::size_t>{static_cast<std::size_t>(*build_side_unique_cols.begin())}
+         : std::nullopt;
++    auto admitted_keys = admit_dynamic_filter_keys(
++      conditions, condition_key_shapes, condition_domains, build_side_unique_column);
++
++    std::vector<sirius::op::dynamic_filter_publish_plan::probe_target> targets;
++    std::size_t scan_target_count = 0;
++    bool const discovery_runs     = build_evidence &&
++                                op.type == duckdb::LogicalOperatorType::LOGICAL_COMPARISON_JOIN &&
++                                !gpu_spaces.empty() && !host_spaces.empty();
++    if (discovery_runs) {
++      bool const scan_bind_armed = scan_route_join_type_admissible(op.join_type);
++      descent_policy const policy{.descend_build_blocks = true};
++      for (std::size_t key_index = 0; key_index < admitted_keys.size(); ++key_index) {
++        auto const& key       = admitted_keys[key_index];
++        auto const& condition = conditions[key.planner_condition_index];
++        auto const terminals =
++          trace_probe_key(*left, static_cast<std::size_t>(key.probe_key_ordinal), policy);
++        // ... elided: bind to a TABLE_SCAN terminal if one is found (scan route) ...
++        if (scan_bound) { continue; }
++        if (!direct_route_admissible(op.join_type, condition.comparison, key.key_shape,
++                                     key.probe_storage_type, key.storage_type)) {
++          continue;
++        }
++        auto placed = place_endpoint(
++          std::move(left), static_cast<std::size_t>(key.probe_key_ordinal), policy,
++          [&](sirius::op::sirius_physical_operator const& site)
++            -> duckdb::unique_ptr<sirius::op::sirius_physical_operator> {
++            auto channel  = std::make_shared<sirius::op::sirius_dynamic_filter_set>();
++            auto endpoint = duckdb::make_uniq<sirius::op::scan::sirius_physical_dynamic_filter>(
++              site.types, site.estimated_cardinality, channel,
++              op_params.dynamic_filter_keep_threshold,
++              sirius::op::scan::dynamic_filter_apply_mode::membership_masks_only);
++            site_channels.push_back(std::move(channel));
++            return endpoint;
++          });
++        left = std::move(placed.subtree);
++      }
++    }
+```
+
+---
+
+## Key Change 2 — Publisher decoupled from DuckDB's `JoinFilterPushdownInfo`; hardened one-shot publication lifecycle
+
+### What it does
+
+[`sirius_physical_hash_join`](../src/include/op/sirius_physical_hash_join.hpp) used to require a
+`duckdb::JoinFilterPushdownInfo` (DuckDB's own join-filter metadata) at
+[construction time](../src/op/sirius_physical_hash_join.cpp#L278) and threw if dynamic filtering
+was enabled without it. That parameter, the member `filter_pushdown`, and the class-based
+`dynamic_filter_publisher{filter_pushdown, ...}.publish(...)` are all removed. Publication is now
+driven entirely by the plan-time `dynamic_filter_publish_plan` built in Key Change 1, consumed by
+a new free function
+[`sirius::op::publish_dynamic_filters(plan, build_view, stream)`](../src/op/dynamic_filter/dynamic_filter_publisher.cpp#L71).
+
+Alongside the decoupling, the one-shot "publish when the whole build side arrives" hook
+([`push_data_batch_partitioned`](../src/op/sirius_physical_hash_join.cpp#L2092)) picked up three
+behaviors that didn't exist before:
+- a **replica-residency check**
+  ([`_dynamic_filter_plan.has_replica_on_device(...)`](../src/op/sirius_physical_hash_join.cpp#L2158))
+  before using the build batch as a filter source, instead of assuming any GPU-resident batch is
+  usable;
+- an **OOM-safe catch** around publication — `rmm::out_of_memory` now fails the *publication*
+  (marks state `FAILED`) without failing the *query*, since dynamic filters are advisory;
+- a `dynamic_filter_stats*` counters sink threaded through the constructor, incremented at every
+  branch of the publication state machine (attempts, skips, domain-gate skips, failures, etc.).
+
+### Why (from PR description / #1244)
+
+> Runtime dynamic-filter publication no longer reads DuckDB's `JoinFilterPushdownInfo`.
+> Admitted-key metadata is decided at plan time and carried on `dynamic_filter_publish_plan`; the
+> publisher consumes only that... Behavior-preserving for every accepted configuration.
+
+The OOM handling is new behavior, not just a refactor — the code comment at the catch site is
+explicit about why it fails the publication rather than retrying:
+
+> FAILED, not reopen: retrying a sibling delivery under the same memory pressure is the storm this
+> catch exists to avoid.
+
+### Where it's invoked
+
+- [`push_data_batch_partitioned(port_id="build", batch, partition_idx)`](../src/op/sirius_physical_hash_join.cpp#L2092) — **[modified]**
+  (claims the publication slot under `op_state_mutex`, checks `_build_arrives_whole`)
+  - → [`publish_dynamic_filters(build_view, publish_stream)`](../src/op/sirius_physical_hash_join.cpp#L2025) [member function] — **[modified]**
+    - → [`sirius::op::publish_dynamic_filters(_dynamic_filter_plan, build_view, stream)`](../src/op/sirius_physical_hash_join.cpp#L2035) — **[new]** free function, implemented in [dynamic_filter_publisher.cpp](../src/op/dynamic_filter/dynamic_filter_publisher.cpp); builds membership/zone-map filters from the build table and pushes them into each `probe_target`'s `filter_set`
+
+Both `push_data_batch_partitioned` and the member `publish_dynamic_filters` already existed before
+this PR (same names, same call relationship) — what changed is their bodies: the residency check,
+OOM handling, and stats sink described above, plus routing to the new free function instead of the
+old `dynamic_filter_publisher` class.
+
+`push_data_batch_partitioned` is a pipeline callback invoked once per hash join whenever a batch
+lands on its `"build"` port; the *whole-build-in-one-batch* precondition (`_build_arrives_whole`)
+is set upstream by the `PARTITION` operator's sizing decision.
+
+### Diff — API surface (new free function replaces the class)
+
+[dynamic_filter_publisher.hpp](../src/include/op/dynamic_filter/dynamic_filter_publisher.hpp) (new file, shown in full):
+
+```diff
++struct dynamic_filter_publication_outcome {
++  std::size_t keys_considered            = 0;
++  std::size_t keys_with_known_domain     = 0;
++  std::size_t keys_build_exceeded_domain = 0;
++  std::size_t skipped_targets_drained    = 0;
++  std::size_t keys_skipped_domain_gate   = 0;
++  std::size_t keys_skipped_type_mismatch = 0;
++  std::size_t membership_filters_built   = 0;
++  std::size_t zone_map_filters_built     = 0;
++  std::size_t active_targets             = 0;
++  std::size_t filters_pushed             = 0;
++};
++
++/**
++ * @brief Builds and publishes filters from a complete hash-join build table
++ * @pre @p plan is enabled
++ */
++[[nodiscard]] dynamic_filter_publication_outcome publish_dynamic_filters(
++  dynamic_filter_publish_plan const& plan,
++  cudf::table_view const& build_view,
++  rmm::cuda_stream_view stream);
+```
+
+### Diff — constructor no longer takes DuckDB pushdown metadata (trimmed)
+
+[sirius_physical_hash_join.cpp](../src/op/sirius_physical_hash_join.cpp), constructor starting at
+[line 278](../src/op/sirius_physical_hash_join.cpp#L278). **Trimmed** to the signature and the
+changed body; unrelated parameters and the join-condition-reordering body in between are elided.
+
+```diff
+ sirius_physical_hash_join::sirius_physical_hash_join(
+   ...
+   duckdb::vector<sirius::logical_type> delim_types,
+   std::size_t estimated_cardinality,
+-  duckdb::unique_ptr<duckdb::JoinFilterPushdownInfo> pushdown_info_p,
+   uint64_t max_build_hash_table_bytes,
+   dynamic_filter_publish_plan dynamic_filter_plan,
+   uint64_t hash_partition_bytes,
+-  uint64_t max_broadcast_join_size)
++  uint64_t max_broadcast_join_size,
++  dynamic_filter_stats* dynamic_filter_stats_sink)
+   ...
+-  filter_pushdown = std::move(pushdown_info_p);
+-  if (_dynamic_filter_plan.enabled() && !filter_pushdown) {
+-    throw std::invalid_argument(
+-      "[sirius_physical_hash_join] An enabled dynamic-filter publication plan requires join "
+-      "filter-pushdown metadata");
++  _dynamic_filter_stats = dynamic_filter_stats_sink;
++  if (_dynamic_filter_stats != nullptr && _dynamic_filter_plan.enabled()) {
++    _dynamic_filter_stats->producers_enabled.fetch_add(1, std::memory_order_relaxed);
+   }
+```
+
+### Diff — OOM-safe, residency-checked publication (trimmed to the new control flow)
+
+[sirius_physical_hash_join.cpp](../src/op/sirius_physical_hash_join.cpp), around
+[`publish_dynamic_filters`](../src/op/sirius_physical_hash_join.cpp#L2025) and the residency check
+inside [`push_data_batch_partitioned`](../src/op/sirius_physical_hash_join.cpp#L2092) starting near
+[line 2155](../src/op/sirius_physical_hash_join.cpp#L2155). **Trimmed**: stats-accumulation and
+logging call bodies are elided.
+
+```diff
+   try {
+-    if (filter_pushdown && _dynamic_filter_plan.enabled()) {
+-      dynamic_filter_publisher{
+-        *filter_pushdown, _dynamic_filter_plan, key_casts, right_key_col_indices}
+-        .publish(build_view, stream);
++    if (_dynamic_filter_plan.enabled()) {
++      auto const outcome =
++        sirius::op::publish_dynamic_filters(_dynamic_filter_plan, build_view, stream);
++      if (_dynamic_filter_stats != nullptr) { /* accumulate outcome.* into stats, relaxed */ }
+     }
+     _dynamic_filter_publication_state.store(dynamic_filter_publication_state::FINISHED, ...);
++  } catch (rmm::out_of_memory const& oom) {
++    // Dynamic filters are optional; device OOM fails publication without failing the query.
++    // FAILED, not reopen: retrying a sibling delivery under the same memory pressure is the
++    // storm this catch exists to avoid.
++    _dynamic_filter_publication_state.store(dynamic_filter_publication_state::FAILED, ...);
++    SIRIUS_LOG_WARN(... "device memory exhaustion; continuing without filters" ...);
+   } catch (...) {
+     _dynamic_filter_publication_state.store(dynamic_filter_publication_state::FAILED, ...);
+     throw;
+   }
+```
+
+```diff
+-  if (!ms || build_ro->get_current_tier() != ::cucascade::memory::Tier::GPU) { return; }
++  bool const gpu_resident =
++    ms != nullptr && build_ro.get_current_tier() == ::cucascade::memory::Tier::GPU;
++  bool const source_usable =
++    gpu_resident && _dynamic_filter_plan.has_replica_on_device(ms->get_device_id());
++  if (!source_usable) {
++    // ... elided: log which case it was, then reopen the publication slot for another delivery ...
++    std::scoped_lock lg(op_state_mutex);
++    _dynamic_filter_publication_state.store(dynamic_filter_publication_state::OPEN, ...);
++    return;
++  }
+```
+
+---
+
+## Key Change 3 — Consolidated `enable_dynamic_filter` setting + shared domain-coverage-threshold validator
+
+### What it does
+
+The YAML/SQL setting `enable_dynamic_filter_pushdown` is renamed to `enable_dynamic_filter`
+(single on/off switch for the whole feature, matching the fact that scan-route and direct-route
+publication now share one plan-time gate). The `dynamic_filter_domain_coverage_threshold` setting
+is validated by a new shared predicate type,
+[`config::valid_domain_coverage_threshold`](../src/include/sirius_config.hpp#L78), used by both
+the YAML reader and the SQL `SET` handler.
+
+### Why (from PR description / #1244)
+
+> One deliberate exception: the YAML surface now rejects a
+> `dynamic_filter_domain_coverage_threshold` that the SQL `SET` surface already rejected. On
+> `dev` that value was accepted from YAML and reached a constructor built for every GPU hash
+> join, so a non-positive or NaN setting failed planning for every such query.
+
+I.e. this is a genuine bug fix bundled into the rename, not pure renaming — previously the two
+entry points (YAML config file vs. `SET dynamic_filter_domain_coverage_threshold = ...`) enforced
+different validity rules for the same value, and the looser one (YAML) could pass through a value
+that later crashed planning universally.
+
+### Where it's invoked
+
+- YAML config load: [sirius_config.cpp:273](../src/sirius_config.cpp#L273) (`operator_params::from_yaml`) — **[modified]** (existing function; the two `r.optional(...)` lines shown in the diff below changed)
+- SQL `SET` handler: [sirius_extension.cpp:2103](../src/sirius_extension.cpp#L2103) (`SetDynamicFilterDomainCoverageThreshold`) — **[modified]** (existing function; now calls the shared `valid_domain_coverage_threshold` predicate instead of an inline check)
+- Extension option default: [sirius_extension.cpp:2299](../src/sirius_extension.cpp#L2299) (`AddExtensionOption("enable_dynamic_filter", ...)`) — **[modified]**, renamed from `AddExtensionOption("enable_dynamic_filter_pushdown", ...)`; its callback was also renamed from `SetEnableDynamicFilterPushdown` to `SetEnableDynamicFilter` (same body)
+- The validator itself, `config::valid_domain_coverage_threshold` ([sirius_config.hpp:78](../src/include/sirius_config.hpp#L78)) — **[new]** struct, is what both of the above now call into
+
+### Diff
+
+[sirius_config.cpp](../src/sirius_config.cpp), lines
+[270](../src/sirius_config.cpp#L270)–[278](../src/sirius_config.cpp#L278):
+
+```diff
+   r.optional("enable_runtime_distinct_build_probe", opt.enable_runtime_distinct_build_probe);
+-  r.optional("enable_dynamic_filter_pushdown", opt.enable_dynamic_filter_pushdown);
++  r.optional("enable_dynamic_filter", opt.enable_dynamic_filter);
+   r.optional("enable_dynamic_zone_map_filter", opt.enable_dynamic_zone_map_filter);
+   r.optional("dynamic_filter_domain_coverage_threshold",
+              opt.dynamic_filter_domain_coverage_threshold,
+-             yaml::greater_than<double>{0.0});
++             config::valid_domain_coverage_threshold{});
+```
+
+[sirius_extension.cpp](../src/sirius_extension.cpp), lines
+[2103](../src/sirius_extension.cpp#L2103)–[2106](../src/sirius_extension.cpp#L2106) (SQL `SET`
+handler reusing the same predicate):
+
+```diff
++  if (!sirius::config::valid_domain_coverage_threshold{}(threshold)) {
++    throw InvalidInputException("dynamic_filter_domain_coverage_threshold %s, got %f",
++                                sirius::config::valid_domain_coverage_threshold::description(),
++                                threshold);
++  }
+```
+
+---
+
+## Relocations
+
+Most of this PR's raw diff volume is the dynamic-filter substrate moving into
+`op/dynamic_filter/` and `planner/dynamic_filter/`. **Read this section before opening any of
+those files** — several are pure moves you can skip entirely, but three of them carry real logic
+changes buried in the relocation noise.
+
+**How these were classified:** for each move, old and new content were diffed with comment lines
+and blank lines stripped, so only substantive differences survive. Git detected five of these as
+renames (with a `similarity index`); the rest appear in the diff as a delete/add pair because
+their content changed too much for rename detection, and were paired up by name and reconstructed
+from the base branch.
+
+### Pure moves — safe to skip
+
+Content is identical apart from the file's own path, `#include` paths following the move, and
+doc-comment reformatting (the PR converts `///` Doxygen blocks to `/** */` and condenses the
+prose). No behavioral difference.
+
+| Old path | New path | Note |
+|---|---|---|
+| `src/include/op/dynamic_filter_device.hpp` | [dynamic_filter_device.hpp](../src/include/op/dynamic_filter/dynamic_filter_device.hpp) | One comment reworded; code byte-identical. |
+| `src/include/op/dynamic_filter_replica_reservation.hpp` | [dynamic_filter_replica_reservation.hpp](../src/include/op/dynamic_filter/dynamic_filter_replica_reservation.hpp) | Include path + doc reformat. See the verification note below. |
+| `src/include/op/dynamic_filter_replica_space.hpp` | [dynamic_filter_replica_space.hpp](../src/include/op/dynamic_filter/dynamic_filter_replica_space.hpp) | Comment condensing only. |
+| `src/include/op/dynamic_filter_replica_transfer.hpp` | [dynamic_filter_replica_transfer.hpp](../src/include/op/dynamic_filter/dynamic_filter_replica_transfer.hpp) | `replica_transfer_route` / `replica_transfer_policy` enums collapsed to one line each; enumerators and their order unchanged. |
+
+**Verification note on `dynamic_filter_replica_reservation.hpp`:** the moved version's docs gained
+`@throw std::invalid_argument if @p bytes is zero`, which reads like new behavior. It isn't —
+checking `dev` at [line 68](../src/include/op/dynamic_filter/dynamic_filter_replica_reservation.hpp#L68),
+the `if (bytes == 0) { throw std::invalid_argument(...) }` guard was already there and the PR only
+documented it. Worth stating explicitly, since a newly-appeared `@throw` in a moved file is exactly
+the kind of thing that looks like a silent behavior change.
+
+### Renamed, logic intact
+
+- `dynamic_filter_publisher` (class) → [`sirius::op::publish_dynamic_filters`](../src/op/dynamic_filter/dynamic_filter_publisher.cpp#L71)
+  (free function). This is a genuine API reshape rather than a rename alone — it's covered in
+  detail as **Key Change 2**; listed here only so a reader who searches for the old class name
+  knows where it went.
+
+### Moved *with* logic changes — do not skip these
+
+- **`src/op/sirius_dynamic_filter.cpp` → [sirius_dynamic_filter.cpp](../src/op/dynamic_filter/sirius_dynamic_filter.cpp)**
+  (git similarity 90%). Three real changes hide in this move:
+  1. A new `sirius_dynamic_zone_map_filter::supports(cudf::data_type)` type allowlist that
+     excludes floating-point types — this is the PR's "suppress dynamic zone maps for
+     floating-point join keys" behavior.
+  2. New validation in zone construction: throws `std::invalid_argument` if a zone's min and max
+     types differ, if zones don't all share one bound type, or if the bound type isn't in the
+     allowlist above. Previously unvalidated.
+  3. `_consumer_col_remap` and `set_consumer_column_remap()` were **deleted** — the
+     producer-index-to-consumer-column translation they performed is gone, consistent with
+     routing now being decided at plan time (Key Change 1). Anyone who depended on that remap
+     needs to know it no longer exists.
+- **`src/include/op/sirius_dynamic_filter.hpp` → [sirius_dynamic_filter.hpp](../src/include/op/dynamic_filter/sirius_dynamic_filter.hpp)**
+  (668 lines deleted, 421 added). The header counterpart of the above; the size drop is mostly the
+  removed remap API plus doc condensing, but the declaration changes track the `.cpp` changes
+  listed above.
+- **`src/include/op/dynamic_filter_publish_plan.hpp` → [dynamic_filter_publish_plan.hpp](../src/include/op/dynamic_filter/dynamic_filter_publish_plan.hpp)**.
+  Moved *and* gained three new plan-time types that Key Change 1 depends on:
+  `dynamic_filter_key_shape` (`direct`/`cast`/`computed`), `dynamic_filter_condition_shape`, and
+  `dynamic_filter_route_class` (`scan`/`direct`).
+- **`src/planner/duckdb_join_filter_candidate_adapter.cpp` → [duckdb_join_filter_candidate_adapter.cpp](../src/planner/dynamic_filter/duckdb_join_filter_candidate_adapter.cpp)**
+  (git similarity 81%) and its [header](../src/include/planner/dynamic_filter/duckdb_join_filter_candidate_adapter.hpp).
+  A 63-line block was deleted in the move: `detail::clone_sirius_filter_pushdown_info` plus the
+  `structurally_aligned` / `preserve_aligned` plan-copy helpers. That deletion is what turns this
+  adapter from a runtime participant into the test-only parity oracle the PR description mentions.
+
+## Not covered in this pass (flagged, not guessed)
+
+- **`duckdb_join_filter_candidate_adapter`**
+  ([duckdb_join_filter_candidate_adapter.hpp](../src/include/planner/dynamic_filter/duckdb_join_filter_candidate_adapter.hpp),
+  [duckdb_join_filter_candidate_adapter.cpp](../src/planner/dynamic_filter/duckdb_join_filter_candidate_adapter.cpp),
+  new/relocated, version-pinned DuckDB metadata adapter) — per the PR description this now exists
+  "only as a test parity oracle." It's exercised by
+  [test_duckdb_join_filter_candidate_adapter.cpp](../test/cpp/planner/test_duckdb_join_filter_candidate_adapter.cpp)
+  and
+  [test_dynamic_filter_discovery_parity.cpp](../test/cpp/planner/test_dynamic_filter_discovery_parity.cpp)
+  but doesn't sit on the runtime path documented above. The Relocations section records *what* was
+  deleted from it during the move; what parity those tests actually assert, and why the adapter is
+  worth keeping alive as dead-weight-looking code, was not traced.
+- **Marginal keep-ratio suppression** and the **domain-coverage gate's actual pass/fail
+  arithmetic** (mentioned in the PR description, and the source of `keys_skipped_domain_gate` /
+  `keys_build_exceeded_domain` in `dynamic_filter_publication_outcome`) live inside
+  [dynamic_filter_publisher.cpp](../src/op/dynamic_filter/dynamic_filter_publisher.cpp) but weren't
+  traced through in this pass — Key Change 2 shows only the call site and the counters, not the
+  gate logic itself.
+- The **test files** (roughly half this PR's line count — `test_dynamic_filter_target_discovery.cpp`
+  at 713 lines, `test_dynamic_filter_discovery_parity.cpp` at 895, and a dozen more) were not read.
+  They're where the admission/discovery edge cases are actually pinned down, so a reader who wants
+  to know exactly which join shapes are covered should start there rather than from this digest.
+- Within the **Relocations** section, the two largest moved files
+  ([sirius_dynamic_filter.cpp](../src/op/dynamic_filter/sirius_dynamic_filter.cpp) and its header)
+  were classified by diffing comment-stripped content, which reliably surfaces the logic changes
+  listed but would not catch a subtle reordering of otherwise-identical statements.

--- a/.agents/skills/pr-digest/references/example_digest.md
+++ b/.agents/skills/pr-digest/references/example_digest.md
@@ -44,6 +44,48 @@ prune a probe input that is itself the output of another join, aggregate, or CTE
 travel *sideways* through the plan tree to reach a fact-table scan that sits several operators
 below the join that actually produced the filter.
 
+## Before and after
+
+**Illustrative example, traced from the planner paths linked below:** suppose a selective build
+side produces the key domain `{17, 42}`, but the other side of its join is an intermediate join or
+aggregate rather than a leaf scan. The query and key domain are identical in both columns.
+
+| | Before PR #1277 | After PR #1277 |
+|---|---|---|
+| **Probe shape** | `fact input → intermediate join/aggregate/CTE → publishing join` | The same plan shape. |
+| **Filter route** | The scan-only route cannot carry `{17, 42}` through the intermediate operator. | Sirius traces the key ordinal through safe operators and places a consumer at a reachable scan or direct endpoint. |
+| **Plan effect** | The downstream fact input remains unpruned by this build-side domain. | Eligible rows outside `{17, 42}` can be removed before they reach the publishing join. |
+| **Safety boundary** | No cross-operator route is attempted. | Traversal still stops at outer-join, row-duplication, type, null, and other unsupported boundaries. |
+
+## Flow at a glance
+
+```mermaid
+flowchart TB
+  subgraph Before["Before PR #1277"]
+    B1["Build side yields keys 17 and 42"] --> J1["Join publishes a dynamic filter"]
+    J1 -. "scan-only route stops" .-> I1["Intermediate join, aggregate, or CTE"]
+    I1 --> F1["Fact input remains unpruned"]
+  end
+
+  subgraph After["After PR #1277"]
+    B2["Build side yields keys 17 and 42"] --> J2["Join publishes a dynamic filter"]
+    J2 --> T2["Trace the probe key through safe operators"]
+    T2 --> E2["Attach at a scan or direct endpoint"]
+    E2 --> F2["Prune eligible fact-side rows earlier"]
+  end
+```
+
+**Code anchors:**
+
+- [`plan_comparison_join`](../src/planner/sirius_plan_comparison_join.cpp#L399) coordinates key
+  admission, tracing, and endpoint placement.
+- [`trace_probe_key`](../src/planner/sirius_plan_comparison_join.cpp#L506) attempts the scan route.
+- [`place_endpoint`](../src/planner/sirius_plan_comparison_join.cpp#L555) inserts a direct-route
+  consumer when no scan terminal was found.
+- [`probe_block_is_value_preserving`](../src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp#L34)
+  and [`build_block_is_value_preserving`](../src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp#L53)
+  define key traversal safety boundaries.
+
 ## Key changes at a glance
 
 1. **[SIP-capable planning pipeline in `plan_comparison_join`](#key-change-1--sip-capable-planning-pipeline-in-plan_comparison_join-ranked-1-this-is-the-feature)** — Three new planner

--- a/.agents/skills/pr-digest/references/plain_language.md
+++ b/.agents/skills/pr-digest/references/plain_language.md
@@ -11,26 +11,26 @@ explanation so readers can still search for it.
 
 | Avoid | Prefer |
 |---|---|
-| “decode-side row selection” | “choose which rows to keep while the compressed data is being decoded” |
-| “positional mask” | “a bitmap that marks which original row positions remain visible (the positional mask)” |
-| “materialize only rows satisfying both” | “create output rows only when both checks keep them” |
-| “confirmed decoder consumption” | “the decoder reports that it already applied the visibility bitmap” |
-| “compose visibility into the decode selection” | “apply row visibility together with the query filter during decoding” |
-| “writer-free covering snapshot” | “a read-only snapshot that includes every commit present when the bitmap was built” |
-| “cache probe/build/publish loop” | “look for saved visibility information, build it when missing, then save a safe result” |
-| “admit the zero-copy transfer” | “allow Sirius to reuse the decoded table directly instead of copying it” |
-| “key admission” | “decide which join keys can safely use the optimization” |
-| “fallback contract” | “the rules for using the older path when the optimization cannot run” |
+| "decode-side row selection" | "choose which rows to keep while the compressed data is being decoded" |
+| "positional mask" | "a bitmap that marks which original row positions remain visible (the positional mask)" |
+| "materialize only rows satisfying both" | "create output rows only when both checks keep them" |
+| "confirmed decoder consumption" | "the decoder reports that it already applied the visibility bitmap" |
+| "compose visibility into the decode selection" | "apply row visibility together with the query filter during decoding" |
+| "writer-free covering snapshot" | "a read-only snapshot that includes every commit present when the bitmap was built" |
+| "cache probe/build/publish loop" | "look for saved visibility information, build it when missing, then save a safe result" |
+| "admit the zero-copy transfer" | "allow Sirius to reuse the decoded table directly instead of copying it" |
+| "key admission" | "decide which join keys can safely use the optimization" |
+| "fallback contract" | "the rules for using the older path when the optimization cannot run" |
 
 These are patterns, not replacements to apply blindly. Use the meaning established by the PR's
 actual code.
 
 ## Introduce abbreviations and identifiers
 
-- On first use, write “multi-version concurrency control (MVCC), which determines which rows a
-  query is allowed to see.” Adjust the explanation to the PR's actual concern.
-- Introduce an identifier by purpose: “The function that checks whether saved visibility data can
-  be reused, `mvcc_mask_cache_reusable`, ...”
+- On first use, write "multi-version concurrency control (MVCC), which determines which rows a
+  query is allowed to see." Adjust the explanation to the PR's actual concern.
+- Introduce an identifier by purpose: "The function that checks whether saved visibility data can
+  be reused, `mvcc_mask_cache_reusable`, ..."
 - Keep identifiers out of the opening summary and diagram unless the identifier itself is the
   user-facing concept.
 - Do not repeat both the plain phrase and technical term in every sentence. Define the term once,
@@ -46,7 +46,7 @@ Prefer a short chain the reader can follow:
 4. What work, behavior, or safety property changes as a result?
 5. What happens when the new path cannot run?
 
-Avoid sentences that only rename code. “The request gains `keep_mask_words`” is incomplete. Add
+Avoid sentences that only rename code. "The request gains `keep_mask_words`" is incomplete. Add
 the consequence: those words let the decoder exclude invisible rows at the same time as it applies
 the query filter.
 
@@ -58,9 +58,9 @@ detailed section without looking at the code. Revise them if any of these are tr
 - a term names an implementation technique but does not say what it does;
 - an acronym appears before its meaning;
 - a heading is mostly class names, field names, or stacked nouns;
-- verbs such as “compose,” “materialize,” “consume,” “admit,” or “dispatch” could be replaced by a
+- verbs such as "compose," "materialize," "consume," "admit," or "dispatch" could be replaced by a
   clearer action;
-- “fast path” or “fallback” appears without explaining the optimized or older behavior;
+- "fast path" or "fallback" appears without explaining the optimized or older behavior;
 - the reader must infer why the change matters from the diff.
 
 Keep technical terms inside quoted PR text and code diffs unchanged. Explain them immediately

--- a/.agents/skills/pr-digest/references/plain_language.md
+++ b/.agents/skills/pr-digest/references/plain_language.md
@@ -1,0 +1,67 @@
+# Plain-language guide for PR digests
+
+Use this guide before writing or revising a digest. The reader is an engineer who may not know the
+PR's subsystem. Accuracy still comes first, but unfamiliar vocabulary must not carry the
+explanation by itself.
+
+## Translate the mechanism without hiding it
+
+Start with what the code does in familiar words. Put an important source-code term after the
+explanation so readers can still search for it.
+
+| Avoid | Prefer |
+|---|---|
+| “decode-side row selection” | “choose which rows to keep while the compressed data is being decoded” |
+| “positional mask” | “a bitmap that marks which original row positions remain visible (the positional mask)” |
+| “materialize only rows satisfying both” | “create output rows only when both checks keep them” |
+| “confirmed decoder consumption” | “the decoder reports that it already applied the visibility bitmap” |
+| “compose visibility into the decode selection” | “apply row visibility together with the query filter during decoding” |
+| “writer-free covering snapshot” | “a read-only snapshot that includes every commit present when the bitmap was built” |
+| “cache probe/build/publish loop” | “look for saved visibility information, build it when missing, then save a safe result” |
+| “admit the zero-copy transfer” | “allow Sirius to reuse the decoded table directly instead of copying it” |
+| “key admission” | “decide which join keys can safely use the optimization” |
+| “fallback contract” | “the rules for using the older path when the optimization cannot run” |
+
+These are patterns, not replacements to apply blindly. Use the meaning established by the PR's
+actual code.
+
+## Introduce abbreviations and identifiers
+
+- On first use, write “multi-version concurrency control (MVCC), which determines which rows a
+  query is allowed to see.” Adjust the explanation to the PR's actual concern.
+- Introduce an identifier by purpose: “The function that checks whether saved visibility data can
+  be reused, `mvcc_mask_cache_reusable`, ...”
+- Keep identifiers out of the opening summary and diagram unless the identifier itself is the
+  user-facing concept.
+- Do not repeat both the plain phrase and technical term in every sentence. Define the term once,
+  then use whichever version makes the next sentence easiest to understand.
+
+## Make cause and consequence explicit
+
+Prefer a short chain the reader can follow:
+
+1. What condition starts this path?
+2. What does the old code do?
+3. What does the new code do instead?
+4. What work, behavior, or safety property changes as a result?
+5. What happens when the new path cannot run?
+
+Avoid sentences that only rename code. “The request gains `keep_mask_words`” is incomplete. Add
+the consequence: those words let the decoder exclude invisible rows at the same time as it applies
+the query filter.
+
+## Final jargon check
+
+Read the title, summary, before/after table, diagram, key-change titles, and first paragraph of each
+detailed section without looking at the code. Revise them if any of these are true:
+
+- a term names an implementation technique but does not say what it does;
+- an acronym appears before its meaning;
+- a heading is mostly class names, field names, or stacked nouns;
+- verbs such as “compose,” “materialize,” “consume,” “admit,” or “dispatch” could be replaced by a
+  clearer action;
+- “fast path” or “fallback” appears without explaining the optimized or older behavior;
+- the reader must infer why the change matters from the diff.
+
+Keep technical terms inside quoted PR text and code diffs unchanged. Explain them immediately
+before or after the quote when they are necessary to understand it.

--- a/.agents/skills/pr-digest/scripts/render_digest_html.py
+++ b/.agents/skills/pr-digest/scripts/render_digest_html.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+"""Render a PR digest Markdown file as a self-contained HTML preview.
+
+The renderer intentionally supports the Markdown subset emitted by the pr-digest skill. It has
+no third-party dependencies, colors diff additions/removals, and turns simple Mermaid flowcharts
+into inline SVG so the preview works offline in Codex.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+FENCE_RE = re.compile(r"^```([A-Za-z0-9_-]*)\s*$")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+LIST_RE = re.compile(r"^(\s*)([-+*]|\d+\.)\s+(.+)$")
+TABLE_RULE_RE = re.compile(r"^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$")
+LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+CODE_RE = re.compile(r"`([^`]+)`")
+NODE_RE = re.compile(
+    r'^([A-Za-z_][\w-]*)(?:\["([^"]*)"\]|\[([^\]]*)\]|\{"([^"]*)"\}|\{([^}]*)\}|\("([^"]*)"\)|\(([^)]*)\))?$'
+)
+EDGE_RE = re.compile(r"^(.*?)\s*(-->|==>)\s*(?:\|\"?([^|\"]+)\"?\|\s*)?(.*?)$")
+SUBGRAPH_RE = re.compile(
+    r'^subgraph\s+([A-Za-z_][\w-]*)(?:\["([^"]*)"\]|\[([^\]]*)\])?\s*$'
+)
+SCHEME_RE = re.compile(r"^([A-Za-z][A-Za-z0-9+.-]*):")
+
+
+def safe_href(value: str) -> str:
+    """Escape a link target and reject schemes that can execute in a local preview."""
+    target = value.strip()
+    scheme = SCHEME_RE.match(target)
+    if scheme and scheme.group(1).lower() not in {"http", "https", "mailto"}:
+        target = "#"
+    return html.escape(target, quote=True)
+
+
+def render_inline(value: str) -> str:
+    placeholders: list[str] = []
+
+    def hold(rendered: str) -> str:
+        token = f"\x00{len(placeholders)}\x00"
+        placeholders.append(rendered)
+        return token
+
+    def link(match: re.Match[str]) -> str:
+        label = render_inline(match.group(1))
+        href = safe_href(match.group(2))
+        return hold(f'<a href="{href}">{label}</a>')
+
+    value = LINK_RE.sub(link, value)
+    value = CODE_RE.sub(
+        lambda match: hold(f"<code>{html.escape(match.group(1))}</code>"), value
+    )
+    value = html.escape(value, quote=False)
+    value = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", value)
+    value = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"<em>\1</em>", value)
+    value = re.sub(r"~~(.+?)~~", r"<del>\1</del>", value)
+    for index, rendered in enumerate(placeholders):
+        value = value.replace(f"\x00{index}\x00", rendered)
+    return value
+
+
+def slugify(value: str, counts: dict[str, int]) -> str:
+    plain = html.unescape(re.sub(r"<[^>]+>", "", value)).lower()
+    base = re.sub(r"[^\w\s-]", "", plain, flags=re.UNICODE).strip()
+    # GitHub's heading IDs preserve the two spaces around an em dash as two hyphens after the
+    # punctuation is removed. Match that behavior so authored table-of-contents links still work.
+    base = re.sub(r"\s", "-", base) or "section"
+    seen = counts.get(base, 0)
+    counts[base] = seen + 1
+    return base if seen == 0 else f"{base}-{seen}"
+
+
+def split_table_row(line: str) -> list[str]:
+    stripped = line.strip().strip("|")
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+@dataclass
+class FlowNode:
+    identifier: str
+    label: str
+    shape: str = "rect"
+    group: str | None = None
+
+
+@dataclass
+class FlowEdge:
+    source: str
+    target: str
+    label: str = ""
+
+
+@dataclass
+class FlowGraph:
+    direction: str = "TD"
+    nodes: dict[str, FlowNode] = field(default_factory=dict)
+    order: list[str] = field(default_factory=list)
+    edges: list[FlowEdge] = field(default_factory=list)
+    groups: dict[str, str] = field(default_factory=dict)
+
+    def add_node(self, token: str, group: str | None) -> str | None:
+        token = token.strip().rstrip(";")
+        match = NODE_RE.match(token)
+        if not match:
+            return None
+        identifier = match.group(1)
+        candidates = match.groups()[1:]
+        label = next(
+            (candidate for candidate in candidates if candidate is not None), identifier
+        )
+        shape = (
+            "decision" if token[len(identifier) :].lstrip().startswith("{") else "rect"
+        )
+        if identifier not in self.nodes:
+            self.nodes[identifier] = FlowNode(identifier, label, shape, group)
+            self.order.append(identifier)
+        else:
+            node = self.nodes[identifier]
+            if label != identifier:
+                node.label = label
+                node.shape = shape
+            if node.group is None:
+                node.group = group
+        return identifier
+
+
+def parse_flowchart(source: str) -> FlowGraph | None:
+    lines = [line.strip() for line in source.splitlines() if line.strip()]
+    if not lines or not lines[0].startswith("flowchart "):
+        return None
+    graph = FlowGraph(direction=lines[0].split(maxsplit=1)[1].upper())
+    current_group: str | None = None
+    for raw in lines[1:]:
+        if raw.startswith("%%") or raw.startswith(
+            ("classDef ", "class ", "style ", "linkStyle ")
+        ):
+            continue
+        group_match = SUBGRAPH_RE.match(raw)
+        if group_match:
+            current_group = group_match.group(1)
+            graph.groups[current_group] = (
+                group_match.group(2) or group_match.group(3) or current_group
+            )
+            continue
+        if raw == "end":
+            current_group = None
+            continue
+
+        normalized = re.sub(
+            r'-\.\s*"([^"]+)"\s*\.->',
+            lambda match: f'-->|"{match.group(1)}"|',
+            raw,
+        )
+        edge_match = EDGE_RE.match(normalized)
+        if edge_match:
+            source_id = graph.add_node(edge_match.group(1), current_group)
+            target_id = graph.add_node(edge_match.group(4), current_group)
+            if source_id and target_id:
+                graph.edges.append(
+                    FlowEdge(source_id, target_id, (edge_match.group(3) or "").strip())
+                )
+            continue
+        graph.add_node(raw, current_group)
+    return graph if graph.nodes else None
+
+
+def wrap_svg_text(value: str, width: int = 28) -> list[str]:
+    words = value.split()
+    if not words:
+        return [""]
+    lines: list[str] = []
+    current = words[0]
+    for word in words[1:]:
+        if len(current) + len(word) + 1 <= width:
+            current += " " + word
+        else:
+            lines.append(current)
+            current = word
+    lines.append(current)
+    return lines[:3]
+
+
+def render_flowchart(source: str) -> str:
+    graph = parse_flowchart(source)
+    escaped_source = html.escape(source)
+    if graph is None:
+        return (
+            '<figure class="flow-figure"><p class="diagram-warning">'
+            "Diagram preview unavailable for this Mermaid syntax; source retained below.</p>"
+            f"<pre><code>{escaped_source}</code></pre></figure>"
+        )
+
+    indegree = {identifier: 0 for identifier in graph.nodes}
+    outgoing: dict[str, list[str]] = {identifier: [] for identifier in graph.nodes}
+    for edge in graph.edges:
+        outgoing[edge.source].append(edge.target)
+        indegree[edge.target] += 1
+
+    levels = {identifier: 0 for identifier in graph.nodes}
+    queue = [identifier for identifier in graph.order if indegree[identifier] == 0]
+    visited: list[str] = []
+    while queue:
+        identifier = queue.pop(0)
+        visited.append(identifier)
+        for target in outgoing[identifier]:
+            levels[target] = max(levels[target], levels[identifier] + 1)
+            indegree[target] -= 1
+            if indegree[target] == 0:
+                queue.append(target)
+    for identifier in graph.order:
+        if identifier not in visited:
+            levels[identifier] = max(levels.values(), default=0) + 1
+
+    layers: dict[int, list[str]] = {}
+    for identifier in graph.order:
+        layers.setdefault(levels[identifier], []).append(identifier)
+    max_level = max(layers, default=0)
+    max_layer_size = max((len(items) for items in layers.values()), default=1)
+    horizontal = graph.direction in {"LR", "RL"}
+
+    if horizontal:
+        width = max(720, 300 * (max_level + 1))
+        height = max(360, 125 * max_layer_size + 100)
+    else:
+        width = max(760, 280 * max_layer_size + 100)
+        height = max(420, 135 * (max_level + 1) + 100)
+
+    positions: dict[str, tuple[float, float]] = {}
+    for level, identifiers in layers.items():
+        if horizontal:
+            x = 150 + level * 280
+            for index, identifier in enumerate(identifiers):
+                y = (index + 1) * height / (len(identifiers) + 1)
+                positions[identifier] = (x, y)
+        else:
+            y = 80 + level * 130
+            for index, identifier in enumerate(identifiers):
+                x = (index + 1) * width / (len(identifiers) + 1)
+                positions[identifier] = (x, y)
+
+    token = hashlib.sha1(source.encode("utf8"), usedforsecurity=False).hexdigest()[:10]
+    pieces = [
+        f'<figure class="flow-figure"><svg class="flow-svg" viewBox="0 0 {width} {height}" role="img" aria-labelledby="title-{token} desc-{token}">',
+        f'<title id="title-{token}">PR change flowchart</title>',
+        f'<desc id="desc-{token}">Flowchart generated from the digest Mermaid source.</desc>',
+        f'<defs><marker id="arrow-{token}" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head" /></marker></defs>',
+    ]
+
+    for group_id, title in graph.groups.items():
+        members = [
+            positions[node.identifier]
+            for node in graph.nodes.values()
+            if node.group == group_id
+        ]
+        if not members:
+            continue
+        min_x = min(point[0] for point in members) - 140
+        max_x = max(point[0] for point in members) + 140
+        min_y = min(point[1] for point in members) - 65
+        max_y = max(point[1] for point in members) + 65
+        pieces.append(
+            f'<rect class="flow-group" x="{min_x:.1f}" y="{min_y:.1f}" width="{max_x - min_x:.1f}" height="{max_y - min_y:.1f}" rx="16" />'
+        )
+        pieces.append(
+            f'<text class="flow-group-label" x="{min_x + 14:.1f}" y="{min_y + 24:.1f}">{html.escape(title)}</text>'
+        )
+
+    for edge in graph.edges:
+        source_x, source_y = positions[edge.source]
+        target_x, target_y = positions[edge.target]
+        if horizontal:
+            start_x, start_y = source_x + 120, source_y
+            end_x, end_y = target_x - 120, target_y
+        else:
+            start_x, start_y = source_x, source_y + 38
+            end_x, end_y = target_x, target_y - 38
+        pieces.append(
+            f'<path class="flow-edge" marker-end="url(#arrow-{token})" d="M {start_x:.1f} {start_y:.1f} L {end_x:.1f} {end_y:.1f}" />'
+        )
+        if edge.label:
+            label_x = (start_x + end_x) / 2
+            label_y = (start_y + end_y) / 2 - 7
+            pieces.append(
+                f'<text class="flow-edge-label" x="{label_x:.1f}" y="{label_y:.1f}">{html.escape(edge.label)}</text>'
+            )
+
+    for identifier in graph.order:
+        node = graph.nodes[identifier]
+        x, y = positions[identifier]
+        if node.shape == "decision":
+            points = f"{x:.1f},{y - 42:.1f} {x + 130:.1f},{y:.1f} {x:.1f},{y + 42:.1f} {x - 130:.1f},{y:.1f}"
+            pieces.append(
+                f'<polygon class="flow-node flow-decision" points="{points}" />'
+            )
+        else:
+            pieces.append(
+                f'<rect class="flow-node" x="{x - 120:.1f}" y="{y - 34:.1f}" width="240" height="68" rx="12" />'
+            )
+        text_lines = wrap_svg_text(node.label)
+        start_y = y - (len(text_lines) - 1) * 10
+        pieces.append(f'<text class="flow-text" x="{x:.1f}" y="{start_y:.1f}">')
+        for index, line in enumerate(text_lines):
+            dy = "0" if index == 0 else "20"
+            pieces.append(f'<tspan x="{x:.1f}" dy="{dy}">{html.escape(line)}</tspan>')
+        pieces.append("</text>")
+
+    pieces.extend(
+        [
+            "</svg>",
+            '<details class="diagram-source"><summary>Mermaid source</summary>',
+            f"<pre><code>{escaped_source}</code></pre></details></figure>",
+        ]
+    )
+    return "".join(pieces)
+
+
+class DigestRenderer:
+    def __init__(self) -> None:
+        self.heading_counts: dict[str, int] = {}
+        self.diff_blocks = 0
+        self.additions = 0
+        self.removals = 0
+        self.flowcharts = 0
+
+    def render_code(self, language: str, code: str) -> str:
+        if language == "diff":
+            self.diff_blocks += 1
+            rendered: list[str] = []
+            for line in code.splitlines():
+                kind = "context"
+                if line.startswith("+") and not line.startswith("+++"):
+                    kind = "add"
+                    self.additions += 1
+                elif line.startswith("-") and not line.startswith("---"):
+                    kind = "remove"
+                    self.removals += 1
+                rendered.append(
+                    f'<span class="diff-line diff-{kind}">{html.escape(line) or " "}</span>'
+                )
+            return (
+                '<div class="diff-block" role="region" aria-label="Code diff">'
+                f'<pre><code>{"".join(rendered)}</code></pre></div>'
+            )
+        if language == "mermaid":
+            self.flowcharts += 1
+            return render_flowchart(code)
+        language_class = (
+            f' class="language-{html.escape(language, quote=True)}"' if language else ""
+        )
+        return f"<pre><code{language_class}>{html.escape(code)}</code></pre>"
+
+    def render(self, markdown: str) -> str:
+        lines = markdown.splitlines()
+        output: list[str] = []
+        paragraph: list[str] = []
+        index = 0
+
+        def flush_paragraph() -> None:
+            if paragraph:
+                output.append(
+                    f'<p>{render_inline(" ".join(part.strip() for part in paragraph))}</p>'
+                )
+                paragraph.clear()
+
+        while index < len(lines):
+            line = lines[index]
+            fence_match = FENCE_RE.match(line)
+            if fence_match:
+                flush_paragraph()
+                language = fence_match.group(1).lower()
+                index += 1
+                code_lines: list[str] = []
+                while index < len(lines) and lines[index] != "```":
+                    code_lines.append(lines[index])
+                    index += 1
+                output.append(self.render_code(language, "\n".join(code_lines)))
+                index += 1
+                continue
+
+            heading_match = HEADING_RE.match(line)
+            if heading_match:
+                flush_paragraph()
+                level = len(heading_match.group(1))
+                rendered = render_inline(heading_match.group(2))
+                slug = slugify(rendered, self.heading_counts)
+                output.append(f'<h{level} id="{slug}">{rendered}</h{level}>')
+                index += 1
+                continue
+
+            if re.match(r"^\s*(?:---+|___+|\*\*\*+)\s*$", line):
+                flush_paragraph()
+                output.append("<hr />")
+                index += 1
+                continue
+
+            if line.startswith(">"):
+                flush_paragraph()
+                quote_lines: list[str] = []
+                while index < len(lines) and lines[index].startswith(">"):
+                    quote_lines.append(lines[index][1:].lstrip())
+                    index += 1
+                quote_paragraphs: list[str] = []
+                current: list[str] = []
+                for quote_line in quote_lines + [""]:
+                    if quote_line:
+                        current.append(quote_line)
+                    elif current:
+                        quote_paragraphs.append(
+                            f'<p>{render_inline(" ".join(current))}</p>'
+                        )
+                        current = []
+                output.append(f'<blockquote>{"".join(quote_paragraphs)}</blockquote>')
+                continue
+
+            if (
+                index + 1 < len(lines)
+                and "|" in line
+                and TABLE_RULE_RE.match(lines[index + 1])
+            ):
+                flush_paragraph()
+                headers = split_table_row(line)
+                index += 2
+                rows: list[list[str]] = []
+                while (
+                    index < len(lines) and "|" in lines[index] and lines[index].strip()
+                ):
+                    rows.append(split_table_row(lines[index]))
+                    index += 1
+                head = "".join(f"<th>{render_inline(cell)}</th>" for cell in headers)
+                body = "".join(
+                    "<tr>"
+                    + "".join(f"<td>{render_inline(cell)}</td>" for cell in row)
+                    + "</tr>"
+                    for row in rows
+                )
+                output.append(
+                    f'<div class="table-wrap"><table><thead><tr>{head}</tr></thead><tbody>{body}</tbody></table></div>'
+                )
+                continue
+
+            list_match = LIST_RE.match(line)
+            if list_match:
+                flush_paragraph()
+                items: list[tuple[int, str, str]] = []
+                while index < len(lines):
+                    current_match = LIST_RE.match(lines[index])
+                    if not current_match:
+                        if (
+                            items
+                            and lines[index].startswith(" ")
+                            and lines[index].strip()
+                        ):
+                            depth, marker, value = items[-1]
+                            items[-1] = (
+                                depth,
+                                marker,
+                                value + " " + lines[index].strip(),
+                            )
+                            index += 1
+                            continue
+                        break
+                    indent, marker, value = current_match.groups()
+                    depth = max(0, len(indent.expandtabs(2)) // 2)
+                    items.append((depth, marker, value))
+                    index += 1
+                rendered_items = []
+                for depth, marker, value in items:
+                    rendered_items.append(
+                        f'<div class="list-item" style="--depth:{depth}"><span class="list-marker">{html.escape(marker)}</span><span>{render_inline(value)}</span></div>'
+                    )
+                output.append(
+                    f'<div class="list-block">{"".join(rendered_items)}</div>'
+                )
+                continue
+
+            if not line.strip():
+                flush_paragraph()
+                index += 1
+                continue
+
+            paragraph.append(line)
+            index += 1
+
+        flush_paragraph()
+        return "\n".join(output)
+
+
+STYLE = r"""
+:root {
+  --page: #f6f8fa; --surface: #fff; --surface-muted: #f6f8fa; --text: #1f2328;
+  --muted: #59636e; --border: #d0d7de; --link: #0969da; --accent: #8250df;
+  --add-bg: #dafbe1; --add-text: #116329; --add-border: #aceebb;
+  --remove-bg: #ffebe9; --remove-text: #82071e; --remove-border: #ffcecb;
+  --shadow: 0 8px 28px rgba(31,35,40,.08);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page:#0d1117; --surface:#161b22; --surface-muted:#0d1117; --text:#e6edf3;
+    --muted:#9da7b1; --border:#30363d; --link:#58a6ff; --accent:#a371f7;
+    --add-bg:#12261e; --add-text:#7ee787; --add-border:#2ea043;
+    --remove-bg:#321c22; --remove-text:#ff7b72; --remove-border:#f85149;
+    --shadow:0 10px 36px rgba(0,0,0,.35);
+  }
+}
+* { box-sizing:border-box; }
+html { scroll-behavior:smooth; }
+body { margin:0; background:var(--page); color:var(--text); font:16px/1.62 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+.toolbar { position:sticky; top:0; z-index:5; display:flex; justify-content:space-between; gap:1rem; align-items:center; padding:.7rem max(1rem,calc((100vw - 1120px)/2)); border-bottom:1px solid var(--border); background:var(--surface); }
+.toolbar strong { font-size:.92rem; }
+.toolbar nav { display:flex; gap:.9rem; font-size:.9rem; }
+main { width:min(1120px,calc(100% - 2rem)); margin:1.5rem auto 4rem; padding:clamp(1.25rem,3.2vw,3rem); background:var(--surface); border:1px solid var(--border); border-radius:16px; box-shadow:var(--shadow); }
+h1,h2,h3 { line-height:1.25; scroll-margin-top:5rem; }
+h1 { margin-top:0; font-size:clamp(1.85rem,4vw,2.7rem); }
+h2 { margin-top:2.4rem; padding-bottom:.35rem; border-bottom:1px solid var(--border); }
+h3 { margin-top:2rem; }
+a { color:var(--link); text-decoration-thickness:1px; text-underline-offset:.16em; }
+blockquote { margin:1.25rem 0; padding:.3rem 1rem; color:var(--muted); border-left:4px solid var(--accent); background:var(--surface-muted); }
+.table-wrap { overflow-x:auto; }
+table { width:100%; border-collapse:collapse; }
+th,td { padding:.65rem .8rem; border:1px solid var(--border); vertical-align:top; }
+th { background:var(--surface-muted); text-align:left; }
+code { font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; font-size:.9em; }
+:not(pre)>code { padding:.12em .35em; border-radius:5px; background:var(--surface-muted); }
+pre { margin:0; overflow-x:auto; }
+hr { margin:3rem 0; border:0; border-top:1px solid var(--border); }
+.list-block { margin:.85rem 0; }
+.list-item { display:grid; grid-template-columns:2.2rem minmax(0,1fr); margin:.28rem 0; margin-left:calc(var(--depth)*1.55rem); }
+.list-marker { color:var(--muted); text-align:right; padding-right:.65rem; }
+.diff-block { margin:1rem 0 1.6rem; overflow:hidden; border:1px solid var(--border); border-radius:10px; background:var(--surface-muted); }
+.diff-block code { display:block; min-width:max-content; padding:.55rem 0; }
+.diff-line { display:block; min-height:1.45em; padding:0 1rem; white-space:pre; }
+.diff-add { color:var(--add-text); background:var(--add-bg); border-left:3px solid var(--add-border); }
+.diff-remove { color:var(--remove-text); background:var(--remove-bg); border-left:3px solid var(--remove-border); }
+.diff-context { color:var(--muted); border-left:3px solid transparent; }
+.flow-figure { margin:1rem 0 1.75rem; padding:1rem; overflow-x:auto; border:1px solid var(--border); border-radius:12px; background:var(--surface-muted); }
+.flow-svg { display:block; width:100%; height:auto; min-width:680px; }
+.flow-group { fill:color-mix(in srgb,var(--surface) 76%,transparent); stroke:var(--border); stroke-width:1.5; stroke-dasharray:5 4; }
+.flow-group-label { fill:var(--muted); font:600 14px -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; text-anchor:start; }
+.flow-node { fill:var(--surface); stroke:var(--border); stroke-width:2; }
+.flow-decision { fill:var(--surface); stroke:var(--accent); }
+.flow-edge { fill:none; stroke:var(--muted); stroke-width:2.2; }
+.arrow-head { fill:var(--muted); }
+.flow-text,.flow-edge-label { fill:var(--text); font:600 15px -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; text-anchor:middle; }
+.flow-edge-label { fill:var(--muted); font-size:13px; }
+.diagram-source { margin-top:.9rem; color:var(--muted); }
+.diagram-source pre,.diagram-warning+pre { margin-top:.6rem; padding:.8rem; border-radius:8px; background:var(--surface); }
+.diagram-warning { color:var(--muted); }
+.preview-footer { width:min(1120px,calc(100% - 2rem)); margin:-2.5rem auto 2rem; color:var(--muted); font-size:.85rem; text-align:center; }
+@media (max-width:680px) {
+  .toolbar { align-items:flex-start; flex-direction:column; }
+  main { width:min(100% - 1rem,1120px); margin-top:.5rem; padding:1rem; border-radius:10px; }
+  .flow-figure { padding:.4rem; }
+}
+@media print {
+  .toolbar { display:none; }
+  body { background:#fff; }
+  main { width:100%; margin:0; padding:0; border:0; box-shadow:none; }
+  .preview-footer { margin-top:1rem; }
+}
+"""
+
+
+def build_document(markdown_path: Path, content: str, title: str) -> str:
+    source_name = html.escape(markdown_path.name, quote=True)
+    key_changes = re.search(r'id="(key-changes-at-a-glance[^"]*)"', content)
+    coverage_notes = re.search(r'id="(not-covered-in-this-pass[^"]*)"', content)
+    key_changes_href = f"#{key_changes.group(1)}" if key_changes else "#"
+    coverage_notes_href = f"#{coverage_notes.group(1)}" if coverage_notes else "#"
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="light dark" />
+  <title>{html.escape(title)} — HTML Preview</title>
+  <style>{STYLE}</style>
+</head>
+<body>
+  <header class="toolbar">
+    <strong>Rendered PR digest</strong>
+    <nav>
+      <a href="{source_name}">Markdown source</a>
+      <a href="{key_changes_href}">Key changes</a>
+      <a href="{coverage_notes_href}">Coverage notes</a>
+    </nav>
+  </header>
+  <main>{content}</main>
+  <footer class="preview-footer">Generated from <code>{source_name}</code>. Regenerate after editing the Markdown source.</footer>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("markdown", type=Path, help="source PR digest Markdown path")
+    parser.add_argument("html", type=Path, help="destination HTML preview path")
+    args = parser.parse_args()
+
+    markdown = args.markdown.read_text(encoding="utf8")
+    renderer = DigestRenderer()
+    content = renderer.render(markdown)
+    title_match = re.search(r"^#\s+(.+)$", markdown, flags=re.MULTILINE)
+    title = title_match.group(1) if title_match else args.markdown.stem
+    document = build_document(args.markdown, content, title)
+    args.html.parent.mkdir(parents=True, exist_ok=True)
+    args.html.write_text(document, encoding="utf8")
+    print(
+        f"Rendered {args.html}: {renderer.diff_blocks} diff blocks, "
+        f"{renderer.additions} additions, {renderer.removals} removals, "
+        f"{renderer.flowcharts} flowcharts"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/pr-digest/SKILL.md
+++ b/.claude/skills/pr-digest/SKILL.md
@@ -1,28 +1,58 @@
 ---
 name: pr-digest
-description: Generates a "learning" PR-review digest — a markdown file at PR_digests/PR_digest_<N>.md that explains what a GitHub PR does, why, and exactly where in the code, with clickable file/line links and trimmed diffs. Use this whenever the user shares a GitHub PR URL (e.g. github.com/owner/repo/pull/1234) and wants to understand, summarize, review, walk through, or get up to speed on what changed — phrases like "can you review this PR", "what does this PR do", "help me understand this pull request", "summarize the changes in PR #1234", or simply pasting a PR link and asking about it. This explains what changed, why, and where — it deliberately does not hunt for bugs or critique the code, which is a separate concern handled by other review skills; still reach for this skill first even when the user's ultimate goal is a fuller review, since it builds the map that a deeper review needs anyway.
+description: Explain a GitHub pull request in straightforward language as a navigable Markdown digest plus an HTML preview. Start with the behavior before and after the change, define unavoidable technical terms, then connect the explanation to exact code lines and trimmed color-coded diffs. Use when a user wants to understand, summarize, review, walk through, or get up to speed on a GitHub PR. This maps the change without critiquing it; use a separate code-review pass when findings or an approval recommendation are requested.
 ---
 
 # PR Digest
 
-Turns a GitHub PR link into a digest document a reviewer can actually learn from: ranked key
-changes, each with what/why/where-invoked/diff, all cross-referenced with clickable links into
-the actual checked-out source.
+Turns a GitHub PR link into two companion files a reviewer can learn from: editable Markdown and
+an HTML preview that renders reliably in a browser. A before/after example and flowchart explain the
+behavior first. Detailed sections then show what changed, why it matters, where it happens, and
+the relevant code.
 
 Comprehension is the whole job here. This skill does not judge the PR — no bug-hunting, no "is
 this a race condition" adversarial pass, no verdict on whether the change is good. That's a
 different kind of work with a different failure mode (a digest that editorializes tends to bury
 the explanation the reader actually came for), and other review skills cover it. If the user
 seems to expect a full critique from this alone, say plainly that this produces the map, not the
-verdict, and point them at a code-review skill for the rest.
+verdict, and offer a separate code-review pass for the rest.
+
+## Write for a reader who is new to this part of the codebase
+
+Assume the reader understands software engineering but does not know this subsystem's vocabulary.
+The digest should save them from stopping to ask what a phrase means. Use descriptive,
+straightforward language even when it takes a few more words.
+
+- Lead with the familiar concept or action, then give the code's technical name in parentheses if
+  the name helps the reader find it. For example: "a bitmap that marks which original row
+  positions remain visible (the positional mask)."
+- Expand acronyms on first use and explain what they mean in this PR. Do not assume terms such as
+  MVCC, pushdown, materialization, dispatch, snapshot coverage, or zero-copy are self-explanatory.
+- Prefer sentences with an actor, action, and consequence: "The decoder applies both filters, so
+  it creates only the rows that survive" is better than "decode-side compaction is recovered."
+- Avoid compressed noun phrases in headings and summaries. Name the observable behavior, such as
+  "Reuse row-visibility information when the table has not changed."
+- Keep exact class, function, field, and file names in code font and links. Explain their purpose
+  in ordinary language before relying on the identifier.
+- Use a technical term again only after defining it. If a plain phrase remains clear, keep using
+  the plain phrase instead.
+- Prefer "uses the older path" over "falls back," "reports that it applied the mask" over
+  "consumes the mask," and "creates the output rows" over "materializes," unless the technical
+  word itself is the subject being explained.
+- Do not remove necessary technical detail. Translate it, then connect the translation to the
+  exact code name or source line.
+
+Before drafting any digest, read `references/plain_language.md` for PR-specific rewrite patterns
+and the final jargon check. Apply that guide throughout the Markdown; the HTML is generated from
+the same prose.
 
 ## Input
 
 One required argument: a GitHub PR URL, e.g. `https://github.com/sirius-db/sirius/pull/1277`.
 Parse `owner`, `repo`, and PR number out of it.
 
-One optional flag: `--sandbox-bypass`. If the user passes it, skip straight to using the sandbox
-bypass for every `gh` call (see Step 1) instead of probing first.
+One optional flag: `--sandbox-bypass`. If the user passes it, disable the sandbox for every `gh`
+call from the start rather than probing inside the sandbox first.
 
 ## Step 1 — Confirm `gh` access before doing anything else
 
@@ -32,21 +62,21 @@ discovering it's broken three steps in.
 Run `gh pr view <number> --repo <owner>/<repo> --json state`.
 
 - **Works** → continue to Step 2.
-- **Fails with an auth error** (e.g. `HTTP 401`) → this commonly means `gh` is authenticated
-  through the user's OS keyring, which a sandboxed tool call can't reach even though the user's
-  own shell can. Retry the exact same command with the sandbox disabled for that one call (in
-  Claude Code, rerun the Bash tool call with `dangerouslyDisableSandbox: true`).
-  - Bypass fixes it → tell the user plainly: their `gh` auth needs the sandbox bypassed for every
-    `gh` call this skill makes, and they can pass `--sandbox-bypass` next time to skip this
-    detection step. Use the bypass for every `gh` call for the rest of this run.
-  - Still fails → stop here. Tell the user to run `gh auth login` (or `gh auth status` to
-    diagnose) — this skill cannot proceed without read access to the PR's description, linked
-    issues/PRs, commits, and file list.
-- **User passed `--sandbox-bypass`** → skip the probe, use the bypass for every `gh` call from the
-  start.
+- **Fails because network, sandbox, or OS-keyring access appears restricted** → rerun the exact
+  command with Claude Code's Bash sandbox disabled (`dangerouslyDisableSandbox: true`).
+  - Disabling the sandbox fixes it → tell the user plainly that this environment needs the
+    sandbox disabled for `gh`, and use the same mode for every `gh` call for the rest of this run.
+    They can pass `--sandbox-bypass` next time to skip the failed probe.
+  - It still fails with an authentication error (for example, `HTTP 401`) → stop here. Tell the
+    user to run `gh auth login` or `gh auth status` to diagnose it. This skill cannot proceed
+    without read access to the PR's description, linked issues/PRs, commits, and file list.
+  - It still fails for a different reason → stop and report the exact failure without calling it
+    an authentication problem.
+- **User passed `--sandbox-bypass`** → start with the Bash sandbox disabled and use that mode for
+  every `gh` call.
 
-Don't default to "always bypass" for everyone — different environments authenticate differently,
-and probing first is what keeps this skill portable across them.
+Do not disable the sandbox by default. Different environments authenticate and route network
+access differently, and probing first keeps the skill portable.
 
 ## Step 2 — Resolve the PR
 
@@ -119,12 +149,54 @@ important than a small new file that IS the actual feature.
 - Aim for roughly 1–6 key changes, but let the actual number follow the PR: how many genuinely
   distinct *concepts* does it change? A 100-file PR implementing one idea can be 1–2 key changes;
   a 10-file PR bundling five unrelated fixes needs five.
-- Pure file-relocation diffs (moved with no logic change) don't deserve a key-change slot — they
-  get their own dedicated section instead (Step 8).
+- Files that only moved without changing behavior don't deserve a key-change slot — they
+  get their own dedicated section instead (Step 9).
 
-## Step 6 — Write the key-change overview list
+## Step 6 — Orient the reader with a before/after example and a diagram
 
-Immediately after the plain-language summary, before any detailed section, list the key changes
+Immediately after the plain-language summary, add two short orientation sections. Both are
+required and must appear before "Key changes at a glance" so a reader sees the behavior and flow
+before encountering implementation vocabulary.
+
+### Before and after
+
+Show one concrete scenario twice: the same query, plan shape, request, input rows, configuration,
+or error path before the PR and after it. Prefer an example supplied by the PR author or its tests.
+If none exists, synthesize the smallest example supported by code you traced, label it
+**Illustrative**, and cite the supporting code anchors. Never invent an API, benchmark result,
+production symptom, or semantic guarantee.
+
+Use a compact table or paired snippets. Make these four facts easy to find:
+
+- the unchanged starting condition;
+- what happened before;
+- what happens after;
+- what stays unchanged or which older behavior still applies when the new path cannot run.
+
+Keep the example at the user-visible, query-plan-visible, or data-flow-visible level. Detailed
+class and function names belong in the later key-change sections.
+
+### Flow at a glance
+
+Add one Mermaid `flowchart` using `TD`, `TB`, `LR`, or `RL`, choosing the direction that best
+explains the control or data flow. Keep it to simple quoted nodes, decision nodes, labeled arrows,
+and optional `subgraph` groups so both GitHub and the bundled HTML renderer can display it. Put at
+most one edge on each source line. The diagram should:
+
+- contain roughly 4–10 nodes or participants and fit on one screen;
+- make the old stopping point and new path visible, or show the full new flow when a comparison
+  would be misleading;
+- use plain conceptual labels rather than filenames and full function signatures;
+- distinguish decisions and older paths that materially affect behavior;
+- avoid branches that were not verified from the PR description, diff, or checked-out code.
+
+Immediately below the diagram, add a short **Code anchors** list linking 2–5 diagram concepts to
+their exact source lines. The diagram is orientation, not evidence by itself; the links make its
+claims inspectable. Keep Mermaid labels simple and quoted so GitHub renders the block reliably.
+
+## Step 7 — Write the key-change overview list
+
+Immediately after the two orientation sections, before any detailed section, list the key changes
 you're about to cover — each as a heading-matching title plus **1–3 sentences**. This is the
 digest's table of contents in prose form: a reader should be able to stop after this list and
 already know what the PR does and roughly how it's structured, then choose which detailed sections
@@ -134,35 +206,39 @@ Keep each entry genuinely short. The temptation is to front-load explanation her
 detailed section redundant — resist it. The overview answers "what is this change and why should I
 care", the detailed section answers "how does it work and where does it live".
 
-...` heading), and link each entry to its section so the reader can jump straight there.
+Use a `## Key changes at a glance` heading. Make every title a plain description of the behavior,
+not an internal mechanism or identifier. Match it to the detailed section and link it so the
+reader can jump straight there.
 
 After the glance list, add a **"Suggested reading order"**: 5–8 numbered steps naming which
 files and functions to open, in which order, for someone reviewing this PR for the first time.
 Start from the artifact that defines the target shape (often a test), then the mechanism, then
-the guards. Tag the load-bearing line each step exists to protect ("this emit mapping is the
-line the rest depends on") so the reader knows what to slow down for. This is pedagogy, not a
+the guards. Identify the important line each step exists to protect ("this mapping is the line the
+rest depends on") so the reader knows what to slow down for. This is pedagogy, not a
 verdict — no severity labels, no "must fix", no approval language.
 
-## Step 7 — Write each key change
+## Step 8 — Write each key change
 
 For every key change, in this order:
 
-**What it does.** Plain description of the new feature/fix/modified class — write for someone
-unfamiliar with this part of the codebase, not for the PR author.
+**What changed.** Start with the behavior in plain language. Introduce classes and functions only
+after the reader knows their purpose.
 
-**Why.** Pull from the PR description or code comments wherever they state it, and label every
-causal claim and failure mode by its evidence:
+**Why it matters.** Describe the previous cost, limitation, or incorrect behavior and the practical
+effect of the change. Pull from the PR description or code comments wherever they state it, and
+label every causal claim and failure mode by its evidence:
 
-- **Author-stated** — quoted from the PR body, a commit message, or a review comment. Keep it
+- **From the PR author** — quoted from the PR body, a commit message, or a review comment. Keep it
   quoted and attributed; never paraphrase it into the digest's own voice as established fact.
-- **Traced** — you read the code (in-diff or related) that shows it.
-- **Unverified** — neither stated by the author nor traced. List it under "Not covered in this
+- **Confirmed in code** — you read the code (in-diff or related) that shows it.
+- **Not verified** — neither stated by the author nor traced. List it under "Not covered in this
   pass", phrased as "I did not check X". It must not appear in the opening summary.
 
 If the why is genuinely not stated, say so explicitly ("not stated in the PR description; best
 guess: ...") — never present a guess as a confirmed fact.
-**Where it's invoked.** The call chain from a recognizable entry point down to this
-function/class. Write this as a nested markdown bullet list with `→` for the tree structure —
+**Where it happens.** Explain the route through the code from a recognizable entry point down to
+this function or class. Introduce it with one plain sentence, then write the exact call chain as a
+nested markdown bullet list with `→` for the tree structure —
 **never inside a triple-backtick fence**, because fenced code blocks don't render markdown links,
 and clickable links are the entire point of this format. Every function or file named in the list
 must be a link (see Link rules below), and **every line must carry one of three tags**:
@@ -178,17 +254,21 @@ Don't guess from the function's vibe. Skip the tag on pure context that isn't Si
 (e.g. "DuckDB's own logical-plan dispatch" as an entry point). Put a one-line legend above the
 *first* such list in the digest so it doesn't need repeating in every section.
 
-**Diff.** A trimmed, relevant hunk — the changed function or class body, not the whole file's
-diff. Trimming is expected and good (a 300-line file diff in the middle of a digest defeats the
-purpose), but say so explicitly right before the fence: name what's elided (e.g. "license header
-and an ~90-case exhaustive switch elided") and mark cuts inline with a comment like
+**Relevant diff.** A trimmed, relevant hunk — the changed function or class body, not the whole
+file's diff. Trimming is expected and good (a 300-line file diff in the middle of a digest defeats
+the purpose), but say so explicitly right before the fence: name what's elided (e.g. "license
+header and an ~90-case exhaustive switch elided") and mark cuts inline with a comment like
 `// ... elided: <what> ...`. Link the source file (with a line range if useful) immediately before
-the diff. The diff itself stays inside a normal ` ```diff ` fence — this is the one place a fence
-is correct, since real diffs need +/- coloring and don't contain links anyway.
+the diff. Put the diff inside a fenced code block whose info string is `diff`. Preserve the patch
+marker as the first character of every changed line: `+` for additions and `-` for removals, with
+one leading space for unchanged context. Do not use a plain code fence or strip the markers:
+renderers can recognize the additions and removals. This is the one place a fence is correct,
+since diffs need syntax coloring and contain no links. Markdown viewers may choose their own
+syntax colors; the companion HTML preview always renders additions green and removals red.
 
-## Step 8 — Audit moved code and files (its own section: "Relocations")
+## Step 9 — Audit moved code and files (its own section: "Moved and renamed code")
 
-Relocation is the single biggest source of wasted reviewer time on a large PR. A file moved from
+Moved code is one of the biggest sources of wasted reviewer time on a large PR. A file moved from
 `src/op/foo.hpp` to `src/op/bar/foo.hpp` shows up as a 400-line delete plus a 400-line add, and a
 reviewer who doesn't know it's a pure move will read all 800 lines looking for the change. The
 point of this section is to let them skip that entirely — but only where skipping is actually
@@ -221,7 +301,7 @@ If you couldn't verify a move (too large to diff carefully, ambiguous rename det
 here rather than claiming it's intact. An unverified "probably fine" that turns out to hide a logic
 change is worse than no claim at all.
 
-## Step 9 — Write "Not covered in this pass"
+## Step 10 — Write "Not covered in this pass"
 
 Close with an honest list of things you noticed but didn't trace through: a component only
 reachable via tests, gate/threshold logic the PR description mentions but you didn't read in
@@ -246,8 +326,13 @@ what keeps it honest instead of silently confident.
 
 ## Output
 
-- Path: `PR_digests/PR_digest_<PR_NUMBER>.md`, relative to repo root. Create the `PR_digests/`
-  directory if it doesn't exist.
+- Produce both companion files, relative to the repo root:
+  - `PR_digests/PR_digest_<PR_NUMBER>.md` — canonical, editable source.
+  - `PR_digests/PR_digest_<PR_NUMBER>.html` — generated, self-contained preview with an inline SVG
+    flowchart and explicit green/red diff rows.
+- Create the `PR_digests/` directory if it doesn't exist. Write and verify the Markdown first,
+  then generate the HTML from it. Never hand-edit the HTML; regenerate it after every Markdown
+  change.
 - Add `PR_digests/` to the repo's `.gitignore` if it isn't already there — these are local review
   artifacts, not something to commit. Check once per run; don't ask the user about it each time.
 - Structure, top to bottom:
@@ -258,17 +343,37 @@ what keeps it honest instead of silently confident.
   3. Header table: PR number/link, title, author, branch (head → base), scope (commit/file
      count), closes, supersedes.
   4. The PR description, quoted.
-  5. A short plain-language summary in your own words — what problem this solves, one paragraph.
-     It must OPEN with a concrete, user-visible or plan-visible before/after taken from the PR —
-     a query, a row shape, a setting, an error message — and only then introduce type names,
-     file names, or API terms. A reader who knows nothing about this subsystem should get
-     the example before the vocabulary. If the PR contains no such example, say so explicitly and do not invent one.
-  6. "Key changes at a glance" — the numbered overview list, 1–3 sentences each, linked to the
-     detailed sections (Step 6).
-  7. Ranked key changes in detail (Steps 5, 7), separated by `---`.
-  8. "Relocations" — moved files/functions with intact-vs-changed classification (Step 8).
-  9. "Not covered in this pass" (Step 9).
+  5. A short plain-language summary in your own words — what problem this solves and the outcome,
+     in one paragraph without implementation detail.
+  6. "Before and after" — one grounded example comparing the same scenario on both sides of the
+     PR, including unchanged behavior or the older path used when the new one cannot run (Step 6).
+  7. "Flow at a glance" — one compact Mermaid diagram plus 2–5 line-accurate code anchors
+     (Step 6).
+  8. "Key changes at a glance" — the numbered overview list, 1–3 sentences each, linked to the
+     detailed sections (Step 7).
+  9. "Suggested reading order" — the linked 5–8-step path through the code (Step 7).
+  10. Ranked key changes in detail (Steps 5, 8), separated by `---`.
+  11. "Moved and renamed code" — moved files/functions with intact-vs-changed classification
+      (Step 9).
+  12. "Not covered in this pass" (Step 10).
+
+After the Markdown is complete, render its companion preview with the repository-local script:
+
+```sh
+pixi run python .claude/skills/pr-digest/scripts/render_digest_html.py \
+  PR_digests/PR_digest_<PR_NUMBER>.md \
+  PR_digests/PR_digest_<PR_NUMBER>.html
+```
+
+If `pixi` is unavailable, run the same script with `python3`; it uses only the Python standard
+library. Treat a renderer failure as an incomplete digest, not an optional preview. Check the
+reported counts against the Markdown's `diff` and Mermaid fences, confirm the HTML contains no
+remote assets, and open the HTML in a browser or HTML preview when one is available.
+
+In the final response, link both files and identify Markdown as the editable source and HTML as
+the rendered preview. Also mention the branch/commit that was checked out to generate the links.
 
 See `references/example_digest.md` in this skill directory for a full worked example (PR #1277 —
-sirius-db/sirius, "dynamic filters: SIP") showing the expected tone, link density, trimming style,
-and tagging in practice. Read it before writing a digest if you want a concrete model to match.
+sirius-db/sirius, "dynamic filters: SIP") showing the expected structure, link density, trimming
+style, and tagging. Use `references/plain_language.md` as the authority for prose style when the
+worked example uses denser technical language.

--- a/.claude/skills/pr-digest/references/example_digest.md
+++ b/.claude/skills/pr-digest/references/example_digest.md
@@ -44,6 +44,48 @@ prune a probe input that is itself the output of another join, aggregate, or CTE
 travel *sideways* through the plan tree to reach a fact-table scan that sits several operators
 below the join that actually produced the filter.
 
+## Before and after
+
+**Illustrative example, traced from the planner paths linked below:** suppose a selective build
+side produces the key domain `{17, 42}`, but the other side of its join is an intermediate join or
+aggregate rather than a leaf scan. The query and key domain are identical in both columns.
+
+| | Before PR #1277 | After PR #1277 |
+|---|---|---|
+| **Probe shape** | `fact input → intermediate join/aggregate/CTE → publishing join` | The same plan shape. |
+| **Filter route** | The scan-only route cannot carry `{17, 42}` through the intermediate operator. | Sirius traces the key ordinal through safe operators and places a consumer at a reachable scan or direct endpoint. |
+| **Plan effect** | The downstream fact input remains unpruned by this build-side domain. | Eligible rows outside `{17, 42}` can be removed before they reach the publishing join. |
+| **Safety boundary** | No cross-operator route is attempted. | Traversal still stops at outer-join, row-duplication, type, null, and other unsupported boundaries. |
+
+## Flow at a glance
+
+```mermaid
+flowchart TB
+  subgraph Before["Before PR #1277"]
+    B1["Build side yields keys 17 and 42"] --> J1["Join publishes a dynamic filter"]
+    J1 -. "scan-only route stops" .-> I1["Intermediate join, aggregate, or CTE"]
+    I1 --> F1["Fact input remains unpruned"]
+  end
+
+  subgraph After["After PR #1277"]
+    B2["Build side yields keys 17 and 42"] --> J2["Join publishes a dynamic filter"]
+    J2 --> T2["Trace the probe key through safe operators"]
+    T2 --> E2["Attach at a scan or direct endpoint"]
+    E2 --> F2["Prune eligible fact-side rows earlier"]
+  end
+```
+
+**Code anchors:**
+
+- [`plan_comparison_join`](../src/planner/sirius_plan_comparison_join.cpp#L399) coordinates key
+  admission, tracing, and endpoint placement.
+- [`trace_probe_key`](../src/planner/sirius_plan_comparison_join.cpp#L506) attempts the scan route.
+- [`place_endpoint`](../src/planner/sirius_plan_comparison_join.cpp#L555) inserts a direct-route
+  consumer when no scan terminal was found.
+- [`probe_block_is_value_preserving`](../src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp#L34)
+  and [`build_block_is_value_preserving`](../src/planner/dynamic_filter/dynamic_filter_target_discovery.cpp#L53)
+  define key traversal safety boundaries.
+
 ## Key changes at a glance
 
 1. **[SIP-capable planning pipeline in `plan_comparison_join`](#key-change-1--sip-capable-planning-pipeline-in-plan_comparison_join-ranked-1-this-is-the-feature)** — Three new planner

--- a/.claude/skills/pr-digest/references/plain_language.md
+++ b/.claude/skills/pr-digest/references/plain_language.md
@@ -1,0 +1,67 @@
+# Plain-language guide for PR digests
+
+Use this guide before writing or revising a digest. The reader is an engineer who may not know the
+PR's subsystem. Accuracy still comes first, but unfamiliar vocabulary must not carry the
+explanation by itself.
+
+## Translate the mechanism without hiding it
+
+Start with what the code does in familiar words. Put an important source-code term after the
+explanation so readers can still search for it.
+
+| Avoid | Prefer |
+|---|---|
+| "decode-side row selection" | "choose which rows to keep while the compressed data is being decoded" |
+| "positional mask" | "a bitmap that marks which original row positions remain visible (the positional mask)" |
+| "materialize only rows satisfying both" | "create output rows only when both checks keep them" |
+| "confirmed decoder consumption" | "the decoder reports that it already applied the visibility bitmap" |
+| "compose visibility into the decode selection" | "apply row visibility together with the query filter during decoding" |
+| "writer-free covering snapshot" | "a read-only snapshot that includes every commit present when the bitmap was built" |
+| "cache probe/build/publish loop" | "look for saved visibility information, build it when missing, then save a safe result" |
+| "admit the zero-copy transfer" | "allow Sirius to reuse the decoded table directly instead of copying it" |
+| "key admission" | "decide which join keys can safely use the optimization" |
+| "fallback contract" | "the rules for using the older path when the optimization cannot run" |
+
+These are patterns, not replacements to apply blindly. Use the meaning established by the PR's
+actual code.
+
+## Introduce abbreviations and identifiers
+
+- On first use, write "multi-version concurrency control (MVCC), which determines which rows a
+  query is allowed to see." Adjust the explanation to the PR's actual concern.
+- Introduce an identifier by purpose: "The function that checks whether saved visibility data can
+  be reused, `mvcc_mask_cache_reusable`, ..."
+- Keep identifiers out of the opening summary and diagram unless the identifier itself is the
+  user-facing concept.
+- Do not repeat both the plain phrase and technical term in every sentence. Define the term once,
+  then use whichever version makes the next sentence easiest to understand.
+
+## Make cause and consequence explicit
+
+Prefer a short chain the reader can follow:
+
+1. What condition starts this path?
+2. What does the old code do?
+3. What does the new code do instead?
+4. What work, behavior, or safety property changes as a result?
+5. What happens when the new path cannot run?
+
+Avoid sentences that only rename code. "The request gains `keep_mask_words`" is incomplete. Add
+the consequence: those words let the decoder exclude invisible rows at the same time as it applies
+the query filter.
+
+## Final jargon check
+
+Read the title, summary, before/after table, diagram, key-change titles, and first paragraph of each
+detailed section without looking at the code. Revise them if any of these are true:
+
+- a term names an implementation technique but does not say what it does;
+- an acronym appears before its meaning;
+- a heading is mostly class names, field names, or stacked nouns;
+- verbs such as "compose," "materialize," "consume," "admit," or "dispatch" could be replaced by a
+  clearer action;
+- "fast path" or "fallback" appears without explaining the optimized or older behavior;
+- the reader must infer why the change matters from the diff.
+
+Keep technical terms inside quoted PR text and code diffs unchanged. Explain them immediately
+before or after the quote when they are necessary to understand it.

--- a/.claude/skills/pr-digest/scripts/render_digest_html.py
+++ b/.claude/skills/pr-digest/scripts/render_digest_html.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+"""Render a PR digest Markdown file as a self-contained HTML preview.
+
+The renderer intentionally supports the Markdown subset emitted by the pr-digest skill. It has
+no third-party dependencies, colors diff additions/removals, and turns simple Mermaid flowcharts
+into inline SVG so the preview works offline in Codex.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+FENCE_RE = re.compile(r"^```([A-Za-z0-9_-]*)\s*$")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+LIST_RE = re.compile(r"^(\s*)([-+*]|\d+\.)\s+(.+)$")
+TABLE_RULE_RE = re.compile(r"^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$")
+LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+CODE_RE = re.compile(r"`([^`]+)`")
+NODE_RE = re.compile(
+    r'^([A-Za-z_][\w-]*)(?:\["([^"]*)"\]|\[([^\]]*)\]|\{"([^"]*)"\}|\{([^}]*)\}|\("([^"]*)"\)|\(([^)]*)\))?$'
+)
+EDGE_RE = re.compile(r"^(.*?)\s*(-->|==>)\s*(?:\|\"?([^|\"]+)\"?\|\s*)?(.*?)$")
+SUBGRAPH_RE = re.compile(
+    r'^subgraph\s+([A-Za-z_][\w-]*)(?:\["([^"]*)"\]|\[([^\]]*)\])?\s*$'
+)
+SCHEME_RE = re.compile(r"^([A-Za-z][A-Za-z0-9+.-]*):")
+
+
+def safe_href(value: str) -> str:
+    """Escape a link target and reject schemes that can execute in a local preview."""
+    target = value.strip()
+    scheme = SCHEME_RE.match(target)
+    if scheme and scheme.group(1).lower() not in {"http", "https", "mailto"}:
+        target = "#"
+    return html.escape(target, quote=True)
+
+
+def render_inline(value: str) -> str:
+    placeholders: list[str] = []
+
+    def hold(rendered: str) -> str:
+        token = f"\x00{len(placeholders)}\x00"
+        placeholders.append(rendered)
+        return token
+
+    def link(match: re.Match[str]) -> str:
+        label = render_inline(match.group(1))
+        href = safe_href(match.group(2))
+        return hold(f'<a href="{href}">{label}</a>')
+
+    value = LINK_RE.sub(link, value)
+    value = CODE_RE.sub(
+        lambda match: hold(f"<code>{html.escape(match.group(1))}</code>"), value
+    )
+    value = html.escape(value, quote=False)
+    value = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", value)
+    value = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"<em>\1</em>", value)
+    value = re.sub(r"~~(.+?)~~", r"<del>\1</del>", value)
+    for index, rendered in enumerate(placeholders):
+        value = value.replace(f"\x00{index}\x00", rendered)
+    return value
+
+
+def slugify(value: str, counts: dict[str, int]) -> str:
+    plain = html.unescape(re.sub(r"<[^>]+>", "", value)).lower()
+    base = re.sub(r"[^\w\s-]", "", plain, flags=re.UNICODE).strip()
+    # GitHub's heading IDs preserve the two spaces around an em dash as two hyphens after the
+    # punctuation is removed. Match that behavior so authored table-of-contents links still work.
+    base = re.sub(r"\s", "-", base) or "section"
+    seen = counts.get(base, 0)
+    counts[base] = seen + 1
+    return base if seen == 0 else f"{base}-{seen}"
+
+
+def split_table_row(line: str) -> list[str]:
+    stripped = line.strip().strip("|")
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+@dataclass
+class FlowNode:
+    identifier: str
+    label: str
+    shape: str = "rect"
+    group: str | None = None
+
+
+@dataclass
+class FlowEdge:
+    source: str
+    target: str
+    label: str = ""
+
+
+@dataclass
+class FlowGraph:
+    direction: str = "TD"
+    nodes: dict[str, FlowNode] = field(default_factory=dict)
+    order: list[str] = field(default_factory=list)
+    edges: list[FlowEdge] = field(default_factory=list)
+    groups: dict[str, str] = field(default_factory=dict)
+
+    def add_node(self, token: str, group: str | None) -> str | None:
+        token = token.strip().rstrip(";")
+        match = NODE_RE.match(token)
+        if not match:
+            return None
+        identifier = match.group(1)
+        candidates = match.groups()[1:]
+        label = next(
+            (candidate for candidate in candidates if candidate is not None), identifier
+        )
+        shape = (
+            "decision" if token[len(identifier) :].lstrip().startswith("{") else "rect"
+        )
+        if identifier not in self.nodes:
+            self.nodes[identifier] = FlowNode(identifier, label, shape, group)
+            self.order.append(identifier)
+        else:
+            node = self.nodes[identifier]
+            if label != identifier:
+                node.label = label
+                node.shape = shape
+            if node.group is None:
+                node.group = group
+        return identifier
+
+
+def parse_flowchart(source: str) -> FlowGraph | None:
+    lines = [line.strip() for line in source.splitlines() if line.strip()]
+    if not lines or not lines[0].startswith("flowchart "):
+        return None
+    graph = FlowGraph(direction=lines[0].split(maxsplit=1)[1].upper())
+    current_group: str | None = None
+    for raw in lines[1:]:
+        if raw.startswith("%%") or raw.startswith(
+            ("classDef ", "class ", "style ", "linkStyle ")
+        ):
+            continue
+        group_match = SUBGRAPH_RE.match(raw)
+        if group_match:
+            current_group = group_match.group(1)
+            graph.groups[current_group] = (
+                group_match.group(2) or group_match.group(3) or current_group
+            )
+            continue
+        if raw == "end":
+            current_group = None
+            continue
+
+        normalized = re.sub(
+            r'-\.\s*"([^"]+)"\s*\.->',
+            lambda match: f'-->|"{match.group(1)}"|',
+            raw,
+        )
+        edge_match = EDGE_RE.match(normalized)
+        if edge_match:
+            source_id = graph.add_node(edge_match.group(1), current_group)
+            target_id = graph.add_node(edge_match.group(4), current_group)
+            if source_id and target_id:
+                graph.edges.append(
+                    FlowEdge(source_id, target_id, (edge_match.group(3) or "").strip())
+                )
+            continue
+        graph.add_node(raw, current_group)
+    return graph if graph.nodes else None
+
+
+def wrap_svg_text(value: str, width: int = 28) -> list[str]:
+    words = value.split()
+    if not words:
+        return [""]
+    lines: list[str] = []
+    current = words[0]
+    for word in words[1:]:
+        if len(current) + len(word) + 1 <= width:
+            current += " " + word
+        else:
+            lines.append(current)
+            current = word
+    lines.append(current)
+    return lines[:3]
+
+
+def render_flowchart(source: str) -> str:
+    graph = parse_flowchart(source)
+    escaped_source = html.escape(source)
+    if graph is None:
+        return (
+            '<figure class="flow-figure"><p class="diagram-warning">'
+            "Diagram preview unavailable for this Mermaid syntax; source retained below.</p>"
+            f"<pre><code>{escaped_source}</code></pre></figure>"
+        )
+
+    indegree = {identifier: 0 for identifier in graph.nodes}
+    outgoing: dict[str, list[str]] = {identifier: [] for identifier in graph.nodes}
+    for edge in graph.edges:
+        outgoing[edge.source].append(edge.target)
+        indegree[edge.target] += 1
+
+    levels = {identifier: 0 for identifier in graph.nodes}
+    queue = [identifier for identifier in graph.order if indegree[identifier] == 0]
+    visited: list[str] = []
+    while queue:
+        identifier = queue.pop(0)
+        visited.append(identifier)
+        for target in outgoing[identifier]:
+            levels[target] = max(levels[target], levels[identifier] + 1)
+            indegree[target] -= 1
+            if indegree[target] == 0:
+                queue.append(target)
+    for identifier in graph.order:
+        if identifier not in visited:
+            levels[identifier] = max(levels.values(), default=0) + 1
+
+    layers: dict[int, list[str]] = {}
+    for identifier in graph.order:
+        layers.setdefault(levels[identifier], []).append(identifier)
+    max_level = max(layers, default=0)
+    max_layer_size = max((len(items) for items in layers.values()), default=1)
+    horizontal = graph.direction in {"LR", "RL"}
+
+    if horizontal:
+        width = max(720, 300 * (max_level + 1))
+        height = max(360, 125 * max_layer_size + 100)
+    else:
+        width = max(760, 280 * max_layer_size + 100)
+        height = max(420, 135 * (max_level + 1) + 100)
+
+    positions: dict[str, tuple[float, float]] = {}
+    for level, identifiers in layers.items():
+        if horizontal:
+            x = 150 + level * 280
+            for index, identifier in enumerate(identifiers):
+                y = (index + 1) * height / (len(identifiers) + 1)
+                positions[identifier] = (x, y)
+        else:
+            y = 80 + level * 130
+            for index, identifier in enumerate(identifiers):
+                x = (index + 1) * width / (len(identifiers) + 1)
+                positions[identifier] = (x, y)
+
+    token = hashlib.sha1(source.encode("utf8"), usedforsecurity=False).hexdigest()[:10]
+    pieces = [
+        f'<figure class="flow-figure"><svg class="flow-svg" viewBox="0 0 {width} {height}" role="img" aria-labelledby="title-{token} desc-{token}">',
+        f'<title id="title-{token}">PR change flowchart</title>',
+        f'<desc id="desc-{token}">Flowchart generated from the digest Mermaid source.</desc>',
+        f'<defs><marker id="arrow-{token}" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head" /></marker></defs>',
+    ]
+
+    for group_id, title in graph.groups.items():
+        members = [
+            positions[node.identifier]
+            for node in graph.nodes.values()
+            if node.group == group_id
+        ]
+        if not members:
+            continue
+        min_x = min(point[0] for point in members) - 140
+        max_x = max(point[0] for point in members) + 140
+        min_y = min(point[1] for point in members) - 65
+        max_y = max(point[1] for point in members) + 65
+        pieces.append(
+            f'<rect class="flow-group" x="{min_x:.1f}" y="{min_y:.1f}" width="{max_x - min_x:.1f}" height="{max_y - min_y:.1f}" rx="16" />'
+        )
+        pieces.append(
+            f'<text class="flow-group-label" x="{min_x + 14:.1f}" y="{min_y + 24:.1f}">{html.escape(title)}</text>'
+        )
+
+    for edge in graph.edges:
+        source_x, source_y = positions[edge.source]
+        target_x, target_y = positions[edge.target]
+        if horizontal:
+            start_x, start_y = source_x + 120, source_y
+            end_x, end_y = target_x - 120, target_y
+        else:
+            start_x, start_y = source_x, source_y + 38
+            end_x, end_y = target_x, target_y - 38
+        pieces.append(
+            f'<path class="flow-edge" marker-end="url(#arrow-{token})" d="M {start_x:.1f} {start_y:.1f} L {end_x:.1f} {end_y:.1f}" />'
+        )
+        if edge.label:
+            label_x = (start_x + end_x) / 2
+            label_y = (start_y + end_y) / 2 - 7
+            pieces.append(
+                f'<text class="flow-edge-label" x="{label_x:.1f}" y="{label_y:.1f}">{html.escape(edge.label)}</text>'
+            )
+
+    for identifier in graph.order:
+        node = graph.nodes[identifier]
+        x, y = positions[identifier]
+        if node.shape == "decision":
+            points = f"{x:.1f},{y - 42:.1f} {x + 130:.1f},{y:.1f} {x:.1f},{y + 42:.1f} {x - 130:.1f},{y:.1f}"
+            pieces.append(
+                f'<polygon class="flow-node flow-decision" points="{points}" />'
+            )
+        else:
+            pieces.append(
+                f'<rect class="flow-node" x="{x - 120:.1f}" y="{y - 34:.1f}" width="240" height="68" rx="12" />'
+            )
+        text_lines = wrap_svg_text(node.label)
+        start_y = y - (len(text_lines) - 1) * 10
+        pieces.append(f'<text class="flow-text" x="{x:.1f}" y="{start_y:.1f}">')
+        for index, line in enumerate(text_lines):
+            dy = "0" if index == 0 else "20"
+            pieces.append(f'<tspan x="{x:.1f}" dy="{dy}">{html.escape(line)}</tspan>')
+        pieces.append("</text>")
+
+    pieces.extend(
+        [
+            "</svg>",
+            '<details class="diagram-source"><summary>Mermaid source</summary>',
+            f"<pre><code>{escaped_source}</code></pre></details></figure>",
+        ]
+    )
+    return "".join(pieces)
+
+
+class DigestRenderer:
+    def __init__(self) -> None:
+        self.heading_counts: dict[str, int] = {}
+        self.diff_blocks = 0
+        self.additions = 0
+        self.removals = 0
+        self.flowcharts = 0
+
+    def render_code(self, language: str, code: str) -> str:
+        if language == "diff":
+            self.diff_blocks += 1
+            rendered: list[str] = []
+            for line in code.splitlines():
+                kind = "context"
+                if line.startswith("+") and not line.startswith("+++"):
+                    kind = "add"
+                    self.additions += 1
+                elif line.startswith("-") and not line.startswith("---"):
+                    kind = "remove"
+                    self.removals += 1
+                rendered.append(
+                    f'<span class="diff-line diff-{kind}">{html.escape(line) or " "}</span>'
+                )
+            return (
+                '<div class="diff-block" role="region" aria-label="Code diff">'
+                f'<pre><code>{"".join(rendered)}</code></pre></div>'
+            )
+        if language == "mermaid":
+            self.flowcharts += 1
+            return render_flowchart(code)
+        language_class = (
+            f' class="language-{html.escape(language, quote=True)}"' if language else ""
+        )
+        return f"<pre><code{language_class}>{html.escape(code)}</code></pre>"
+
+    def render(self, markdown: str) -> str:
+        lines = markdown.splitlines()
+        output: list[str] = []
+        paragraph: list[str] = []
+        index = 0
+
+        def flush_paragraph() -> None:
+            if paragraph:
+                output.append(
+                    f'<p>{render_inline(" ".join(part.strip() for part in paragraph))}</p>'
+                )
+                paragraph.clear()
+
+        while index < len(lines):
+            line = lines[index]
+            fence_match = FENCE_RE.match(line)
+            if fence_match:
+                flush_paragraph()
+                language = fence_match.group(1).lower()
+                index += 1
+                code_lines: list[str] = []
+                while index < len(lines) and lines[index] != "```":
+                    code_lines.append(lines[index])
+                    index += 1
+                output.append(self.render_code(language, "\n".join(code_lines)))
+                index += 1
+                continue
+
+            heading_match = HEADING_RE.match(line)
+            if heading_match:
+                flush_paragraph()
+                level = len(heading_match.group(1))
+                rendered = render_inline(heading_match.group(2))
+                slug = slugify(rendered, self.heading_counts)
+                output.append(f'<h{level} id="{slug}">{rendered}</h{level}>')
+                index += 1
+                continue
+
+            if re.match(r"^\s*(?:---+|___+|\*\*\*+)\s*$", line):
+                flush_paragraph()
+                output.append("<hr />")
+                index += 1
+                continue
+
+            if line.startswith(">"):
+                flush_paragraph()
+                quote_lines: list[str] = []
+                while index < len(lines) and lines[index].startswith(">"):
+                    quote_lines.append(lines[index][1:].lstrip())
+                    index += 1
+                quote_paragraphs: list[str] = []
+                current: list[str] = []
+                for quote_line in quote_lines + [""]:
+                    if quote_line:
+                        current.append(quote_line)
+                    elif current:
+                        quote_paragraphs.append(
+                            f'<p>{render_inline(" ".join(current))}</p>'
+                        )
+                        current = []
+                output.append(f'<blockquote>{"".join(quote_paragraphs)}</blockquote>')
+                continue
+
+            if (
+                index + 1 < len(lines)
+                and "|" in line
+                and TABLE_RULE_RE.match(lines[index + 1])
+            ):
+                flush_paragraph()
+                headers = split_table_row(line)
+                index += 2
+                rows: list[list[str]] = []
+                while (
+                    index < len(lines) and "|" in lines[index] and lines[index].strip()
+                ):
+                    rows.append(split_table_row(lines[index]))
+                    index += 1
+                head = "".join(f"<th>{render_inline(cell)}</th>" for cell in headers)
+                body = "".join(
+                    "<tr>"
+                    + "".join(f"<td>{render_inline(cell)}</td>" for cell in row)
+                    + "</tr>"
+                    for row in rows
+                )
+                output.append(
+                    f'<div class="table-wrap"><table><thead><tr>{head}</tr></thead><tbody>{body}</tbody></table></div>'
+                )
+                continue
+
+            list_match = LIST_RE.match(line)
+            if list_match:
+                flush_paragraph()
+                items: list[tuple[int, str, str]] = []
+                while index < len(lines):
+                    current_match = LIST_RE.match(lines[index])
+                    if not current_match:
+                        if (
+                            items
+                            and lines[index].startswith(" ")
+                            and lines[index].strip()
+                        ):
+                            depth, marker, value = items[-1]
+                            items[-1] = (
+                                depth,
+                                marker,
+                                value + " " + lines[index].strip(),
+                            )
+                            index += 1
+                            continue
+                        break
+                    indent, marker, value = current_match.groups()
+                    depth = max(0, len(indent.expandtabs(2)) // 2)
+                    items.append((depth, marker, value))
+                    index += 1
+                rendered_items = []
+                for depth, marker, value in items:
+                    rendered_items.append(
+                        f'<div class="list-item" style="--depth:{depth}"><span class="list-marker">{html.escape(marker)}</span><span>{render_inline(value)}</span></div>'
+                    )
+                output.append(
+                    f'<div class="list-block">{"".join(rendered_items)}</div>'
+                )
+                continue
+
+            if not line.strip():
+                flush_paragraph()
+                index += 1
+                continue
+
+            paragraph.append(line)
+            index += 1
+
+        flush_paragraph()
+        return "\n".join(output)
+
+
+STYLE = r"""
+:root {
+  --page: #f6f8fa; --surface: #fff; --surface-muted: #f6f8fa; --text: #1f2328;
+  --muted: #59636e; --border: #d0d7de; --link: #0969da; --accent: #8250df;
+  --add-bg: #dafbe1; --add-text: #116329; --add-border: #aceebb;
+  --remove-bg: #ffebe9; --remove-text: #82071e; --remove-border: #ffcecb;
+  --shadow: 0 8px 28px rgba(31,35,40,.08);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page:#0d1117; --surface:#161b22; --surface-muted:#0d1117; --text:#e6edf3;
+    --muted:#9da7b1; --border:#30363d; --link:#58a6ff; --accent:#a371f7;
+    --add-bg:#12261e; --add-text:#7ee787; --add-border:#2ea043;
+    --remove-bg:#321c22; --remove-text:#ff7b72; --remove-border:#f85149;
+    --shadow:0 10px 36px rgba(0,0,0,.35);
+  }
+}
+* { box-sizing:border-box; }
+html { scroll-behavior:smooth; }
+body { margin:0; background:var(--page); color:var(--text); font:16px/1.62 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+.toolbar { position:sticky; top:0; z-index:5; display:flex; justify-content:space-between; gap:1rem; align-items:center; padding:.7rem max(1rem,calc((100vw - 1120px)/2)); border-bottom:1px solid var(--border); background:var(--surface); }
+.toolbar strong { font-size:.92rem; }
+.toolbar nav { display:flex; gap:.9rem; font-size:.9rem; }
+main { width:min(1120px,calc(100% - 2rem)); margin:1.5rem auto 4rem; padding:clamp(1.25rem,3.2vw,3rem); background:var(--surface); border:1px solid var(--border); border-radius:16px; box-shadow:var(--shadow); }
+h1,h2,h3 { line-height:1.25; scroll-margin-top:5rem; }
+h1 { margin-top:0; font-size:clamp(1.85rem,4vw,2.7rem); }
+h2 { margin-top:2.4rem; padding-bottom:.35rem; border-bottom:1px solid var(--border); }
+h3 { margin-top:2rem; }
+a { color:var(--link); text-decoration-thickness:1px; text-underline-offset:.16em; }
+blockquote { margin:1.25rem 0; padding:.3rem 1rem; color:var(--muted); border-left:4px solid var(--accent); background:var(--surface-muted); }
+.table-wrap { overflow-x:auto; }
+table { width:100%; border-collapse:collapse; }
+th,td { padding:.65rem .8rem; border:1px solid var(--border); vertical-align:top; }
+th { background:var(--surface-muted); text-align:left; }
+code { font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; font-size:.9em; }
+:not(pre)>code { padding:.12em .35em; border-radius:5px; background:var(--surface-muted); }
+pre { margin:0; overflow-x:auto; }
+hr { margin:3rem 0; border:0; border-top:1px solid var(--border); }
+.list-block { margin:.85rem 0; }
+.list-item { display:grid; grid-template-columns:2.2rem minmax(0,1fr); margin:.28rem 0; margin-left:calc(var(--depth)*1.55rem); }
+.list-marker { color:var(--muted); text-align:right; padding-right:.65rem; }
+.diff-block { margin:1rem 0 1.6rem; overflow:hidden; border:1px solid var(--border); border-radius:10px; background:var(--surface-muted); }
+.diff-block code { display:block; min-width:max-content; padding:.55rem 0; }
+.diff-line { display:block; min-height:1.45em; padding:0 1rem; white-space:pre; }
+.diff-add { color:var(--add-text); background:var(--add-bg); border-left:3px solid var(--add-border); }
+.diff-remove { color:var(--remove-text); background:var(--remove-bg); border-left:3px solid var(--remove-border); }
+.diff-context { color:var(--muted); border-left:3px solid transparent; }
+.flow-figure { margin:1rem 0 1.75rem; padding:1rem; overflow-x:auto; border:1px solid var(--border); border-radius:12px; background:var(--surface-muted); }
+.flow-svg { display:block; width:100%; height:auto; min-width:680px; }
+.flow-group { fill:color-mix(in srgb,var(--surface) 76%,transparent); stroke:var(--border); stroke-width:1.5; stroke-dasharray:5 4; }
+.flow-group-label { fill:var(--muted); font:600 14px -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; text-anchor:start; }
+.flow-node { fill:var(--surface); stroke:var(--border); stroke-width:2; }
+.flow-decision { fill:var(--surface); stroke:var(--accent); }
+.flow-edge { fill:none; stroke:var(--muted); stroke-width:2.2; }
+.arrow-head { fill:var(--muted); }
+.flow-text,.flow-edge-label { fill:var(--text); font:600 15px -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; text-anchor:middle; }
+.flow-edge-label { fill:var(--muted); font-size:13px; }
+.diagram-source { margin-top:.9rem; color:var(--muted); }
+.diagram-source pre,.diagram-warning+pre { margin-top:.6rem; padding:.8rem; border-radius:8px; background:var(--surface); }
+.diagram-warning { color:var(--muted); }
+.preview-footer { width:min(1120px,calc(100% - 2rem)); margin:-2.5rem auto 2rem; color:var(--muted); font-size:.85rem; text-align:center; }
+@media (max-width:680px) {
+  .toolbar { align-items:flex-start; flex-direction:column; }
+  main { width:min(100% - 1rem,1120px); margin-top:.5rem; padding:1rem; border-radius:10px; }
+  .flow-figure { padding:.4rem; }
+}
+@media print {
+  .toolbar { display:none; }
+  body { background:#fff; }
+  main { width:100%; margin:0; padding:0; border:0; box-shadow:none; }
+  .preview-footer { margin-top:1rem; }
+}
+"""
+
+
+def build_document(markdown_path: Path, content: str, title: str) -> str:
+    source_name = html.escape(markdown_path.name, quote=True)
+    key_changes = re.search(r'id="(key-changes-at-a-glance[^"]*)"', content)
+    coverage_notes = re.search(r'id="(not-covered-in-this-pass[^"]*)"', content)
+    key_changes_href = f"#{key_changes.group(1)}" if key_changes else "#"
+    coverage_notes_href = f"#{coverage_notes.group(1)}" if coverage_notes else "#"
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="light dark" />
+  <title>{html.escape(title)} — HTML Preview</title>
+  <style>{STYLE}</style>
+</head>
+<body>
+  <header class="toolbar">
+    <strong>Rendered PR digest</strong>
+    <nav>
+      <a href="{source_name}">Markdown source</a>
+      <a href="{key_changes_href}">Key changes</a>
+      <a href="{coverage_notes_href}">Coverage notes</a>
+    </nav>
+  </header>
+  <main>{content}</main>
+  <footer class="preview-footer">Generated from <code>{source_name}</code>. Regenerate after editing the Markdown source.</footer>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("markdown", type=Path, help="source PR digest Markdown path")
+    parser.add_argument("html", type=Path, help="destination HTML preview path")
+    args = parser.parse_args()
+
+    markdown = args.markdown.read_text(encoding="utf8")
+    renderer = DigestRenderer()
+    content = renderer.render(markdown)
+    title_match = re.search(r"^#\s+(.+)$", markdown, flags=re.MULTILINE)
+    title = title_match.group(1) if title_match else args.markdown.stem
+    document = build_document(args.markdown, content, title)
+    args.html.parent.mkdir(parents=True, exist_ok=True)
+    args.html.write_text(document, encoding="utf8")
+    print(
+        f"Rendered {args.html}: {renderer.diff_blocks} diff blocks, "
+        f"{renderer.additions} additions, {renderer.removals} removals, "
+        f"{renderer.flowcharts} flowcharts"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -3,4 +3,7 @@
 # without forcing an unrelated repo-wide Markdown rewrite.
 enable = ["MD051", "MD057"]
 # Illustrative example with links to non-existent files by design.
-exclude = [".claude/skills/pr-digest/references/example_digest.md"]
+exclude = [
+  ".claude/skills/pr-digest/references/example_digest.md",
+  ".agents/skills/pr-digest/references/example_digest.md",
+]


### PR DESCRIPTION
## Motivation

PR #1660 added a repository-local Claude skill for producing navigable learning digests of pull requests. Codex users should have the equivalent workflow available from the repository, with Codex-native discovery and sandbox handling. Reviewers also benefit from seeing the behavioral change and system flow before implementation detail.

The improvements developed for the Codex version are also applied back to the Claude skill so both agents produce the same digest structure, writing style, diagrams, Markdown source, and HTML preview. Only their sandbox instructions, renderer path, and preview wording differ.

Codex opens Markdown files as source, so viewer-selected syntax highlighting does not reliably show additions in green and removals in red. The skill now generates a companion HTML preview to make that presentation deterministic while preserving Markdown as the canonical, portable artifact.

## What changed

- add the `pr-digest` skill under `.agents/skills/` for repository-wide Codex discovery
- bring `.claude/skills/pr-digest/` to feature and writing-style parity with the Codex skill
- keep the renderer, worked example, and plain-language guide byte-identical between both packages
- translate the Claude-specific sandbox bypass into Codex elevated `gh` execution
- require a grounded before/after example and compact Mermaid flowchart before the key-change deep dive
- connect diagram concepts to line-accurate source anchors
- write for engineers who are new to the subsystem: define acronyms and unavoidable terms, use behavior-focused headings, and explain each mechanism as actor, action, and consequence
- add a PR-specific plain-language guide with concrete jargon rewrites and a final readability check
- preserve standard fenced `diff` blocks with `+` and `-` markers in the Markdown source
- require both `PR_digest_<N>.md` and a generated, self-contained `PR_digest_<N>.html` preview
- add a standard-library renderer that converts diff rows to explicit green/red styling and simple Mermaid flowcharts to accessible inline SVG
- keep the HTML free of remote scripts, styles, and images, and reject executable link schemes
- include an updated PR #1277 worked example and Codex UI metadata
- exclude the illustrative reference digest from repository `rumdl` link validation because its links target the historical PR checkout

## Verification

- Codex `quick_validate.py`: `Skill is valid!`
- Claude `quick_validate.py`: `Skill is valid!`
- `rumdl` 0.2.44: no issues in the updated skill instructions
- Black 25.1.0: renderer is formatted
- repository pre-commit hooks applicable to the changed files pass; the unavailable `pixi` wrapper was replaced by the equivalent direct `rumdl` invocation
- renderer exercised against the PR #1277 worked example: 9 diff blocks, 181 additions, 14 removals, and 1 inline flowchart
- revised format exercised against PR #1556 at commit `96ad7c54385691389b06b73767149f77417569ae`: 6 diff blocks, 86 additions, 4 removals, and 1 inline flowchart
- both agent-local renderers produce the same counts for the PR #1277 and PR #1556 fixtures
- revised the PR #1556 digest's title, summary, before/after table, diagram, change headings, and detailed prose using the new plain-language guide
- verified every internal HTML navigation target resolves and neither preview contains remote executable assets
- validated all 41 unique PR #1556 local source-line links against that checkout
- `git diff --check`

## Scope

This is a documentation and agent-workflow change only. No Sirius build or C++ tests were run. Generated files under `PR_digests/` remain ignored local review artifacts. The skill explains what a PR changes and where it lives; adversarial code review remains a separate pass.