### PR TITLE
fix: support scalar cast evaluation

### DIFF
--- a/src/expression_evaluator/specializations/cast.cpp
+++ b/src/expression_evaluator/specializations/cast.cpp
@@ -84,8 +84,8 @@ evaluate_result expression_evaluator::evaluate(sirius::ast::cast const& alt, eva
   auto const return_type = sirius::get_cudf_type(alt.target_type);
   auto child             = evaluate(*alt.child, evaluation_mode::MATERIALIZE);
   if (child.is_scalar()) {
-    child = evaluate_result(cudf::make_column_from_scalar(
-      child.get_scalar(), _input_table.num_rows(), _stream, _mr));
+    child = evaluate_result(
+      cudf::make_column_from_scalar(child.get_scalar(), _input_table.num_rows(), _stream, _mr));
   }
   // Only planner-certified carrier restoration may tunnel through the narrowed representation.
   // A semantic cast delegates to cuDF and is never reinterpreted as a physical DATE restore.

--- a/src/expression_evaluator/specializations/cast.cpp
+++ b/src/expression_evaluator/specializations/cast.cpp
@@ -23,6 +23,7 @@
 #include <sirius/exception.hpp>
 
 // cudf
+#include <cudf/column/column_factories.hpp>
 #include <cudf/cudf_utils.hpp>
 #include <cudf/unary.hpp>
 
@@ -82,7 +83,10 @@ evaluate_result expression_evaluator::evaluate(sirius::ast::cast const& alt, eva
   //===----------3: MATERIALIZE Mode, evaluate node with unary/binary ops----------===//
   auto const return_type = sirius::get_cudf_type(alt.target_type);
   auto child             = evaluate(*alt.child, evaluation_mode::MATERIALIZE);
-  D_ASSERT(!child.is_scalar());  // CAST should never be called on a scalar
+  if (child.is_scalar()) {
+    child = evaluate_result(cudf::make_column_from_scalar(
+      child.get_scalar(), _input_table.num_rows(), _stream, _mr));
+  }
   // Only planner-certified carrier restoration may tunnel through the narrowed representation.
   // A semantic cast delegates to cuDF and is never reinterpreted as a physical DATE restore.
   auto result_column =

--- a/test/cpp/expression_evaluator/test_expression_evaluator.cpp
+++ b/test/cpp/expression_evaluator/test_expression_evaluator.cpp
@@ -1134,12 +1134,11 @@ TEMPLATE_TEST_CASE("evaluate casts scalar constants including HUGEINT and NULL",
   for (auto const row_count : {0, 1, 7}) {
     CAPTURE(row_count);
     std::vector<std::unique_ptr<cudf::column>> columns;
-    columns.push_back(cudf::make_numeric_column(
-      cudf::data_type{cudf::type_id::INT32},
-      row_count,
-      cudf::mask_state::UNALLOCATED,
-      cudf::get_default_stream(),
-      get_resource_ref(*space)));
+    columns.push_back(cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                                row_count,
+                                                cudf::mask_state::UNALLOCATED,
+                                                cudf::get_default_stream(),
+                                                get_resource_ref(*space)));
     auto input = std::make_unique<cudf::table>(std::move(columns));
 
     std::vector<std::unique_ptr<ast_node>> nodes;
@@ -1153,11 +1152,8 @@ TEMPLATE_TEST_CASE("evaluate casts scalar constants including HUGEINT and NULL",
     for (auto const& node : nodes) {
       expressions.push_back(node.get());
     }
-    exp_executor executor(expressions,
-                          get_resource_ref(*space),
-                          cudf::get_default_stream(),
-                          TestType::value,
-                          1);
+    exp_executor executor(
+      expressions, get_resource_ref(*space), cudf::get_default_stream(), TestType::value, 1);
     auto output     = executor.evaluate(input->view());
     auto const view = output->view();
     REQUIRE(view.num_rows() == row_count);

--- a/test/cpp/expression_evaluator/test_expression_evaluator.cpp
+++ b/test/cpp/expression_evaluator/test_expression_evaluator.cpp
@@ -1119,6 +1119,63 @@ TEMPLATE_TEST_CASE("evaluate projects references, constants, and comparisons",
   }
 }
 
+TEMPLATE_TEST_CASE("evaluate casts scalar constants including HUGEINT and NULL",
+                   "[expression_evaluator][scalar_cast]",
+                   mat_strategy,
+                   ast_interpret_strategy,
+                   ast_jit_strategy)
+{
+  auto* space = get_default_gpu_space();
+  REQUIRE(space != nullptr);
+  auto const hugeint = logical_type::make(type_id::HUGEINT);
+  auto const bigint  = logical_type::make(type_id::BIGINT);
+  auto const integer = logical_type::make(type_id::INTEGER);
+
+  for (auto const row_count : {0, 1, 7}) {
+    CAPTURE(row_count);
+    std::vector<std::unique_ptr<cudf::column>> columns;
+    columns.push_back(cudf::make_numeric_column(
+      cudf::data_type{cudf::type_id::INT32},
+      row_count,
+      cudf::mask_state::UNALLOCATED,
+      cudf::get_default_stream(),
+      get_resource_ref(*space)));
+    auto input = std::make_unique<cudf::table>(std::move(columns));
+
+    std::vector<std::unique_ptr<ast_node>> nodes;
+    nodes.push_back(make_cast(make_int_const(-42), hugeint, false));
+    // The outer AST cast consumes the materialized HUGEINT cast as a temporary column.
+    nodes.push_back(make_cast(make_cast(make_int_const(1), hugeint, false), bigint, false));
+    nodes.push_back(make_cast(make_null_const(integer), hugeint, false));
+    nodes.push_back(make_cast(make_cast(make_null_const(integer), hugeint, false), bigint, false));
+    nodes.push_back(make_cast(make_int_const(42), logical_type::make(type_id::DOUBLE), false));
+    std::vector<ast_node const*> expressions;
+    for (auto const& node : nodes) {
+      expressions.push_back(node.get());
+    }
+    exp_executor executor(expressions,
+                          get_resource_ref(*space),
+                          cudf::get_default_stream(),
+                          TestType::value,
+                          1);
+    auto output     = executor.evaluate(input->view());
+    auto const view = output->view();
+    REQUIRE(view.num_rows() == row_count);
+    REQUIRE(view.num_columns() == 5);
+    for (int i = 0; i < 4; ++i) {
+      REQUIRE(view.column(i).type() == cudf::data_type{cudf::type_id::INT64});
+    }
+    REQUIRE(copy_column_to_host<int64_t>(view.column(0)) == std::vector<int64_t>(row_count, -42));
+    REQUIRE(copy_column_to_host<int64_t>(view.column(1)) == std::vector<int64_t>(row_count, 1));
+    REQUIRE(view.column(0).null_count() == 0);
+    REQUIRE(view.column(1).null_count() == 0);
+    REQUIRE(view.column(2).null_count() == row_count);
+    REQUIRE(view.column(3).null_count() == row_count);
+    REQUIRE(view.column(4).type() == cudf::data_type{cudf::type_id::FLOAT64});
+    REQUIRE(copy_column_to_host<double>(view.column(4)) == std::vector<double>(row_count, 42.0));
+  }
+}
+
 // ---------------------------------------------------------------------------
 // select() — basic filter + edge cases
 // ---------------------------------------------------------------------------

--- a/test/cpp/integration/test_gpu_execution_semantic_cast_fallback.cpp
+++ b/test/cpp/integration/test_gpu_execution_semantic_cast_fallback.cpp
@@ -233,3 +233,19 @@ TEST_CASE_METHOD(SemanticCastFixture,
     REQUIRE(rows == cpu_rows);
   }
 }
+
+TEST_CASE_METHOD(SemanticCastFixture,
+                 "scalar cast - sum_rewriter arithmetic runs without CPU fallback",
+                 "[integration][gpu_execution][scalar_cast]")
+{
+  run_ok("CREATE TABLE hits(ResolutionWidth INTEGER, grp INTEGER);");
+  run_ok("INSERT INTO hits VALUES (1920, 1), (1280, 1), (NULL, 1), (-1, 2), (0, 2), (NULL, 3);");
+  run_ok("CHECKPOINT;");
+  run_ok("SET disabled_optimizers = '';");
+  run_ok("SET enable_duckdb_fallback = false;");
+
+  compare_gpu_vs_cpu("SELECT SUM(ResolutionWidth + 1) FROM hits;");
+  compare_gpu_vs_cpu("SELECT grp, SUM(ResolutionWidth + 1) FROM hits GROUP BY grp;");
+  compare_gpu_vs_cpu("SELECT SUM(ResolutionWidth + 1) FROM hits WHERE grp = 3;");
+  compare_gpu_vs_cpu("SELECT SUM(ResolutionWidth + 1) FROM hits WHERE grp = 99;");
+}

--- a/test/cpp/integration/test_gpu_execution_semantic_cast_fallback.cpp
+++ b/test/cpp/integration/test_gpu_execution_semantic_cast_fallback.cpp
@@ -241,7 +241,11 @@ TEST_CASE_METHOD(SemanticCastFixture,
   run_ok("CREATE TABLE hits(ResolutionWidth INTEGER, grp INTEGER);");
   run_ok("INSERT INTO hits VALUES (1920, 1), (1280, 1), (NULL, 1), (-1, 2), (0, 2), (NULL, 3);");
   run_ok("CHECKPOINT;");
-  run_ok("SET disabled_optimizers = '';");
+  // Keep Sirius's optimizer exclusions; sum_rewriter is enabled by default.
+  auto disabled = con->Query("SELECT current_setting('disabled_optimizers');");
+  REQUIRE(disabled);
+  REQUIRE_FALSE(disabled->HasError());
+  REQUIRE(disabled->GetValue(0, 0).ToString().find("sum_rewriter") == std::string::npos);
   run_ok("SET enable_duckdb_fallback = false;");
 
   compare_gpu_vs_cpu("SELECT SUM(ResolutionWidth + 1) FROM hits;");


### PR DESCRIPTION
This fixes a crash when casting scalar values, such as `CAST(1 AS HUGEINT)` generated by DuckDB's `sum_rewriter` for `SUM(ResolutionWidth + 1)` in Clickbench [Q30](https://github.com/ClickHouse/ClickBench/blob/f44b1d0331c8feb3fa375497f1e34ad42542c95c/gendb/generated/q30.cpp#L1).