### PR TITLE
fix: fix optionals in nightly cudf ``slice_strings``

### DIFF
--- a/src/expression_evaluator/specializations/function.cpp
+++ b/src/expression_evaluator/specializations/function.cpp
@@ -186,13 +186,12 @@ evaluate_result expression_evaluator::evaluate(sirius::ast::function_call const&
 
     auto const input_strings = cudf::strings_column_view(input.get_column_view());
 #if CUDF_VERSION_NUM >= 2610
-    auto result_column = cudf::strings::slice_strings(
-      input_strings,
-      std::optional<cudf::size_type>{start_val},
-      std::optional<cudf::size_type>{stop_val},
-      std::optional<cudf::size_type>{1},
-      _stream,
-      _mr);
+    auto result_column = cudf::strings::slice_strings(input_strings,
+                                                      std::optional<cudf::size_type>{start_val},
+                                                      std::optional<cudf::size_type>{stop_val},
+                                                      std::optional<cudf::size_type>{1},
+                                                      _stream,
+                                                      _mr);
 #else
     auto result_column =
       cudf::strings::slice_strings(input_strings,

--- a/src/expression_evaluator/specializations/function.cpp
+++ b/src/expression_evaluator/specializations/function.cpp
@@ -47,6 +47,7 @@
 
 // standard library
 #include <algorithm>
+#include <optional>
 #include <regex>
 #include <string>
 #include <variant>
@@ -185,8 +186,13 @@ evaluate_result expression_evaluator::evaluate(sirius::ast::function_call const&
 
     auto const input_strings = cudf::strings_column_view(input.get_column_view());
 #if CUDF_VERSION_NUM >= 2610
-    auto result_column =
-      cudf::strings::slice_strings(input_strings, start_val, stop_val, 1, _stream, _mr);
+    auto result_column = cudf::strings::slice_strings(
+      input_strings,
+      std::optional<cudf::size_type>{start_val},
+      std::optional<cudf::size_type>{stop_val},
+      std::optional<cudf::size_type>{1},
+      _stream,
+      _mr);
 #else
     auto result_column =
       cudf::strings::slice_strings(input_strings,


### PR DESCRIPTION
I noticed the nightly build is failing with this build error ([CI logs](https://github.com/sirius-db/sirius/actions/runs/34493208048/job/102924945721)):

```
/home/runner/actions-runner/_work/sirius/sirius/src/expression_evaluator/specializations/function.cpp: In member function 'sirius::evaluate_result sirius::expression_evaluator::evaluate(const sirius::ast::function_call&, evaluation_mode)':
/home/runner/actions-runner/_work/sirius/sirius/src/expression_evaluator/specializations/function.cpp:189:35: error: call of overloaded 'slice_strings(const cudf::strings_column_view&, const int&, const int&, int, rmm::_RMM_26_12::cuda_stream_view&, rmm::_RMM_26_12::device_async_resource_ref&)' is ambiguous
  189 |       cudf::strings::slice_strings(input_strings, start_val, stop_val, 1, _stream, _mr);
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/actions-runner/_work/sirius/sirius/src/expression_evaluator/specializations/function.cpp:189:35: note: there are 2 candidates
In file included from /home/runner/actions-runner/_work/sirius/sirius/src/expression_evaluator/specializations/function.cpp:44:
/home/runner/actions-runner/_work/sirius/sirius/envs/nightly/.pixi/envs/default/include/cudf/strings/slice.hpp:64:1: note: candidate 1: 'std::unique_ptr<cudf::column> cudf::strings::slice_strings(const cudf::strings_column_view&, const cudf::numeric_scalar<int>&, const cudf::numeric_scalar<int>&, const cudf::numeric_scalar<int>&, cuda::__4::stream_ref, rmm::_RMM_26_12::device_async_resource_ref)'
   64 | slice_strings(strings_column_view const& input,
      | ^~~~~~~~~~~~~
/home/runner/actions-runner/_work/sirius/sirius/envs/nightly/.pixi/envs/default/include/cudf/strings/slice.hpp:100:25: note: candidate 2: 'std::unique_ptr<cudf::column> cudf::strings::slice_strings(const cudf::strings_column_view&, std::optional<int>, std::optional<int>, std::optional<int>, cuda::__4::stream_ref, rmm::_RMM_26_12::device_async_resource_ref)'
  100 | std::unique_ptr<column> slice_strings(
      |                         ^~~~~~~~~~~~~
```


cuDF nightly added new `std::optional` overloads for `slice_strings`. Passing integer bounds made overload resolution ambiguous and broke nightly CI builds.

This PR explicitly wraps the bounds in `std::optional<cudf::size_type>` for newer cuDF.